### PR TITLE
Update H2 Database to 2.0.206 to address CVE-2021-42392.

### DIFF
--- a/assemblies/plugins/databases/h2-assemblies/pom.xml
+++ b/assemblies/plugins/databases/h2-assemblies/pom.xml
@@ -37,7 +37,7 @@
     <description></description>
 
     <properties>
-        <h2.version>1.4.200</h2.version>
+        <h2.version>2.0.206</h2.version>
     </properties>
 
 


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42392