### PR TITLE
HOP-3876 Using contrast color for foreground in text

### DIFF
--- a/ui/src/main/java/org/apache/hop/ui/core/widget/StyledTextComp.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/widget/StyledTextComp.java
@@ -245,8 +245,11 @@ public class StyledTextComp extends Composite {
       Color background =
           Display.getDefault()
               .getSystemColor(enabled ? SWT.COLOR_WHITE : SWT.COLOR_WIDGET_BACKGROUND);
-      textWidget.setForeground(foreground);
-      textWidget.setBackground(background);
+      GuiResource guiResource = GuiResource.getInstance();
+      textWidget.setForeground(
+          guiResource.getColor(foreground.getRed(), foreground.getGreen(), foreground.getBlue()));
+      textWidget.setBackground(
+          guiResource.getColor(background.getRed(), background.getGreen(), background.getBlue()));
     }
   }
 


### PR DESCRIPTION
Only change foreground in text control.

Hop-GUI seems to always use the same background when enable value is changed.