### PR TITLE
[HOP-3606] Disabled java 11 tests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -58,7 +58,7 @@
         <httpclient.version>4.5.3</httpclient.version>
         <httpccore.version>4.4.6</httpccore.version>
         <xmlunit.version>1.5</xmlunit.version>
-        <javassist.version>3.20.0-GA</javassist.version>
+        <javassist.version>3.28.0-GA</javassist.version>
         <json-simple.version>1.1.1</json-simple.version>
         <gson.version>2.8.5</gson.version>
         <jackson.version>2.12.0</jackson.version>

--- a/core/src/test/java/org/apache/hop/core/database/DatabaseMetaTest.java
+++ b/core/src/test/java/org/apache/hop/core/database/DatabaseMetaTest.java
@@ -41,8 +41,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 public class DatabaseMetaTest {
@@ -168,7 +168,6 @@ public class DatabaseMetaTest {
   }
 
   @Test
-  @Ignore
   public void testModifyingName() throws Exception {
     DatabaseMeta databaseMeta = mock(DatabaseMeta.class);
     NoneDatabaseMeta odbm = new NoneDatabaseMeta();
@@ -186,15 +185,13 @@ public class DatabaseMetaTest {
     doCallRealMethod().when(databaseMeta2).setIDatabase(any(IDatabase.class));
     doCallRealMethod().when(databaseMeta2).setName(anyString());
     doCallRealMethod().when(databaseMeta2).getName();
-    doCallRealMethod()
-        .when(databaseMeta2)
-        .verifyAndModifyDatabaseName(any(ArrayList.class), anyString());
+    doCallRealMethod().when(databaseMeta2).verifyAndModifyDatabaseName(any(ArrayList.class), any());
     databaseMeta2.setIDatabase(odbm2);
     databaseMeta2.setName("test");
 
     databaseMeta2.verifyAndModifyDatabaseName(list, null);
 
-    assertTrue(!databaseMeta.getName().equals(databaseMeta2.getName()));
+    assertNotEquals(databaseMeta.getName(), databaseMeta2.getName());
   }
 
   @Test

--- a/core/src/test/java/org/apache/hop/core/database/DatabaseTest.java
+++ b/core/src/test/java/org/apache/hop/core/database/DatabaseTest.java
@@ -36,7 +36,7 @@ import java.util.List;
 
 import static org.junit.Assert.*;
 import static org.mockito.AdditionalMatchers.aryEq;
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @SuppressWarnings("deprecation")
@@ -85,7 +85,6 @@ public class DatabaseTest {
   public void tearDown() {}
 
   @Test
-  @Ignore
   public void testGetQueryFieldsFromDatabaseMetaData() throws Exception {
     DatabaseMeta meta = mock(DatabaseMeta.class);
     DatabaseMetaData dbMetaData = mock(DatabaseMetaData.class);
@@ -95,7 +94,12 @@ public class DatabaseTest {
     String columnType = "Integer";
     int columnSize = 15;
 
-    when(dbMetaData.getColumns(anyString(), anyString(), anyString(), anyString())).thenReturn(rs);
+    when(dbMetaData.getColumns(
+            nullable(String.class),
+            nullable(String.class),
+            nullable(String.class),
+            nullable(String.class)))
+        .thenReturn(rs);
     when(rs.next()).thenReturn(true).thenReturn(false);
     when(rs.getString("COLUMN_NAME")).thenReturn(columnName);
     when(rs.getString("SOURCE_DATA_TYPE")).thenReturn(columnType);
@@ -123,17 +127,18 @@ public class DatabaseTest {
    * @throws SQLException
    */
   @Test
-  @Ignore
   public void testGetLookupMetaCalls() throws HopDatabaseException, SQLException {
-    when(meta.getQuotedSchemaTableCombination(any(), anyString(), anyString())).thenReturn("a");
-    when(meta.quoteField(anyString())).thenReturn("a");
+    when(meta.getQuotedSchemaTableCombination(
+            nullable(IVariables.class), nullable(String.class), nullable(String.class)))
+        .thenReturn("a");
+    when(meta.quoteField(any())).thenReturn("a");
     when(ps.executeQuery()).thenReturn(rs);
     when(rs.getMetaData()).thenReturn(rsMetaData);
     when(rsMetaData.getColumnCount()).thenReturn(0);
     when(ps.getMetaData()).thenReturn(rsMetaData);
     Database db = new Database(log, variables, meta);
     Connection conn = mock(Connection.class);
-    when(conn.prepareStatement(anyString())).thenReturn(ps);
+    when(conn.prepareStatement(any())).thenReturn(ps);
 
     db.setConnection(conn);
     String[] name = new String[] {"a"};
@@ -487,11 +492,12 @@ public class DatabaseTest {
   }
 
   @Test
-  @Ignore
   public void testGetTablenames() throws SQLException, HopDatabaseException {
     when(rs.next()).thenReturn(true, false);
     when(rs.getString("TABLE_NAME")).thenReturn(EXISTING_TABLE_NAME);
-    when(dbMetaDataMock.getTables(any(), anyString(), anyString(), any())).thenReturn(rs);
+    when(dbMetaDataMock.getTables(
+            nullable(String.class), nullable(String.class), nullable(String.class), any()))
+        .thenReturn(rs);
     Database db = new Database(log, variables, dbMetaMock);
     db.setConnection(mockConnection(dbMetaDataMock));
 

--- a/core/src/test/java/org/apache/hop/core/row/value/ValueMetaBaseTest.java
+++ b/core/src/test/java/org/apache/hop/core/row/value/ValueMetaBaseTest.java
@@ -52,8 +52,8 @@ import java.util.Date;
 import java.util.*;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.*;
 
 public class ValueMetaBaseTest {
@@ -729,7 +729,6 @@ public class ValueMetaBaseTest {
   }
 
   @Test
-  @Ignore
   public void testConvertDataUsingConversionMetaData() throws HopValueException, ParseException {
     ValueMetaString base = new ValueMetaString();
     double DELTA = 1e-15;
@@ -900,7 +899,6 @@ public class ValueMetaBaseTest {
   }
 
   @Test
-  @Ignore
   public void testConvertNumberToString() throws HopValueException {
     String expectedStringRepresentation = "123.123";
     Number numberToTest = Double.valueOf("123.123");

--- a/core/src/test/java/org/apache/hop/core/row/value/ValueMetaStringTest.java
+++ b/core/src/test/java/org/apache/hop/core/row/value/ValueMetaStringTest.java
@@ -899,7 +899,6 @@ public class ValueMetaStringTest {
   }
 
   @Test
-  @Ignore
   public void testGetIntegerWithoutConversionMask() throws HopValueException, ParseException {
     String value = "100.56";
     IValueMeta stringValueMeta = new ValueMetaString("test");
@@ -910,7 +909,6 @@ public class ValueMetaStringTest {
   }
 
   @Test
-  @Ignore
   public void testGetNumberWithoutConversionMask() throws HopValueException, ParseException {
     String value = "100.56";
     IValueMeta stringValueMeta = new ValueMetaString("test");
@@ -921,7 +919,6 @@ public class ValueMetaStringTest {
   }
 
   @Test
-  @Ignore
   public void testGetBigNumberWithoutConversionMask() throws HopValueException, ParseException {
     String value = "100.5";
     IValueMeta stringValueMeta = new ValueMetaString("test");

--- a/engine/src/test/java/org/apache/hop/core/attributes/AttributesUtilTest.java
+++ b/engine/src/test/java/org/apache/hop/core/attributes/AttributesUtilTest.java
@@ -18,7 +18,6 @@
 package org.apache.hop.core.attributes;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
@@ -31,8 +30,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 
 @PrepareForTest(AttributesUtil.class)
 @RunWith(PowerMockRunner.class)
@@ -106,11 +104,10 @@ public class AttributesUtilTest {
   }
 
   @Test
-  @Ignore
   public void testGetAttributesXml_DefaultTag_NullParameter() {
 
-    PowerMockito.when(AttributesUtil.getAttributesXml(any(Map.class))).thenCallRealMethod();
-    PowerMockito.when(AttributesUtil.getAttributesXml(any(Map.class), anyString()))
+    PowerMockito.when(AttributesUtil.getAttributesXml(nullable(Map.class))).thenCallRealMethod();
+    PowerMockito.when(AttributesUtil.getAttributesXml(nullable(Map.class), nullable(String.class)))
         .thenCallRealMethod();
 
     String attributesXml = AttributesUtil.getAttributesXml(null);
@@ -122,10 +119,9 @@ public class AttributesUtilTest {
   }
 
   @Test
-  @Ignore
   public void testGetAttributesXml_CustomTag_NullParameter() {
 
-    PowerMockito.when(AttributesUtil.getAttributesXml(any(Map.class), anyString()))
+    PowerMockito.when(AttributesUtil.getAttributesXml(nullable(Map.class), nullable(String.class)))
         .thenCallRealMethod();
 
     String attributesXml = AttributesUtil.getAttributesXml(null, CUSTOM_TAG);

--- a/engine/src/test/java/org/apache/hop/pipeline/PipelineMetaTest.java
+++ b/engine/src/test/java/org/apache/hop/pipeline/PipelineMetaTest.java
@@ -34,12 +34,9 @@ import org.apache.hop.pipeline.transform.*;
 import org.apache.hop.pipeline.transforms.dummy.DummyMeta;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
-import org.powermock.modules.junit4.PowerMockRunner;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -51,7 +48,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.same;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.*;
 
 public class PipelineMetaTest {
@@ -95,7 +92,6 @@ public class PipelineMetaTest {
   }
 
   @Test
-  @Ignore
   public void getThisTransformFieldsPassesCloneRowMeta() throws Exception {
     final String overriddenValue = "overridden";
 
@@ -114,12 +110,12 @@ public class PipelineMetaTest {
                 })
         .when(smi)
         .getFields(
-            any(IRowMeta.class),
-            anyString(),
-            any(IRowMeta[].class),
+            nullable(IRowMeta.class),
+            nullable(String.class),
+            nullable(IRowMeta[].class),
             eq(nextTransform),
-            any(IVariables.class),
-            any(IHopMetadataProvider.class));
+            nullable(IVariables.class),
+            nullable(IHopMetadataProvider.class));
 
     TransformMeta thisTransform = mockTransformMeta("thisTransform");
     when(thisTransform.getTransform()).thenReturn(smi);

--- a/engine/src/test/java/org/apache/hop/pipeline/TransformWithMappingMetaTest.java
+++ b/engine/src/test/java/org/apache/hop/pipeline/TransformWithMappingMetaTest.java
@@ -24,13 +24,12 @@ import org.apache.hop.core.variables.Variables;
 import org.apache.hop.pipeline.engines.local.LocalPipelineEngine;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class TransformWithMappingMetaTest {
 
   @Mock PipelineMeta pipelineMeta;
@@ -46,8 +45,6 @@ public class TransformWithMappingMetaTest {
   }
 
   @Test
-  @Ignore
-  @PrepareForTest(TransformWithMappingMeta.class)
   public void activateParamsTest() throws Exception {
     String childParam = "childParam";
     String childValue = "childValue";
@@ -81,8 +78,6 @@ public class TransformWithMappingMetaTest {
   }
 
   @Test
-  @Ignore
-  @PrepareForTest(TransformWithMappingMeta.class)
   public void activateParamsWithTruePassParametersFlagTest() throws Exception {
     String childParam = "childParam";
     String childValue = "childValue";
@@ -124,7 +119,6 @@ public class TransformWithMappingMetaTest {
   }
 
   @Test
-  @PrepareForTest(TransformWithMappingMeta.class)
   public void replaceVariablesWithWorkflowInternalVariablesTest() {
     String variableOverwrite = "paramOverwrite";
     String variableChildOnly = "childValueVariable";
@@ -152,7 +146,6 @@ public class TransformWithMappingMetaTest {
   }
 
   @Test
-  @PrepareForTest(TransformWithMappingMeta.class)
   public void replaceVariablesWithPipelineInternalVariablesTest() {
     String variableOverwrite = "paramOverwrite";
     String variableChildOnly = "childValueVariable";

--- a/engine/src/test/java/org/apache/hop/server/HopServerTest.java
+++ b/engine/src/test/java/org/apache/hop/server/HopServerTest.java
@@ -47,9 +47,10 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -101,7 +102,7 @@ public class HopServerTest {
     hopServer = spy(new HopServer());
     variables = new Variables();
     doReturn(httpClient).when(hopServer).getHttpClient();
-    doReturn("response_body").when(hopServer).getResponseBodyAsString(any(InputStream.class));
+    doReturn("response_body").when(hopServer).getResponseBodyAsString(nullable(InputStream.class));
   }
 
   private HttpResponse mockResponse(int statusCode, String entityText) throws IOException {
@@ -133,7 +134,6 @@ public class HopServerTest {
   }
 
   @Test(expected = HopException.class)
-  @Ignore
   public void testSendXml() throws Exception {
     hopServer.setHostname("hostNameStub");
     hopServer.setUsername("userNAmeStub");
@@ -148,7 +148,6 @@ public class HopServerTest {
   }
 
   @Test(expected = HopException.class)
-  @Ignore
   public void testSendExport() throws Exception {
     hopServer.setHostname("hostNameStub");
     hopServer.setUsername("userNAmeStub");
@@ -167,7 +166,6 @@ public class HopServerTest {
   }
 
   @Test
-  @Ignore
   public void testSendExportOk() throws Exception {
     hopServer.setUsername("uname");
     hopServer.setPassword("passw");

--- a/engine/src/test/java/org/apache/hop/www/GetWorkflowStatusServletTest.java
+++ b/engine/src/test/java/org/apache/hop/www/GetWorkflowStatusServletTest.java
@@ -24,9 +24,9 @@ import org.apache.hop.workflow.Workflow;
 import org.apache.hop.workflow.WorkflowMeta;
 import org.apache.hop.workflow.engine.IWorkflowEngine;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.internal.verification.VerificationModeFactory;
 import org.owasp.encoder.Encode;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -41,12 +41,11 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 
 import static junit.framework.Assert.assertFalse;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @RunWith(PowerMockRunner.class)
-@Ignore
 public class GetWorkflowStatusServletTest {
   private WorkflowMap mockWorkflowMap;
 
@@ -109,7 +108,7 @@ public class GetWorkflowStatusServletTest {
     getWorkflowStatusServlet.doGet(mockHttpServletRequest, mockHttpServletResponse);
     assertFalse(out.toString().contains(ServletTestUtils.BAD_STRING_TO_TEST));
 
-    PowerMockito.verifyStatic(Encode.class);
+    PowerMockito.verifyStatic(Encode.class, VerificationModeFactory.atLeastOnce());
     Encode.forHtml(anyString());
   }
 

--- a/plugins/actions/deletefiles/src/test/java/org/apache/hop/workflow/actions/deletefiles/WorkflowEntryDeleteFilesTest.java
+++ b/plugins/actions/deletefiles/src/test/java/org/apache/hop/workflow/actions/deletefiles/WorkflowEntryDeleteFilesTest.java
@@ -20,20 +20,22 @@ package org.apache.hop.workflow.actions.deletefiles;
 import org.apache.hop.core.Const;
 import org.apache.hop.core.Result;
 import org.apache.hop.core.RowMetaAndData;
+import org.apache.hop.core.logging.HopLogStore;
+import org.apache.hop.core.logging.LogLevel;
 import org.apache.hop.core.row.RowMeta;
 import org.apache.hop.core.row.value.ValueMetaString;
 import org.apache.hop.workflow.Workflow;
 import org.apache.hop.workflow.WorkflowMeta;
 import org.apache.hop.workflow.engine.IWorkflowEngine;
 import org.junit.Before;
-import org.junit.Ignore;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 public class WorkflowEntryDeleteFilesTest {
@@ -42,11 +44,17 @@ public class WorkflowEntryDeleteFilesTest {
 
   private ActionDeleteFiles action;
 
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    HopLogStore.init();
+  }
+
   @Before
   public void setUp() throws Exception {
     action = new ActionDeleteFiles();
     IWorkflowEngine<WorkflowMeta> parentWorkflow = mock(Workflow.class);
     doReturn(false).when(parentWorkflow).isStopped();
+    doReturn(LogLevel.BASIC).when(parentWorkflow).getLogLevel();
 
     action.setParentWorkflow(parentWorkflow);
     WorkflowMeta mockWorkflowMeta = mock(WorkflowMeta.class);
@@ -66,7 +74,6 @@ public class WorkflowEntryDeleteFilesTest {
   }
 
   @Test
-  @Ignore
   public void filesWithPath_AreProcessed_ArgsOfCurrentJob() throws Exception {
     String[] args = new String[] {PATH_TO_FILE};
     action.setArguments(args);
@@ -74,7 +81,8 @@ public class WorkflowEntryDeleteFilesTest {
     action.setArgFromPrevious(false);
 
     action.execute(new Result(), 0);
-    verify(action, times(args.length)).processFile(anyString(), anyString(), any(Workflow.class));
+    verify(action, times(args.length))
+        .processFile(nullable(String.class), nullable(String.class), any(Workflow.class));
   }
 
   @Test
@@ -94,7 +102,6 @@ public class WorkflowEntryDeleteFilesTest {
   }
 
   @Test
-  @Ignore
   public void filesPath_AreProcessed_ArgsOfPreviousMeta() throws Exception {
     action.setArgFromPrevious(true);
 
@@ -106,11 +113,10 @@ public class WorkflowEntryDeleteFilesTest {
 
     action.execute(prevMetaResult, 0);
     verify(action, times(metaAndDataList.size()))
-        .processFile(anyString(), anyString(), any(Workflow.class));
+        .processFile(anyString(), nullable(String.class), any(Workflow.class));
   }
 
   @Test
-  @Ignore
   public void filesPathVariables_AreProcessed_OnlyIfValueIsNotBlank() throws Exception {
     final String pathToFileBlankValue = "pathToFileBlankValue";
     final String pathToFileValidValue = "pathToFileValidValue";
@@ -125,7 +131,7 @@ public class WorkflowEntryDeleteFilesTest {
 
     action.execute(new Result(), 0);
 
-    verify(action).processFile(eq(PATH_TO_FILE), anyString(), any(Workflow.class));
+    verify(action).processFile(eq(PATH_TO_FILE), nullable(String.class), any(Workflow.class));
   }
 
   @Test

--- a/plugins/transforms/checksum/src/main/java/org/apache/hop/pipeline/transforms/checksum/CheckSumMeta.java
+++ b/plugins/transforms/checksum/src/main/java/org/apache/hop/pipeline/transforms/checksum/CheckSumMeta.java
@@ -56,7 +56,7 @@ public class CheckSumMeta extends BaseTransformMeta
   private static final Class<?> PKG = CheckSumMeta.class; // For Translator
 
   public enum CheckSumType implements IEnumHasCode {
-    NONE("", ""),
+    NONE("NONE", ""),
     CRC32("CRC32", BaseMessages.getString(PKG, "CheckSumMeta.Type.CRC32")),
     ADLER32("ADLER32", BaseMessages.getString(PKG, "CheckSumMeta.Type.ADLER32")),
     MD5("MD5", BaseMessages.getString(PKG, "CheckSumMeta.Type.MD5")),

--- a/plugins/transforms/databaselookup/src/test/java/org/apache/hop/pipeline/transforms/databaselookup/DatabaseLookupUTest.java
+++ b/plugins/transforms/databaselookup/src/test/java/org/apache/hop/pipeline/transforms/databaselookup/DatabaseLookupUTest.java
@@ -40,7 +40,7 @@ import org.apache.hop.pipeline.transform.TransformMeta;
 import org.apache.hop.pipeline.transforms.databaselookup.readallcache.ReadAllCache;
 import org.apache.hop.pipeline.transforms.mock.TransformMockHelper;
 import org.junit.*;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import java.sql.Connection;
@@ -53,11 +53,11 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-@Ignore
 public class DatabaseLookupUTest {
   @ClassRule public static RestoreHopEngineEnvironment env = new RestoreHopEngineEnvironment();
 
@@ -104,12 +104,12 @@ public class DatabaseLookupUTest {
 
     Mockito.doReturn(rowSet)
         .when(mockHelper.pipeline)
-        .findRowSet(anyString(), anyInt(), anyString(), anyInt());
+        .findRowSet(nullable(String.class), anyInt(), nullable(String.class), anyInt());
 
     when(mockHelper.pipeline.findRowSet(anyString(), anyInt(), anyString(), anyInt()))
         .thenReturn(rowSet);
 
-    when(mockHelper.pipelineMeta.findNextTransforms(Matchers.any(TransformMeta.class)))
+    when(mockHelper.pipelineMeta.findNextTransforms(ArgumentMatchers.any(TransformMeta.class)))
         .thenReturn(Collections.singletonList(mock(TransformMeta.class)));
     when(mockHelper.pipelineMeta.findPreviousTransforms(any(TransformMeta.class), anyBoolean()))
         .thenReturn(Collections.singletonList(mock(TransformMeta.class)));
@@ -170,13 +170,13 @@ public class DatabaseLookupUTest {
     when(ps.executeQuery()).thenReturn(rs);
 
     Connection connection = mock(Connection.class);
-    when(connection.prepareStatement(anyString())).thenReturn(ps);
+    when(connection.prepareStatement(nullable(String.class))).thenReturn(ps);
 
     Database db = new Database(mock(ILoggingObject.class), variables, meta);
     db.setConnection(connection);
 
     db = spy(db);
-    doNothing().when(db).normalConnect(anyString());
+    doNothing().when(db).normalConnect(nullable(String.class));
 
     IValueMeta binary = new ValueMetaString(BINARY_FIELD);
     binary.setStorageType(IValueMeta.STORAGE_TYPE_BINARY_STRING);
@@ -187,8 +187,10 @@ public class DatabaseLookupUTest {
     metaByQuerying.addValueMeta(binary);
     metaByQuerying.addValueMeta(id);
 
-    doReturn(metaByQuerying).when(db).getTableFields(anyString());
-    doReturn(metaByQuerying).when(db).getTableFieldsMeta(anyString(), anyString());
+    doReturn(metaByQuerying).when(db).getTableFields(nullable(String.class));
+    doReturn(metaByQuerying)
+        .when(db)
+        .getTableFieldsMeta(nullable(String.class), nullable(String.class));
 
     return db;
   }
@@ -264,18 +266,18 @@ public class DatabaseLookupUTest {
             })
         .when(meta)
         .getFields(
-            any(IRowMeta.class),
-            anyString(),
-            any(IRowMeta[].class),
-            any(TransformMeta.class),
-            any(IVariables.class),
-            any(IHopMetadataProvider.class));
+            nullable(IRowMeta.class),
+            nullable(String.class),
+            nullable(IRowMeta[].class),
+            nullable(TransformMeta.class),
+            nullable(IVariables.class),
+            nullable(IHopMetadataProvider.class));
 
     DatabaseLookup look =
         new MockDatabaseLookup(
             mockHelper.transformMeta, meta, data, 0, mockHelper.pipelineMeta, mockHelper.pipeline);
 
-    when(look.getPipelineMeta().findDatabase(any(String.class), any(IVariables.class)))
+    when(look.getPipelineMeta().findDatabase(nullable(String.class), nullable(IVariables.class)))
         .thenReturn(dbMeta);
 
     look.init();

--- a/plugins/transforms/http/pom.xml
+++ b/plugins/transforms/http/pom.xml
@@ -42,14 +42,10 @@
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>1.7.4</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
-            <version>1.7.4</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/plugins/transforms/http/src/test/java/org/apache/hop/pipeline/transforms/http/HttpTest.java
+++ b/plugins/transforms/http/src/test/java/org/apache/hop/pipeline/transforms/http/HttpTest.java
@@ -26,7 +26,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -37,14 +36,13 @@ import java.net.HttpURLConnection;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.reflect.Whitebox.setInternalState;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(HttpClientManager.class)
-@Ignore
 public class HttpTest {
 
   private ILogChannel log = mock(ILogChannel.class);

--- a/plugins/transforms/httppost/src/test/java/org/apache/hop/pipeline/transforms/httppost/HttpPostTest.java
+++ b/plugins/transforms/httppost/src/test/java/org/apache/hop/pipeline/transforms/httppost/HttpPostTest.java
@@ -20,16 +20,14 @@ package org.apache.hop.pipeline.transforms.httppost;
 import org.apache.hop.core.exception.HopException;
 import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicNameValuePair;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 
-@Ignore
 public class HttpPostTest {
 
   @Test
@@ -37,7 +35,7 @@ public class HttpPostTest {
     HttpPost http = mock(HttpPost.class);
     doCallRealMethod()
         .when(http)
-        .getRequestBodyParamsAsStr(any(NameValuePair[].class), anyString());
+        .getRequestBodyParamsAsStr(any(NameValuePair[].class), nullable(String.class));
 
     NameValuePair[] pairs =
         new NameValuePair[] {

--- a/plugins/transforms/streamlookup/src/test/java/org/apache/hop/pipeline/transforms/streamlookup/StreamLookupTest.java
+++ b/plugins/transforms/streamlookup/src/test/java/org/apache/hop/pipeline/transforms/streamlookup/StreamLookupTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.hop.pipeline.transforms.streamlookup;
 
-import junit.framework.Assert;
 import org.apache.hop.core.IRowSet;
 import org.apache.hop.core.QueueRowSet;
 import org.apache.hop.core.exception.HopException;
@@ -40,8 +39,8 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 /**
@@ -49,14 +48,13 @@ import static org.mockito.Mockito.*;
  *
  * @see StreamLookup
  */
-@Ignore
 public class StreamLookupTest {
   private TransformMockHelper<StreamLookupMeta, StreamLookupData> smh;
 
   @Before
   public void setUp() {
     smh = new TransformMockHelper<>("StreamLookup", StreamLookupMeta.class, StreamLookupData.class);
-    when(smh.logChannelFactory.create(any(), any(ILoggingObject.class)))
+    when(smh.logChannelFactory.create(any(), nullable(ILoggingObject.class)))
         .thenReturn(smh.iLogChannel);
     when(smh.pipeline.isRunning()).thenReturn(true);
   }
@@ -154,12 +152,12 @@ public class StreamLookupTest {
     doCallRealMethod()
         .when(meta)
         .getFields(
-            any(IRowMeta.class),
-            anyString(),
-            any(IRowMeta[].class),
-            any(TransformMeta.class),
-            any(IVariables.class),
-            any(IHopMetadataProvider.class));
+            nullable(IRowMeta.class),
+            nullable(String.class),
+            nullable(IRowMeta[].class),
+            nullable(TransformMeta.class),
+            nullable(IVariables.class),
+            nullable(IHopMetadataProvider.class));
 
     return meta;
   }
@@ -193,14 +191,14 @@ public class StreamLookupTest {
       Object[] rowData = outputRowSet.getRow();
       if (rowData != null) {
         IRowMeta rowMeta = outputRowSet.getRowMeta();
-        Assert.assertEquals("Output row is of wrong size", 3, rowMeta.size());
+        assertEquals("Output row is of wrong size", 3, rowMeta.size());
         rowNumber++;
         // Verify output
         for (int valueIndex = 0; valueIndex < rowMeta.size(); valueIndex++) {
           String expectedValue = expectedOutput[valueIndex] + rowNumber;
           Object actualValue =
               rowMeta.getValueMeta(valueIndex).convertToNormalStorageType(rowData[valueIndex]);
-          Assert.assertEquals(
+          assertEquals(
               "Unexpected value at row " + rowNumber + " position " + valueIndex,
               expectedValue,
               actualValue);
@@ -208,7 +206,7 @@ public class StreamLookupTest {
       }
     }
 
-    Assert.assertEquals("Incorrect output row number", 2, rowNumber);
+    assertEquals("Incorrect output row number", 2, rowNumber);
   }
 
   @Test

--- a/ui/src/test/java/org/apache/hop/ui/util/EnvironmentUtilsTest.java
+++ b/ui/src/test/java/org/apache/hop/ui/util/EnvironmentUtilsTest.java
@@ -19,7 +19,6 @@ package org.apache.hop.ui.util;
 
 import org.eclipse.swt.SWT;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -39,7 +38,6 @@ import static org.mockito.Mockito.when;
 public class EnvironmentUtilsTest {
 
   @Test
-  @Ignore
   public void isUnSupportedBrowserEnvironmentTest() {
     EnvironmentUtilsMock mock = new EnvironmentUtilsMock(Case.UBUNTU_16);
     assertFalse(mock.getMockedInstance().isUnsupportedBrowserEnvironment());
@@ -54,7 +52,6 @@ public class EnvironmentUtilsTest {
   }
 
   @Test
-  @Ignore
   public void isWebkitUnavailableTest() {
     EnvironmentUtilsMock mock = new EnvironmentUtilsMock(Case.UBUNTU_16);
     assertFalse(mock.getMockedInstance().isWebkitUnavailable());
@@ -69,7 +66,6 @@ public class EnvironmentUtilsTest {
   }
 
   @Test
-  @Ignore
   public void getBrowserName() {
     EnvironmentUtilsMock mock = new EnvironmentUtilsMock(Case.UBUNTU_16);
     Assert.assertEquals(mock.getMockedInstance().getBrowserName(), "Midori");


### PR DESCRIPTION
Resolves problems with some of ignored tests. Most common case is connected with new mockito argument matchers api which does not allow passing null values anymore using anyType() methods. E.g. anyString() could be replaced with nullable(String.class).
Also fixes problems with javassist incompatibility by upgrading to newest version.

Commits are divided by specific type of problems with tests.

- Fixed mockito matchers, mostly by providing nullable(Class) instead 'anyType' which does not respect argument values anymore. Resolves issues: 
HOP-3607, HOP-3608, HOP-3609, HOP-3610, HOP-3611, HOP-3614, HOP-3612, HOP-3624, HOP-3625, HOP-3646, HOP-3626, HOP-3630, HOP-3632, HOP-3631, HOP-3638, HOP-3639, HOP-3640, HOP-3644, HOP-3646, HOP-3649
- Powermock upgrade Resolves: 
HOP-3648
- Upgraded Javassist for Powermock compatibility Resolves: 
HOP-3637, HOP-3636, HOP-3635, HOP-3634
- Added MockitoJUnitRunner Resolves: 
HOP-3627, HOP-3628
- Already working tests, removed ignore annotation Resolves:
HOP-3615, HOP-3616, HOP-3617
