### PR TITLE
HOP-3683: Add support for timestamp and byte[] in HopRowCoder

### DIFF
--- a/plugins/engines/beam/src/main/java/org/apache/hop/beam/core/coder/HopRowCoder.java
+++ b/plugins/engines/beam/src/main/java/org/apache/hop/beam/core/coder/HopRowCoder.java
@@ -112,6 +112,12 @@ public class HopRowCoder extends AtomicCoder<HopRow> {
           out.writeLong(lng);
         }
         break;
+      case IValueMeta.TYPE_TIMESTAMP:
+        {
+          out.writeLong(((Timestamp) object).getTime());
+          out.writeInt(((Timestamp) object).getNanos());
+        }
+        break;
       case IValueMeta.TYPE_DATE:
         {
           Long lng = ((Date) object).getTime();
@@ -159,6 +165,13 @@ public class HopRowCoder extends AtomicCoder<HopRow> {
           return lng;
         }
 
+      case IValueMeta.TYPE_TIMESTAMP:
+        {
+          Timestamp timestamp = new Timestamp(in.readLong());
+          timestamp.setNanos(in.readInt());
+          return timestamp;
+        }
+
       case IValueMeta.TYPE_DATE:
         {
           Long lng = in.readLong();
@@ -194,11 +207,11 @@ public class HopRowCoder extends AtomicCoder<HopRow> {
     if (object instanceof Long) {
       return IValueMeta.TYPE_INTEGER;
     }
-    if (object instanceof Date) {
-      return IValueMeta.TYPE_DATE;
-    }
     if (object instanceof Timestamp) {
       return IValueMeta.TYPE_TIMESTAMP;
+    }
+    if (object instanceof Date) {
+      return IValueMeta.TYPE_DATE;
     }
     if (object instanceof Boolean) {
       return IValueMeta.TYPE_BOOLEAN;

--- a/plugins/engines/beam/src/test/java/org/apache/hop/beam/core/coder/HopRowCoderTest.java
+++ b/plugins/engines/beam/src/test/java/org/apache/hop/beam/core/coder/HopRowCoderTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.sql.Timestamp;
 import java.util.Date;
 
 public class HopRowCoderTest extends TestCase {
@@ -44,7 +45,7 @@ public class HopRowCoderTest extends TestCase {
     HopRow row1 =
         new HopRow(
             new Object[] {
-              "AAA", "BBB", Long.valueOf(100), Double.valueOf(1.234), new Date(876876868)
+              "AAA", "BBB", Long.valueOf(100), Double.valueOf(1.234), new Date(876876868), new Timestamp(810311)
             });
 
     hopRowCoder.encode(row1, outputStream);


### PR DESCRIPTION
Don't encode timestamp field on flink, some data type don't support in HopRowCoder.
* add timestamp type for IValueMeta.TYPE_STRING
* add byte[] type for IValueMeta.TYPE_BINARY
* add InetAddress for IValueMeta.TYPE_INET