### PR TITLE
HOP-3838 "javax.xml.stream" and "org.w3c.dom" packages in more than one module

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -536,17 +536,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-            <version>1.4.01</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>com.googlecode.json-simple</groupId>
             <artifactId>json-simple</artifactId>
             <version>${json-simple.version}</version>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -53,6 +53,7 @@
         <picocli-version>4.6.3</picocli-version>
         <json-simple.version>1.1.1</json-simple.version>
         <commons-vfs2.version>2.9.0</commons-vfs2.version>
+        <jaxen.version>1.2.0</jaxen.version>
     </properties>
 
     <dependencies>
@@ -485,6 +486,7 @@
         <dependency>
             <groupId>jaxen</groupId>
             <artifactId>jaxen</artifactId>
+            <version>${jaxen.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/plugins/transforms/excelinput/pom.xml
+++ b/plugins/transforms/excelinput/pom.xml
@@ -71,6 +71,12 @@
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
             <version>${xerces.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/plugins/transforms/xml/pom.xml
+++ b/plugins/transforms/xml/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <saxon.version>8.7</saxon.version>
-        <jaxen.version>1.1.6</jaxen.version>
+        <jaxen.version>1.2.0</jaxen.version>
     </properties>
 
     <dependencies>
@@ -48,6 +48,12 @@
             <groupId>jaxen</groupId>
             <artifactId>jaxen</artifactId>
             <version>${jaxen.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
There is two last problem:
1) hop-transform-xml plugin, but I can't find the duplicate modules with the "javax.xml.stream" package.
2) hop-plugins-tech-cassandra plugi, but I can't find the duplicate modules with the "java.util" package.