### PR TITLE
HOP-4000 Fix User-defined Java class transformations

### DIFF
--- a/plugins/transforms/janino/src/main/java/org/apache/hop/pipeline/transforms/userdefinedjavaclass/UserDefinedJavaClassDialog.java
+++ b/plugins/transforms/janino/src/main/java/org/apache/hop/pipeline/transforms/userdefinedjavaclass/UserDefinedJavaClassDialog.java
@@ -1165,7 +1165,8 @@ public class UserDefinedJavaClassDialog extends BaseTransformDialog implements I
       InfoTransformDefinition transformDefinition = new InfoTransformDefinition();
       int colNr = 1;
       transformDefinition.tag = item.getText(colNr++);
-      transformDefinition.transformMeta = pipelineMeta.findTransform(item.getText(colNr++));
+      transformDefinition.transformName = item.getText(colNr++);
+      transformDefinition.transformMeta = pipelineMeta.findTransform(transformDefinition.transformName);
       transformDefinition.description = item.getText(colNr++);
       meta.getInfoTransformDefinitions().add(transformDefinition);
     }
@@ -1177,7 +1178,8 @@ public class UserDefinedJavaClassDialog extends BaseTransformDialog implements I
       TargetTransformDefinition transformDefinition = new TargetTransformDefinition();
       int colNr = 1;
       transformDefinition.tag = item.getText(colNr++);
-      transformDefinition.transformMeta = pipelineMeta.findTransform(item.getText(colNr++));
+      transformDefinition.transformName = item.getText(colNr++);
+      transformDefinition.transformMeta = pipelineMeta.findTransform(transformDefinition.transformName);
       transformDefinition.description = item.getText(colNr++);
       meta.getTargetTransformDefinitions().add(transformDefinition);
     }


### PR DESCRIPTION
User-defined Java class transformations lose the name of the transformations in the Info and Target tab
