### PR TITLE
[HOP-3976] hop-web docker container cannot generate a fat JAR

### DIFF
--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -49,4 +49,6 @@ COPY ./docker/resources/run-web.sh /tmp/
 # Fix hop-config.json
 RUN sed -i 's/config\/projects/${HOP_CONFIG_FOLDER}\/projects/g' "${CATALINA_HOME}"/webapps/ROOT/config/hop-config.json
 
+RUN mkdir -p "$CATALINA_HOME"/libswt/linux/x86_64
+
 CMD ["/bin/bash", "/tmp/run-web.sh"]


### PR DESCRIPTION
hop-web docker container cannot generate a fat JAR

This is a quick and dirty fix for HOP-3976. After creating this empty directory, the JAR seems to be generated correctly (490MB JAR with all the dependencies in the lib dir, including all the plugins dependencies).

 - [X ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).