### PR TITLE
HOP-3838 package is accessible from more than one module

### DIFF
--- a/assemblies/core/lib/pom.xml
+++ b/assemblies/core/lib/pom.xml
@@ -53,7 +53,6 @@
         <databricks.version>4.0.0</databricks.version>
         <paho.version>1.2.0</paho.version>
         <bahir.version>2.1.1</bahir.version>
-        <xerces.version>2.12.2</xerces.version>
 
         <!-- Spring -->
         <springframework4.version>4.3.18</springframework4.version>
@@ -100,12 +99,6 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <!-- Third-party JDBC dependencies -->
-        <dependency>
-            <groupId>jaxen</groupId>
-            <artifactId>jaxen</artifactId>
         </dependency>
 
         <!-- Other third-party dependencies -->
@@ -290,24 +283,6 @@
         <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
-            <version>${xerces.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-            <version>1.4.01</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
     </dependencies>

--- a/assemblies/lib/pom.xml
+++ b/assemblies/lib/pom.xml
@@ -102,13 +102,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- Third-party JDBC dependencies -->
-        <dependency>
-            <groupId>jaxen</groupId>
-            <artifactId>jaxen</artifactId>
-        </dependency>
 
         <!-- Other third-party dependencies -->
+        <dependency>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>

--- a/assemblies/plugins/transforms/xml/pom.xml
+++ b/assemblies/plugins/transforms/xml/pom.xml
@@ -38,7 +38,8 @@
 
     <properties>
         <saxon.version>8.7</saxon.version>
-        <jaxen.version>1.1.6</jaxen.version>
+        <dom4j.version>2.1.3</dom4j.version>
+        <jaxen.version>1.2.0</jaxen.version>   
     </properties>
 
     <dependencies>
@@ -52,6 +53,11 @@
             <artifactId>saxon-dom</artifactId>
             <version>${saxon.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.dom4j</groupId>
+            <artifactId>dom4j</artifactId>
+            <version>${dom4j.version}</version>
+        </dependency>        
         <dependency>
             <groupId>jaxen</groupId>
             <artifactId>jaxen</artifactId>

--- a/assemblies/plugins/transforms/xml/src/assembly/assembly.xml
+++ b/assemblies/plugins/transforms/xml/src/assembly/assembly.xml
@@ -57,6 +57,13 @@
             <useProjectArtifact>false</useProjectArtifact>
             <outputDirectory>lib</outputDirectory>
             <includes>
+                <include>org.dom4j:dom4j:jar</include>
+            </includes>
+        </dependencySet>        
+        <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>lib</outputDirectory>
+            <includes>
                 <include>jaxen:jaxen:jar</include>
             </includes>
         </dependencySet>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -61,7 +61,6 @@
         <json-simple.version>1.1.1</json-simple.version>
         <gson.version>2.8.5</gson.version>
         <jandex.version>2.2.2.Final</jandex.version>
-        <xerces.version>2.12.2</xerces.version>
     </properties>
 
     <dependencies>
@@ -414,10 +413,6 @@
             <artifactId>commons-compress</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.dom4j</groupId>
-            <artifactId>dom4j</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jandex</artifactId>
             <version>${jandex.version}</version>
@@ -485,7 +480,13 @@
             <artifactId>woodstox-core-asl</artifactId>
             <version>${woodstox-core-asl.version}</version>
             <scope>test</scope>
-        </dependency>
+            <exclusions>
+               <exclusion>
+                 <groupId>javax.xml.stream</groupId>
+                 <artifactId>stax-api</artifactId>
+               </exclusion>
+             </exclusions>
+        </dependency>        
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>java-hamcrest</artifactId>
@@ -516,12 +517,10 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/core/src/main/java/org/apache/hop/core/xml/XmlParserFactoryProducer.java
+++ b/core/src/main/java/org/apache/hop/core/xml/XmlParserFactoryProducer.java
@@ -19,12 +19,8 @@ package org.apache.hop.core.xml;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.dom4j.io.SAXReader;
-import org.xml.sax.EntityResolver;
-import org.xml.sax.SAXException;
 import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
-
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -69,29 +65,11 @@ public class XmlParserFactoryProducer {
   public static SAXParserFactory createSecureSAXParserFactory()
       throws SAXNotSupportedException, SAXNotRecognizedException, ParserConfigurationException {
     SAXParserFactory factory = SAXParserFactory.newInstance();
-    factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);    
     factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
     factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
     factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
 
     return factory;
-  }
-
-  public static SAXReader getSAXReader(final EntityResolver resolver) {
-    SAXReader reader = new SAXReader();
-    if (resolver != null) {
-      reader.setEntityResolver(resolver);
-    }
-    try {
-      reader.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-      reader.setFeature("http://xml.org/sax/features/external-general-entities", false);
-      reader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-      reader.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-    } catch (SAXException e) {
-      logger.error("Some parser properties are not supported.");
-    }
-    reader.setIncludeExternalDTDDeclarations(false);
-    reader.setIncludeInternalDTDDeclarations(false);
-    return reader;
   }
 }

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -53,7 +53,6 @@
         <picocli-version>4.6.3</picocli-version>
         <json-simple.version>1.1.1</json-simple.version>
         <commons-vfs2.version>2.9.0</commons-vfs2.version>
-        <jaxen.version>1.2.0</jaxen.version>
     </properties>
 
     <dependencies>
@@ -480,13 +479,6 @@
             <version>${project.version}</version>
             <classifier>tests</classifier>
             <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <!-- required by org.dom4j -->
-        <dependency>
-            <groupId>jaxen</groupId>
-            <artifactId>jaxen</artifactId>
-            <version>${jaxen.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/plugins/transforms/excelinput/pom.xml
+++ b/plugins/transforms/excelinput/pom.xml
@@ -36,7 +36,6 @@
     <properties>
         <odfdom-java.version>0.8.7</odfdom-java.version>
         <poi.version>5.2.1</poi.version>
-        <xerces.version>2.12.2</xerces.version>
     </properties>
 
     <dependencies>
@@ -70,13 +69,6 @@
         <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
-            <version>${xerces.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 

--- a/plugins/transforms/excelwriter/pom.xml
+++ b/plugins/transforms/excelwriter/pom.xml
@@ -35,7 +35,6 @@
 
     <properties>
         <poi.version>5.2.1</poi.version>
-        <xerces.version>2.12.2</xerces.version>
     </properties>
 
     <dependencies>
@@ -52,7 +51,6 @@
         <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
-            <version>${xerces.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/plugins/transforms/xml/pom.xml
+++ b/plugins/transforms/xml/pom.xml
@@ -35,7 +35,8 @@
 
     <properties>
         <saxon.version>8.7</saxon.version>
-        <jaxen.version>1.2.0</jaxen.version>
+        <dom4j.version>2.1.3</dom4j.version>
+        <jaxen.version>1.2.0</jaxen.version>        
     </properties>
 
     <dependencies>
@@ -44,6 +45,12 @@
             <artifactId>saxon-dom</artifactId>
             <version>${saxon.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.dom4j</groupId>
+            <artifactId>dom4j</artifactId>
+            <version>${dom4j.version}</version>
+        </dependency>        
+        <!-- required by org.dom4j -->
         <dependency>
             <groupId>jaxen</groupId>
             <artifactId>jaxen</artifactId>
@@ -54,6 +61,10 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/Dom4JUtil.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/Dom4JUtil.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hop.pipeline.transforms.xml;
+
+import org.apache.hop.core.logging.HopLogStore;
+import org.apache.hop.core.logging.ILogChannel;
+import org.dom4j.io.SAXReader;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.SAXException;
+import javax.xml.XMLConstants;
+
+public class Dom4JUtil {
+  
+  private static final ILogChannel log = HopLogStore.getLogChannelFactory().create("Xml");
+
+  private Dom4JUtil() {    
+  }
+  
+  public static SAXReader getSAXReader(final EntityResolver resolver) {
+    SAXReader reader = new SAXReader();
+    if (resolver != null) {
+      reader.setEntityResolver(resolver);
+    }
+    try {
+      reader.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      reader.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      reader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+      reader.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+    } catch (SAXException e) {
+      log.logError("Some parser properties are not supported.");
+    }
+    reader.setIncludeExternalDTDDeclarations(false);
+    reader.setIncludeInternalDTDDeclarations(false);
+    return reader;
+  }
+}

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/getxmldata/GetXmlData.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/getxmldata/GetXmlData.java
@@ -31,13 +31,13 @@ import org.apache.hop.core.row.value.ValueMetaFactory;
 import org.apache.hop.core.util.HttpClientManager;
 import org.apache.hop.core.util.Utils;
 import org.apache.hop.core.vfs.HopVfs;
-import org.apache.hop.core.xml.XmlParserFactoryProducer;
 import org.apache.hop.i18n.BaseMessages;
 import org.apache.hop.pipeline.Pipeline;
 import org.apache.hop.pipeline.PipelineMeta;
 import org.apache.hop.pipeline.transform.BaseTransform;
 import org.apache.hop.pipeline.transform.ITransform;
 import org.apache.hop.pipeline.transform.TransformMeta;
+import org.apache.hop.pipeline.transforms.xml.Dom4JUtil;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -81,7 +81,7 @@ public class GetXmlData extends BaseTransform<GetXmlDataMeta, GetXmlDataData>
     this.prevRow = buildEmptyRow(); // pre-allocate previous row
 
     try {
-      SAXReader reader = XmlParserFactoryProducer.getSAXReader(null);
+      SAXReader reader = Dom4JUtil.getSAXReader(null);
       data.stopPruning = false;
       // Validate XML against specified schema?
       if (meta.isValidating()) {

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/getxmldata/LoopNodesImportProgressDialog.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/getxmldata/LoopNodesImportProgressDialog.java
@@ -21,8 +21,8 @@ import org.apache.hop.core.IProgressMonitor;
 import org.apache.hop.core.IRunnableWithProgress;
 import org.apache.hop.core.util.Utils;
 import org.apache.hop.core.vfs.HopVfs;
-import org.apache.hop.core.xml.XmlParserFactoryProducer;
 import org.apache.hop.i18n.BaseMessages;
+import org.apache.hop.pipeline.transforms.xml.Dom4JUtil;
 import org.apache.hop.ui.core.dialog.ErrorDialog;
 import org.apache.hop.ui.core.dialog.ProgressMonitorDialog;
 import org.dom4j.Document;
@@ -30,7 +30,6 @@ import org.dom4j.Element;
 import org.dom4j.Node;
 import org.dom4j.io.SAXReader;
 import org.eclipse.swt.widgets.Shell;
-
 import java.io.InputStream;
 import java.io.StringReader;
 import java.lang.reflect.InvocationTargetException;
@@ -136,7 +135,7 @@ public class LoopNodesImportProgressDialog {
             PKG, "GetXMLDateLoopNodesImportProgressDialog.Task.ScanningFile", filename),
         1);
 
-    SAXReader reader = XmlParserFactoryProducer.getSAXReader(null);
+    SAXReader reader = Dom4JUtil.getSAXReader(null);
     monitor.worked(1);
     if (monitor.isCanceled()) {
       return null;

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/getxmldata/XmlInputFieldsImportProgressDialog.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/getxmldata/XmlInputFieldsImportProgressDialog.java
@@ -23,8 +23,8 @@ import org.apache.hop.core.RowMetaAndData;
 import org.apache.hop.core.row.IValueMeta;
 import org.apache.hop.core.util.Utils;
 import org.apache.hop.core.vfs.HopVfs;
-import org.apache.hop.core.xml.XmlParserFactoryProducer;
 import org.apache.hop.i18n.BaseMessages;
+import org.apache.hop.pipeline.transforms.xml.Dom4JUtil;
 import org.apache.hop.ui.core.dialog.ErrorDialog;
 import org.apache.hop.ui.core.dialog.ProgressMonitorDialog;
 import org.dom4j.Attribute;
@@ -155,7 +155,7 @@ public class XmlInputFieldsImportProgressDialog {
             PKG, "GetXMLDateLoopNodesImportProgressDialog.Task.ScanningFile", filename),
         1);
 
-    SAXReader reader = XmlParserFactoryProducer.getSAXReader(null);
+    SAXReader reader = Dom4JUtil.getSAXReader(null);
     monitor.worked(1);
     if (monitor.isCanceled()) {
       return null;

--- a/pom.xml
+++ b/pom.xml
@@ -168,8 +168,6 @@
 
         <codehaus-jackson.version>1.9.13</codehaus-jackson.version>
         <jackson.version>2.13.0</jackson.version>
-        <dom4j.version>2.1.3</dom4j.version>
-        <jaxen.version>1.1.6</jaxen.version>
         <commons-compress.version>1.21</commons-compress.version>
         <commons-fileupload.version>1.4</commons-fileupload.version>
         <aws-java-sdk.version>1.11.974</aws-java-sdk.version>
@@ -178,7 +176,6 @@
         <spring-security.version>4.1.5.RELEASE</spring-security.version>
 
         <xerces.version>2.12.2</xerces.version>
-        <xml-apis.version>1.4.01</xml-apis.version>
 
         <!-- jdk version -->
         <source.jdk.version>11</source.jdk.version>
@@ -420,17 +417,6 @@
                 <artifactId>jackson-jr-objects</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
-
-            <dependency>
-                <groupId>org.dom4j</groupId>
-                <artifactId>dom4j</artifactId>
-                <version>${dom4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jaxen</groupId>
-                <artifactId>jaxen</artifactId>
-                <version>${jaxen.version}</version>
-            </dependency>
             <dependency>
                 <groupId>commons-fileupload</groupId>
                 <artifactId>commons-fileupload</artifactId>
@@ -470,12 +456,13 @@
                 <groupId>xerces</groupId>
                 <artifactId>xercesImpl</artifactId>
                 <version>${xerces.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>xml-apis</groupId>
-                <artifactId>xml-apis</artifactId>
-                <version>${xml-apis.version}</version>
-            </dependency>
+                <exclusions>
+                  <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                  </exclusion>
+              </exclusions>
+            </dependency>            
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>


### PR DESCRIPTION
Remove library xml-apis dependency native in JVM 11
Exclude xml-apis from xerces dependency
Exclude stax-api from woodstox dependency
Move libraries dom4j and jaxen from core to transform-xml plugin
Remove some <version> tag from managed dependencies
