### PR TITLE
HOP-3606 Disabled java 11

### DIFF
--- a/engine/src/test/java/org/apache/hop/pipeline/transforms/mock/TransformMockHelper.java
+++ b/engine/src/test/java/org/apache/hop/pipeline/transforms/mock/TransformMockHelper.java
@@ -19,6 +19,7 @@ package org.apache.hop.pipeline.transforms.mock;
 
 import org.apache.hop.core.IRowSet;
 import org.apache.hop.core.logging.*;
+import org.apache.hop.core.row.IRowMeta;
 import org.apache.hop.pipeline.Pipeline;
 import org.apache.hop.pipeline.PipelineMeta;
 import org.apache.hop.pipeline.engines.local.LocalPipelineEngine;
@@ -35,7 +36,8 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
 
 public class TransformMockHelper<Meta extends ITransformMeta, Data extends ITransformData> {
@@ -79,6 +81,10 @@ public class TransformMockHelper<Meta extends ITransformMeta, Data extends ITran
     when(rowSet.getRowWait(anyLong(), any(TimeUnit.class))).thenAnswer(answer);
     when(rowSet.getRow()).thenAnswer(answer);
     when(rowSet.isDone()).thenAnswer((Answer<Boolean>) invocation -> index.get() >= rows.size());
+
+    IRowMeta rowMeta = mock(IRowMeta.class);
+    when((rowMeta.clone())).thenReturn(mock((IRowMeta.class)));
+    when(rowSet.getRowMeta()).thenReturn(rowMeta);
     return rowSet;
   }
 
@@ -124,6 +130,6 @@ public class TransformMockHelper<Meta extends ITransformMeta, Data extends ITran
                   return false;
                 })
         .when(log)
-        .println((ILogMessage) anyObject(), (LogLevel) anyObject());
+        .println(any(), any(LogLevel.class));
   }
 }

--- a/engine/src/test/java/org/apache/hop/www/GetPipelineStatusServletTest.java
+++ b/engine/src/test/java/org/apache/hop/www/GetPipelineStatusServletTest.java
@@ -23,7 +23,6 @@ import org.apache.hop.core.logging.ILogChannel;
 import org.apache.hop.pipeline.Pipeline;
 import org.apache.hop.pipeline.PipelineMeta;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.owasp.encoder.Encode;
@@ -38,9 +37,9 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
-import static junit.framework.Assert.assertFalse;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @RunWith(PowerMockRunner.class)
@@ -74,12 +73,11 @@ public class GetPipelineStatusServletTest {
     getPipelineStatusServlet.doGet(mockHttpServletRequest, mockHttpServletResponse);
     assertFalse(ServletTestUtils.hasBadText(ServletTestUtils.getInsideOfTag("H1", out.toString())));
 
-    PowerMockito.verifyStatic(Encode.class);
+    PowerMockito.verifyStatic(Encode.class, atLeastOnce());
     Encode.forHtml(anyString());
   }
 
   @Test
-  @Ignore
   @PrepareForTest({Encode.class})
   public void testGetPipelineStatusServletEscapesHtmlWhenPipelineFound()
       throws ServletException, IOException {
@@ -106,7 +104,7 @@ public class GetPipelineStatusServletTest {
     assertFalse(
         ServletTestUtils.hasBadText(ServletTestUtils.getInsideOfTag("TITLE", out.toString())));
 
-    PowerMockito.verifyStatic(Encode.class);
+    PowerMockito.verifyStatic(Encode.class, atLeastOnce());
     Encode.forHtml(anyString());
   }
 }

--- a/plugins/transforms/fuzzymatch/src/test/java/org/apache/hop/pipeline/transforms/fuzzymatch/FuzzyMatchTest.java
+++ b/plugins/transforms/fuzzymatch/src/test/java/org/apache/hop/pipeline/transforms/fuzzymatch/FuzzyMatchTest.java
@@ -30,7 +30,10 @@ import org.apache.hop.pipeline.transform.ITransformIOMeta;
 import org.apache.hop.pipeline.transform.TransformMeta;
 import org.apache.hop.pipeline.transform.errorhandling.IStream;
 import org.apache.hop.pipeline.transforms.mock.TransformMockHelper;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 import org.mockito.InjectMocks;
 
 import java.util.ArrayList;
