### PR TITLE
[HOP-3485] Clarifying driver location

### DIFF
--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases.adoc
@@ -23,19 +23,24 @@ Creating a database connection in HOP is done using one of the many database typ
 To create a database connection go to file -> New and select Database connection.
 
 The connection is saved in a central location and can then be used by all pipelines and workflows.
+If you have set your project to work with Hop, the database information will be in the `${PROJECT_HOME}/metadata/rdbms` folder.
+Each connection created will generate a .json file in this folder with the name of the connection, containing the connection information.
 
-If the license allowed it a jdbc driver is included in the distribution.
-The documentation of the database type shows you whether the driver is included and if it isn't included will guide you to the location on where to download it.
+If the license allowed it, a jdbc driver is included in the distribution, in a folder specific for each driver, in the general path: `Installation directory/plugins/databases/Database type/lib`.
+The documentation of the database type in following subsections shows you whether the driver is included and if it isn't included will guide you to the location on where to download it.
 
 The `HOP_SHARED_JDBC_FOLDER` variable can be set before starting Hop to point at a centralized location of your required jdbc drivers.
-This can be set as an environment variable or be added to the Hop start script as an exported variable.
+This can be set as an OS environment variable or be added to the Hop start script as an exported variable.
+Setting this variable pointed to a folder separated from the Hop installation folder, allows you to keep your drivers versions, no matter which Hop version or installation you use.
+
+To avoid conflicts, be sure that for each class of driver, there is only one in any of this folders, `HOP_SHARED_JDBC_FOLDER`, `hop/plugins/databases/Database type/lib` or `hop/lib` folder.
 
 == Generic connection
 
 HOP can connect to any database that has a jdbc driver available, the list of supplied databases contain some database specific configuration and a list of reserved keywords.
 
 When a specific database type is not yet available for the database you want to use, you can use the generic connection.
-To use a generic connection you have to copy your jdbc driver to the `Installation directory/lib` folder.
+To use a generic connection you have to copy your jdbc driver to the `Installation directory/lib` folder, or in the `HOP_SHARED_JDBC_FOLDER` if you have set this variable.
 
 image::generic_connection.png[Generic Connection Dialog]
 

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/as400.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/as400.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://www.ibm.com/support/knowledgecenter/ssw_ibm_i_71/rzahh/javadoc/com/ibm/as400/access/doc-files/JDBCProperties.html[Documentation Link]
 |JDBC Url | jdbc:as400://hostname/default-schema
+|Driver folder | Hop Installation/plugins/databases/as400/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/cache.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/cache.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://cedocs.intersystems.com/latest/csp/docbook/DocBook.UI.Page.cls?KEY=BGJD[Documentation Link]
 |JDBC Url  | jdbc:Cache://hostname:1972/database
+|Driver folder | Hop Installation/plugins/databases/cache/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/clickhouse.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/clickhouse.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://github.com/blynkkk/clickhouse4j[Documentation Link]
 |JDBC Url | jdbc:clickhouse://<host>:<port>[/<database>]
+|Driver folder | Hop Installation/plugins/databases/clickhouse/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/db2.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/db2.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://www.ibm.com/support/knowledgecenter/SSCQGF_7.2.0.1/com.ibm.IBMDI.doc_7.2.0.1/rg_conn_jdbc.html[Documentation Link]
 |JDBC Url  | jdbc:db2://hostname:port/dbname
+|Driver folder | Hop Installation/plugins/databases/db2/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/derby.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/derby.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://db.apache.org/derby/derby_downloads.html[Documentation Link]
 |JDBC Url | jdbc:derby:myDB
+|Driver folder | Hop Installation/plugins/databases/derby/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/doris.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/doris.adoc
@@ -32,6 +32,7 @@ Please see the https://doris.apache.org[Apache Doris website] for more informati
 |Hop Dependencies | None
 |Documentation | https://dev.mysql.com/doc/connector-j/8.0/en/[Documentation Link]
 |JDBC Url | jdbc:mysql://hostname:9030/databaseName
+|Driver folder | Hop Installation/plugins/databases/doris/lib
 |===
 
 The port of JDBC Url is same as the query port of Frontend in Doris.

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/exasol.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/exasol.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://docs.exasol.com/connect_exasol/drivers/jdbc.htm[Documentation Link]
 |JDBC Url | jdbc:exa:<server>:<port8563>
+|Driver folder | Hop Installation/plugins/databases/exasol4/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/firebird.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/firebird.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://firebirdsql.github.io/jaybird-manual/jaybird_manual.html[Documentation Link]
 |JDBC Url | jdbc:firebirdsql://localhost:3050/c:/database/example.fdb
+|Driver folder | Hop Installation/plugins/databases/firebird/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/googlebigquery.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/googlebigquery.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://www.simba.com/products/BigQuery/doc/JDBC_InstallGuide/content/jdbc/d-intro.htm[Documentation Link]
 |JDBC Url | jdbc:bigquery://[Host]:[Port];ProjectId=[Project];OAuthType=[AuthValue]
