### PR TITLE
HOP-3838 Remove duplicate test dependency with hop-core

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -485,6 +485,12 @@
             <artifactId>woodstox-core-asl</artifactId>
             <version>${woodstox-core-asl.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/plugins/transforms/pom.xml
+++ b/plugins/transforms/pom.xml
@@ -288,14 +288,6 @@
 
             <dependency>
                 <groupId>org.apache.hop</groupId>
-                <artifactId>hop-core</artifactId>
-                <version>${project.version}</version>
-                <classifier>test</classifier>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.hop</groupId>
                 <artifactId>hop-engine</artifactId>
                 <version>${project.version}</version>
                 <type>test-jar</type>


### PR DESCRIPTION
The test dependency with the old woodstox-core-asl.version 4.4.1 should probably be removed but if I remove it, some tests fail.