### PR TITLE
[HOP-3977] Fat JAR generated in hop-web container is missing some dependencies

### DIFF
--- a/plugins/engines/beam/src/main/java/org/apache/hop/beam/gui/HopBeamGuiPlugin.java
+++ b/plugins/engines/beam/src/main/java/org/apache/hop/beam/gui/HopBeamGuiPlugin.java
@@ -201,6 +201,12 @@ public class HopBeamGuiPlugin {
 
     jarFiles.addAll(FileUtils.listFiles(new File("plugins"), new String[] {"jar"}, true));
 
+    // If we are in the hop-web Docker container, we need to import the Hop main JARs too for Dataflow
+    // (and for other runners probably too)
+    File hopWebJars = new File("webapps/ROOT/WEB-INF/lib");
+    if (hopWebJars.exists())
+      jarFiles.addAll(FileUtils.listFiles(hopWebJars, new String[] {"jar"}, true));
+
     List<String> jarFilenames = new ArrayList<>();
     jarFiles.forEach(file -> jarFilenames.add(file.toString()));
     return jarFilenames;

--- a/plugins/engines/beam/src/main/java/org/apache/hop/beam/gui/HopBeamGuiPlugin.java
+++ b/plugins/engines/beam/src/main/java/org/apache/hop/beam/gui/HopBeamGuiPlugin.java
@@ -193,8 +193,12 @@ public class HopBeamGuiPlugin {
   public static final List<String> findInstalledJarFilenames() {
     Set<File> jarFiles = new HashSet<>();
     jarFiles.addAll(FileUtils.listFiles(new File("lib"), new String[] {"jar"}, true));
-    jarFiles.addAll(
-        FileUtils.listFiles(new File("libswt/linux/x86_64"), new String[] {"jar"}, true));
+
+    File libSwtFiles = new File("libswt/linux/x86_64");
+    if (libSwtFiles.exists())
+      jarFiles.addAll(
+          FileUtils.listFiles(libSwtFiles, new String[] {"jar"}, true));
+
     jarFiles.addAll(FileUtils.listFiles(new File("plugins"), new String[] {"jar"}, true));
 
     List<String> jarFilenames = new ArrayList<>();


### PR DESCRIPTION
Fat JAR generated in hop-web container is missing some dependencies

The fat JAR generated with the docker hop-web container is missing all the JARs included in the `lib` directory of Hop, and it only includes the JARs in the Tomcat `lib` directory, and the plugins JARs.

This change checks if we are running in Tomcat in the docker hop-web container and in that case, it adds all the Hop lib JARs too.

There is an additional small change, related to HOP-3966: if the `libswt` directory does not exist, the plugin does not attempt to import JARs from that directory. Attempting that import makes the fat JAR generation fail.

 - [X ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).