### PR TITLE
[HOP-3606] Disabled java 11 tests

### DIFF
--- a/plugins/transforms/fieldsplitter/src/test/java/org/apache/hop/pipeline/transforms/fieldsplitter/FieldSplitterTest.java
+++ b/plugins/transforms/fieldsplitter/src/test/java/org/apache/hop/pipeline/transforms/fieldsplitter/FieldSplitterTest.java
@@ -38,8 +38,7 @@ import org.junit.*;
 import java.util.Arrays;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 /**
@@ -61,7 +60,7 @@ public class FieldSplitterTest {
     transformMockHelper =
         new TransformMockHelper<>(
             "Field Splitter", FieldSplitterMeta.class, FieldSplitterData.class);
-    when(transformMockHelper.logChannelFactory.create(any(), any(ILoggingObject.class)))
+    when(transformMockHelper.logChannelFactory.create(any(), nullable(ILoggingObject.class)))
         .thenReturn(transformMockHelper.iLogChannel);
     when(transformMockHelper.pipeline.isRunning()).thenReturn(true);
   }
@@ -81,12 +80,12 @@ public class FieldSplitterTest {
     doCallRealMethod()
         .when(meta)
         .getFields(
-            any(IRowMeta.class),
-            anyString(),
-            any(IRowMeta[].class),
-            any(TransformMeta.class),
-            any(IVariables.class),
-            any(IHopMetadataProvider.class));
+                any(IRowMeta.class),
+                nullable(String.class),
+		        nullable(IRowMeta[].class),
+		        nullable(TransformMeta.class),
+		        nullable(IVariables.class),
+		        nullable(IHopMetadataProvider.class));
     doReturn(new String[] {"a", "b"}).when(meta).getFieldName();
     doReturn(new int[] {IValueMeta.TYPE_STRING, IValueMeta.TYPE_STRING}).when(meta).getFieldType();
     doReturn(new String[] {"a=", "b="}).when(meta).getFieldID();
@@ -116,7 +115,6 @@ public class FieldSplitterTest {
   }
 
   @Test
-  @Ignore
   public void testSplitFields() throws HopException {
 
     FieldSplitter transform =

--- a/plugins/transforms/xml/src/test/java/org/apache/hop/pipeline/transforms/xml/xmljoin/XmlJoinOmitNullValuesTest.java
+++ b/plugins/transforms/xml/src/test/java/org/apache/hop/pipeline/transforms/xml/xmljoin/XmlJoinOmitNullValuesTest.java
@@ -28,14 +28,11 @@ import org.apache.hop.pipeline.transform.errorhandling.IStream;
 import org.apache.hop.pipeline.transforms.mock.TransformMockHelper;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.List;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 /**
@@ -43,8 +40,6 @@ import static org.mockito.Mockito.*;
  *
  * @see XmlJoin
  */
-@RunWith(MockitoJUnitRunner.class)
-@Ignore
 public class XmlJoinOmitNullValuesTest {
   TransformMockHelper<XmlJoinMeta, XmlJoinData> tmh;
 


### PR DESCRIPTION
HOP-3645 any() replaced with nullable() matchers
HOP-3641 Removed unnecessary mockito runner annotation to avoid setting silent mockito runner mode or refactoring in transformhelper (unused stubs detection)
HOP-3629 Fixed by mocking HttpClient response because of complexity of properly mocking full execute api of HttpClient 