### PR TITLE
HOP-3729 Add missing annotation to plugin variable

### DIFF
--- a/core/src/main/java/org/apache/hop/core/Const.java
+++ b/core/src/main/java/org/apache/hop/core/Const.java
@@ -518,7 +518,7 @@ public class Const {
   public static final String HOP_ROWSET_PUT_TIMEOUT = "HOP_ROWSET_PUT_TIMEOUT";
 
   /** Set this variable to Y if you want to test a more efficient batching row set. (default = N) */
-  @Variable(value="N", description=" Set this variable to Y if you want to test a more efficient batching row set.")
+  @Variable(value="N", description="Set this variable to 'Y' if you want to test a more efficient batching row set.")
   public static final String HOP_BATCHING_ROWSET = "HOP_BATCHING_ROWSET";
 
   /**

--- a/docs/hop-user-manual/modules/ROOT/pages/variables.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/variables.adoc
@@ -174,12 +174,6 @@ Otherwise by default a NULL is returned when all values are NULL.
 Otherwise by default NULL is ignored by the MIN aggregate and MIN is set to the minimum value that is not NULL.
 See also the variable HOP_AGGREGATION_ALL_NULLS_ARE_ZERO.
 |HOP_ALLOW_EMPTY_FIELD_NAMES_AND_TYPES|N|Set this variable to Y to allow your pipeline to pass 'null' fields and/or empty types.
-|HOP_COMPATIBILITY_DB_IGNORE_TIMEZONE|N|System wide flag to ignore timezone while writing date/timestamp value to the database.
-|HOP_COMPATIBILITY_MERGE_ROWS_USE_REFERENCE_STREAM_WHEN_IDENTICAL|N|Set this variable to Y for backward compatibility for the Merge Rows (diff) transform.
-Setting this to Y will use the data from the reference stream (instead of the comparison stream) in case the compared rows are identical.
-|HOP_COMPATIBILITY_TEXT_FILE_OUTPUT_APPEND_NO_HEADER|N|Set this variable to Y for backward compatibility for the Text File Output transform.
-Setting this to Ywill add no header row at all when the append option is enabled, regardless if the file is existing or not.
-You can use this to customize the list of available internal transforms outside of the codebase.
 |HOP_DEFAULT_BIGNUMBER_FORMAT||The name of the variable containing an alternative default bignumber format
 |HOP_DEFAULT_DATE_FORMAT||The name of the variable containing an alternative default date format
 |HOP_DEFAULT_INTEGER_FORMAT||The name of the variable containing an alternative default integer format

--- a/plugins/tech/aws/src/main/java/org/apache/hop/vfs/s3/s3common/S3HopProperty.java
+++ b/plugins/tech/aws/src/main/java/org/apache/hop/vfs/s3/s3common/S3HopProperty.java
@@ -18,15 +18,16 @@
 package org.apache.hop.vfs.s3.s3common;
 
 import org.apache.hop.core.config.HopConfig;
+import org.apache.hop.core.variables.Variable;
 
 /** Class that handles operations dealing with hop property file. */
 public class S3HopProperty {
-  // TODO: figure out a way to allow this plugin to add default values to the global list of
-  // variables
-  //
-  public static final String S3VFS_PART_SIZE = "HOP_S3_VFS_PART_SIZE";
+  
+  // TODO: Provide variable description
+  @Variable(description="")
+  public static final String HOP_S3_VFS_PART_SIZE = "HOP_S3_VFS_PART_SIZE";
 
   public String getPartSize() {
-    return HopConfig.getInstance().findDescribedVariableValue(S3VFS_PART_SIZE);
+    return HopConfig.getInstance().findDescribedVariableValue(HOP_S3_VFS_PART_SIZE);
   }
 }

--- a/plugins/tech/neo4j/src/main/java/org/apache/hop/neo4j/logging/Defaults.java
+++ b/plugins/tech/neo4j/src/main/java/org/apache/hop/neo4j/logging/Defaults.java
@@ -18,9 +18,12 @@
 
 package org.apache.hop.neo4j.logging;
 
+import org.apache.hop.core.variables.Variable;
+
 public class Defaults {
 
-  public static final String VARIABLE_NEO4J_LOGGING_CONNECTION = "NEO4J_LOGGING_CONNECTION";
+  @Variable(description="Set this variable to the name of an existing Neo4j connection to enable execution logging to a Neo4j database.")
+  public static final String NEO4J_LOGGING_CONNECTION = "NEO4J_LOGGING_CONNECTION";
 
   public static String TRANS_NODE_UPDATES_GROUP = "NODE_UPDATES";
 

--- a/plugins/tech/neo4j/src/main/java/org/apache/hop/neo4j/logging/util/LoggingCore.java
+++ b/plugins/tech/neo4j/src/main/java/org/apache/hop/neo4j/logging/util/LoggingCore.java
@@ -38,14 +38,14 @@ import java.util.concurrent.TimeUnit;
 public class LoggingCore {
 
   public static final boolean isEnabled(IVariables space) {
-    String connectionName = space.getVariable(Defaults.VARIABLE_NEO4J_LOGGING_CONNECTION);
+    String connectionName = space.getVariable(Defaults.NEO4J_LOGGING_CONNECTION);
     return StringUtils.isNotEmpty(connectionName)
         && !Defaults.VARIABLE_NEO4J_LOGGING_CONNECTION_DISABLED.equals(connectionName);
   }
 
   public static final NeoConnection getConnection(
       IHopMetadataProvider metadataProvider, IVariables space) throws HopException {
-    String connectionName = space.getVariable(Defaults.VARIABLE_NEO4J_LOGGING_CONNECTION);
+    String connectionName = space.getVariable(Defaults.NEO4J_LOGGING_CONNECTION);
     if (StringUtils.isEmpty(connectionName)) {
       return null;
     }

--- a/plugins/tech/neo4j/src/main/java/org/apache/hop/neo4j/logging/xp/PipelineLoggingExtensionPoint.java
+++ b/plugins/tech/neo4j/src/main/java/org/apache/hop/neo4j/logging/xp/PipelineLoggingExtensionPoint.java
@@ -70,7 +70,7 @@ public class PipelineLoggingExtensionPoint
     //
     pipeline.getExtensionDataMap().put(PIPELINE_START_DATE, new Date());
 
-    String connectionName = pipeline.getVariable(Defaults.VARIABLE_NEO4J_LOGGING_CONNECTION);
+    String connectionName = pipeline.getVariable(Defaults.NEO4J_LOGGING_CONNECTION);
 
     try {
 

--- a/plugins/tech/neo4j/src/main/java/org/apache/hop/neo4j/logging/xp/WorkflowLoggingExtensionPoint.java
+++ b/plugins/tech/neo4j/src/main/java/org/apache/hop/neo4j/logging/xp/WorkflowLoggingExtensionPoint.java
@@ -73,7 +73,7 @@ public class WorkflowLoggingExtensionPoint
     //
     workflow.getExtensionDataMap().put(WORKFLOW_START_DATE, new Date());
 
-    String connectionName = workflow.getVariable(Defaults.VARIABLE_NEO4J_LOGGING_CONNECTION);
+    String connectionName = workflow.getVariable(Defaults.NEO4J_LOGGING_CONNECTION);
 
     try {
       final NeoConnection connection =

--- a/plugins/tech/neo4j/src/main/java/org/apache/hop/neo4j/perspective/HopNeo4jPerspective.java
+++ b/plugins/tech/neo4j/src/main/java/org/apache/hop/neo4j/perspective/HopNeo4jPerspective.java
@@ -746,7 +746,7 @@ public class HopNeo4jPerspective implements IHopPerspective {
     if (!LoggingCore.isEnabled(variables)) {
       return null;
     }
-    String connectionName = variables.getVariable(Defaults.VARIABLE_NEO4J_LOGGING_CONNECTION);
+    String connectionName = variables.getVariable(Defaults.NEO4J_LOGGING_CONNECTION);
 
     final NeoConnection connection =
         LoggingCore.getConnection(hopGui.getMetadataProvider(), variables);

--- a/plugins/tech/neo4j/src/main/java/org/apache/hop/neo4j/transforms/loginfo/GetLoggingInfo.java
+++ b/plugins/tech/neo4j/src/main/java/org/apache/hop/neo4j/transforms/loginfo/GetLoggingInfo.java
@@ -195,7 +195,7 @@ public class GetLoggingInfo extends BaseTransform<GetLoggingInfoMeta, GetLogging
     if (connection == null) {
       throw new HopException(
           "Unable to find logging Neo4j connection (variable "
-              + Defaults.VARIABLE_NEO4J_LOGGING_CONNECTION
+              + Defaults.NEO4J_LOGGING_CONNECTION
               + ")");
     }
 
@@ -221,7 +221,7 @@ public class GetLoggingInfo extends BaseTransform<GetLoggingInfoMeta, GetLogging
     if (connection == null) {
       throw new HopException(
           "Unable to find logging Neo4j connection (variable "
-              + Defaults.VARIABLE_NEO4J_LOGGING_CONNECTION
+              + Defaults.NEO4J_LOGGING_CONNECTION
               + ")");
     }
 
@@ -248,7 +248,7 @@ public class GetLoggingInfo extends BaseTransform<GetLoggingInfoMeta, GetLogging
     if (connection == null) {
       throw new HopException(
           "Unable to find logging Neo4j connection (variable "
-              + Defaults.VARIABLE_NEO4J_LOGGING_CONNECTION
+              + Defaults.NEO4J_LOGGING_CONNECTION
               + ")");
     }
 
@@ -274,7 +274,7 @@ public class GetLoggingInfo extends BaseTransform<GetLoggingInfoMeta, GetLogging
     if (connection == null) {
       throw new HopException(
           "Unable to find logging Neo4j connection (variable "
-              + Defaults.VARIABLE_NEO4J_LOGGING_CONNECTION
+              + Defaults.NEO4J_LOGGING_CONNECTION
               + ")");
     }
 


### PR DESCRIPTION
Add missing annotation to plugin variable
- NEO4J_LOGGING_CONNECTION
- HOP_S3_VFS_PART_SIZE

Remove obsolete variable doc
- HOP_PIPELINE_PAN_JVM_EXIT_CODE
- HOP_COMPATIBILITY_DB_IGNORE_TIMEZONE
- HOP_COMPATIBILITY_MERGE_ROWS_USE_REFERENCE_STREAM_WHEN_IDENTICAL
- HOP_COMPATIBILITY_TEXT_FILE_OUTPUT_APPEND_NO_HEADER