+|Driver folder | Hop Installation/plugins/databases/googlebigquery/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/greenplum.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/greenplum.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | Postgresql Plugin
 |Documentation | https://gpdb.docs.pivotal.io/590/datadirect/datadirect_jdbc.html[Documentation Link]
 |JDB Url | jdbc:pivotal:greenplum://host:port;DatabaseName=<name>
+|Driver folder | Hop Installation/plugins/databases/greenplum/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/h2.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/h2.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://jdbc.postgresql.org/documentation/head/index.html[Documentation Link]
 |JDBC Url | jdbc:h2:[file:][<path>]<databaseName>
+|Driver folder | Hop Installation/plugins/databases/h2/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/hypersonic.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/hypersonic.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | http://hsqldb.org/doc/2.0/guide/dbproperties-chapt.html[Documentation Link]
 |JDBC Url | jdbc:hsqldb:hsql//hostname
+|Driver folder | Hop Installation/plugins/databases/hypersonic/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/infinidb.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/infinidb.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | Mysql Database Plugin
 |Documentation | https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference.html[Documentation Link]
 |JDBC Url | jdbc:mysql://hostname:3306/databaseName
+|Driver folder | Hop Installation/plugins/databases/infinidb/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/infobright.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/infobright.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | Mysql Database Plugin
 |Documentation | https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference.html[Documentation Link]
 |JDBC Url | jdbc:mysql://hostname:3306/databaseName
+|Driver folder | Hop Installation/plugins/databases/infobright/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/informix.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/informix.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://www.ibm.com/support/knowledgecenter/en/SSGU8G_12.1.0/com.ibm.jdbc_pg.doc/jdbc.htm[Documentation Link]
 |JDBC Url | jdbc:informix-sqli://hostname:1533/databaseName
+|Driver folder | Hop Installation/plugins/databases/informix/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/ingres.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/ingres.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://docs.actian.com/ingres/11.0/index.html#page/Connectivity%2FJDBC_Driver_and_Data_Source_Classes.htm%23[Documentation Link]
 |JDBC Url | jdbc:ingres://host:port{,port}{;host:port{,port}}/db{;attr=value}
+|Driver folder | Hop Installation/plugins/databases/ingres/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/interbase.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/interbase.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | http://docwiki.embarcadero.com/InterBase/2020/en/Programming_with_JDBC[Documentation Link]
 |JDBC Url | jdbc:interbase://hostname:3050/path/to/database.ib
+|Driver folder | Hop Installation/plugins/databases/interbase/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/kingbasees.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/kingbasees.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://www.kingbase.com.cn/zhuanti/kes/html/jdbc.html[Documentation Link]
 |JDBC Url | jdbc:kingbase8://host:port/database
+|Driver folder | Hop Installation/plugins/databases/kingbasees/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/mariadb.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/mariadb.adoc
@@ -28,5 +28,6 @@ under the License.
 |Version Included | None
 |Hop Dependencies | Mysql Database plugin
 |Documentation | https://mariadb.com/kb/en/about-mariadb-connector-j/[Documentation Link]
-|JDBC Url |
+|JDBC Url | jdbc:mariadb://hostname:port/databaseName
+|Driver folder | Hop Installation/plugins/databases/mariadb/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/monetdb.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/monetdb.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://www.monetdb.org/Documentation/Manuals/SQLreference/Programming/JDBC[Documentation Link]
 |JDBC Url |  jdbc:monetdb://hostname/databaseName
+|Driver folder | Hop Installation/plugins/databases/monetdb/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/mssql.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/mssql.adoc
@@ -32,4 +32,5 @@ When creating new database connections it is recommended to use the native conne
 |Hop Dependencies | None
 |Documentation | http://jtds.sourceforge.net/faq.html[Documentation Link]
 |JDBC Url | jdbc:jtds:sqlserver://<server>[:<port>][/<database>][;<property>=<value>[;...]]
+|Driver folder | Hop Installation/plugins/databases/mssql/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/mssqlnative.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/mssqlnative.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://docs.microsoft.com/en-us/sql/connect/jdbc/setting-the-connection-properties?view=sql-server-ver15[Documentation Link]
 |JDBC Url | jdbc:sqlserver://[serverName[\instanceName][:portNumber]][;property=value[;property=value]]
+|Driver folder | Hop Installation/plugins/databases/mssqlnative/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/mysql.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/mysql.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://dev.mysql.com/doc/connector-j/8.0/en/[Documentation Link]
 |JDBC Url | jdbc:mysql://hostname:33060/databaseName
+|Driver folder | Hop Installation/plugins/databases/mysql/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/netezza.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/netezza.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://www.ibm.com/support/knowledgecenter/SSULQD_7.2.1/com.ibm.nz.datacon.doc/c_datacon_installing_configuring_jdbc.html[Documentation Link]
 |JDBC Url | jdbc:netezza://hostname:5490/databaseName
+|Driver folder | Hop Installation/plugins/databases/netezza/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/oracle.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/oracle.adoc
@@ -29,6 +29,7 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://docs.oracle.com/cd/E11882_01/java.112/e16548/toc.htm[Documentation Link]
 |JDBC Url | jdbc:oracle:thin:@hostname:port Number:databaseName