@@ -38,7 +41,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 public class FuzzyMatchTest {
@@ -113,7 +116,6 @@ public class FuzzyMatchTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  @Ignore
   public void testProcessRow() throws Exception {
     fuzzyMatch =
         new FuzzyMatchHandler(

--- a/plugins/transforms/mapping/src/test/java/org/apache/hop/pipeline/transforms/mapping/SimpleMappingTest.java
+++ b/plugins/transforms/mapping/src/test/java/org/apache/hop/pipeline/transforms/mapping/SimpleMappingTest.java
@@ -34,7 +34,7 @@ import org.mockito.Mockito;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 public class SimpleMappingTest {
@@ -154,7 +154,6 @@ public class SimpleMappingTest {
   }
 
   @Test
-  @Ignore
   public void testTransformShouldStopProcessingInput_IfUnderlyingTransitionIsStopped()
       throws Exception {
 

--- a/plugins/transforms/memgroupby/pom.xml
+++ b/plugins/transforms/memgroupby/pom.xml
@@ -37,13 +37,11 @@
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>1.7.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
-            <version>1.7.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/plugins/transforms/memgroupby/src/test/java/org/apache/hop/pipeline/transforms/memgroupby/MemoryGroupByAggregationNullsTest.java
+++ b/plugins/transforms/memgroupby/src/test/java/org/apache/hop/pipeline/transforms/memgroupby/MemoryGroupByAggregationNullsTest.java
@@ -41,7 +41,6 @@ import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ValueMetaFactory.class})
-@Ignore
 public class MemoryGroupByAggregationNullsTest {
 
   static TransformMockHelper<MemoryGroupByMeta, MemoryGroupByData> mockHelper;

--- a/plugins/transforms/memgroupby/src/test/java/org/apache/hop/pipeline/transforms/memgroupby/MemoryGroupByMetaGetFieldsTest.java
+++ b/plugins/transforms/memgroupby/src/test/java/org/apache/hop/pipeline/transforms/memgroupby/MemoryGroupByMetaGetFieldsTest.java
@@ -28,22 +28,19 @@ import org.apache.hop.metadata.api.IHopMetadataProvider;
 import org.apache.hop.pipeline.transform.TransformMeta;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.apache.hop.pipeline.transforms.memgroupby.MemoryGroupByMeta.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.*;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ValueMetaFactory.class})
-@Ignore
 public class MemoryGroupByMetaGetFieldsTest {
 
   private MemoryGroupByMeta memoryGroupByMeta;
@@ -121,7 +118,7 @@ public class MemoryGroupByMetaGetFieldsTest {
 
     verify(rowMeta, times(1)).clear();
     verify(rowMeta, times(1)).addRowMeta(any());
-    assertEquals(null, rowMeta.searchValueMeta("minDate").getConversionMask());
+    assertNull(rowMeta.searchValueMeta("minDate").getConversionMask());
   }
 
   @Test

--- a/plugins/transforms/metainject/src/test/java/org/apache/hop/pipeline/transforms/metainject/MetaInjectTest.java
+++ b/plugins/transforms/metainject/src/test/java/org/apache/hop/pipeline/transforms/metainject/MetaInjectTest.java
@@ -29,7 +29,6 @@ import org.apache.hop.pipeline.transform.ITransform;
 import org.apache.hop.pipeline.transform.ITransformMeta;
 import org.apache.hop.pipeline.transform.TransformMeta;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
@@ -39,12 +38,11 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.util.*;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({MetaInject.class})
-@Ignore
 public class MetaInjectTest {
 
   private static final String INJECTOR_TRANSFORM_NAME = "TEST_TRANSFORM_FOR_INJECTION";


### PR DESCRIPTION
HOP-3633 Restored at leastOnce mode in verifyStatic which was initially used before commit 20da4ef7
HOP-3642 HOP-3643 Powermock upgrade
HOP-3651 HOP-3652 ignore removed - already working tests 
HOP-3647 Added explicit mock of IRowMeta to IRowSet objects - fixes ClassCastException when invoking mocked clone method