### PR TITLE
HOP-3711 CheckSumMetaTest.testSerialization fails randomly

### DIFF
--- a/plugins/transforms/checksum/src/main/java/org/apache/hop/pipeline/transforms/checksum/CheckSumMeta.java
+++ b/plugins/transforms/checksum/src/main/java/org/apache/hop/pipeline/transforms/checksum/CheckSumMeta.java
@@ -56,7 +56,7 @@ public class CheckSumMeta extends BaseTransformMeta
   private static final Class<?> PKG = CheckSumMeta.class; // For Translator
 
   public enum CheckSumType implements IEnumHasCode {
-    NONE("", ""),
+    NONE("NONE", ""),
     CRC32("CRC32", BaseMessages.getString(PKG, "CheckSumMeta.Type.CRC32")),
     ADLER32("ADLER32", BaseMessages.getString(PKG, "CheckSumMeta.Type.ADLER32")),
     MD5("MD5", BaseMessages.getString(PKG, "CheckSumMeta.Type.MD5")),


### PR DESCRIPTION
To replicate bug easily you can run the test multiple times for example by defining Repeat N (e.g. 100) times option in Intellij Idea Test Runner config

Cause:
During the test the EnumLoadSaveValidator#getTestObject generates random enum value to set checkSumType field in CheckSumMeta object.
Most of the time seems to draws well matched value to pass the test.
However the problem occurs when the validator draws CheckSumMeta.CheckSumType#NONE enum, which has 'code' property value defined as an empty string "".

Next the LoadSaveTester#testXmlRoundTrip creates meta with provided checkSumType to save to and then applies transform xml to meta. 

So when checkSumType==NONE has 'code' defined as "" , the generated transform xml looks just like empty <checksumtype/>. Which means no transform at all.

After that in LoadSaveBase#validateLoadedMeta performs validation of loaded data with applied transformations. Because transform was empty the old checksumtype is loaded e.g CRC32. 
So the transform has no effect at all in this case and the test fails .

Setting code to "NONE" in the enum seems to fix the problem with empty transform and passes validation but im not sure if this is the best solution.