+|Driver folder | Hop Installation/plugins/databases/oracle/lib
 |===
 
 TIP: Starting with Oracle Database 11g Release 1 (11.1), data type "Date" will be mapped to "Timestamp" by default. 

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/oraclerdb.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/oraclerdb.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://www.oracle.com/technetwork/database/database-technologies/rdb/documentation/rdbjdbc-ug-725-129654.pdf[Documentation Link]
 |JDBC Url | jdbc:rdbThin://<node>:<port>/<database_specification>
+|Driver folder | Hop Installation/plugins/databases/oraclerdb/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/postgresql.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/postgresql.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://jdbc.postgresql.org/documentation/head/index.html[Documentation Link]
 |JDBC Url  | jdbc:postgresql://host:port/database
+|Driver folder | Hop Installation/plugins/databases/as400/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/redshift.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/redshift.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | Postgresql Database plugin
 |Documentation | https://docs.aws.amazon.com/redshift/latest/mgmt/configure-jdbc-connection.html[Documentation Link]
 |JDBC Url | jdbc:redshift://endpoint:port/database
+|Driver folder | Hop Installation/plugins/databases/redshift/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/sapdb.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/sapdb.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://help.sap.com/saphelp_tm93/helpdata/en/37/5f6b6e966242aead8025bdc5296489/frameset.htm[Documentation Link]
 |JDBC Url | jdbc:sapdb://<database_computer>[:<port>]/<database_name>
+|Driver folder | Hop Installation/plugins/databases/sapdb/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/snowflake.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/snowflake.adoc
@@ -28,5 +28,6 @@ under the License.
 |Version Included | 3.11.1
 |Hop Dependencies | None
 |Documentation | https://docs.snowflake.net/manuals/user-guide/jdbc-configure.html[Documentation Link]
-|JDBC Url | jdbc:snowflake://<account_name>.snowflakecomputing.com/?<connection_params>
+|JDBC Url | `jdbc:snowflake://<account_name>.snowflakecomputing.com/?<connection_params>`
+|Driver folder | Hop Installation/plugins/databases/snowflake/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/sqlbase.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/sqlbase.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://knowledge.opentext.com/knowledge/cs.dll/kcs/kb[Documentation Link]
 |JDBC Url | jdbc:sqlbase://hostname:port/databaseName
+|Driver folder | Hop Installation/plugins/databases/sqlbase/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/sqlite.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/sqlite.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://www.sqlitetutorial.net/sqlite-java/sqlite-jdbc-driver/[Documentation Link]
 |JDBC Url | jdbc:sqlite:sample.db
+|Driver folder | Hop Installation/plugins/databases/sqlite/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/sybase.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/sybase.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | http://jtds.sourceforge.net/faq.html[Documentation Link]
 |JDBC Url | jdbc:jtds:sybase://<server>[:<port>][/<database>][;<property>=<value>[;...]]
+|Driver folder | Hop Installation/plugins/databases/sybase/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/sybaseiq.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/sybaseiq.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | http://infocenter.sybase.com/help/index.jsp?topic=/com.sybase.infocenter.dc01776.1600/doc/html/san1357754910584.html[Documentation Link]
 |JDBC Url | jdbc:sybase:Tds:localhost:2638
+|Driver folder | Hop Installation/plugins/databases/sybaseiq/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/teradata.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/teradata.adoc
@@ -28,4 +28,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://teradata-docs.s3.amazonaws.com/doc/connectivity/jdbc/reference/current/frameset.html[Documentation Link]
 |JDBC Url | jdbc:teradata://Hostname
+|Driver folder | Hop Installation/plugins/databases/teradata/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/universe.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/universe.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://www-05.ibm.com/e-business/linkweb/publications/servlet/pbi.wss?CTY=US&FNC=SRX&PBL=G251-1210-00#[Documentation Link]
 |JDBC Url | jdbc:ibmu2://localhost
+|Driver folder | Hop Installation/plugins/databases/universe/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/vectorwise.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/vectorwise.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://docs.actian.com/ingres/11.0/index.html#page/Connectivity%2FJDBC_Driver_and_Data_Source_Classes.htm%23[Documentation Link]
 |JDBC Url | jdbc:ingres://host:port{,port}{;host:port{,port}}/db{;attr=value}
+|Driver folder | Hop Installation/plugins/databases/vectorwise/lib
 |===

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/vertica.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/vertica.adoc
@@ -29,4 +29,5 @@ under the License.
 |Hop Dependencies | None
 |Documentation | https://www.vertica.com/docs/9.2.x/HTML/Content/Authoring/ConnectingToVertica/ClientJDBC/JDBCConnectionProperties.htm[Documentation Link]
 |JDBC Url | jdbc:vertica://VerticaHost:portNumber/databaseName
+|Driver folder | Hop Installation/plugins/databases/vertica/lib
 |===


### PR DESCRIPTION
Modified the database documentation files, the driver specific files have been modified adding a new row in the table with the specific folder for the driver, the generic database.adoc file has some paragraphs added to clarify how to set the driver locations