### PR TITLE
(DOC) - Fix table formatting in workflow/actions/pipeline Parameters Tab section

### DIFF
--- a/docs/hop-user-manual/modules/ROOT/pages/workflow/actions/pipeline.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/workflow/actions/pipeline.adoc
@@ -103,15 +103,14 @@ If the 'Execute for every result row' option is selected then each row is a set 
 [width="90%",options="header"]
 |===
 |Option|Description
-|Copy results to parameters Copies the results from a previous pipeline as parameters of the pipeline using the Copy rows to result transform.
-|Pass parameter values to sub pipeline Pass all parameters of the workflow down to the sub-pipeline.
-|Parameters Specify the parameter name passed to the pipeline.
-|Stream column name Specify the field of an incoming record from a previous pipeline as the parameter.
-|Value|Specify pipeline parameter values through one of the following actions:
-
-- Manually entering a value (ETL workflow for example).
-- Using another parameter to set the value ({openvar}Internal.workflow.Name{closevar} for example).
-- Using a combination of manually specified values and parameter values ({openvar}FILE_PREFIX{closevar}_{openvar}FILE_DATE{closevar}.txt for example).
+|Copy results to parameters|Copies the results from a previous pipeline as parameters of the pipeline using the Copy rows to result transform.
+|Pass parameter values to sub pipeline|Pass all parameters of the workflow down to the sub-pipeline.
+|Parameters|Specify the parameter name passed to the pipeline.
+|Stream column name|Specify the field of an incoming record from a previous pipeline as the parameter.
+|Value|Specify pipeline parameter values through one of the following actions: +
+- Manually entering a value (ETL workflow for example). +
+- Using another parameter to set the value ({openvar}Internal.workflow.Name{closevar} for example). +
+- Using a combination of manually specified values and parameter values (\{openvar}FILE_PREFIX{closevar}_{openvar}FILE_DATE{closevar}.txt for example).
 
 |Get Parameters|Get the existing parameters already associated by the pipeline.
 |===


### PR DESCRIPTION
Following this checklist to help us incorporate your contribution quickly and easily:

- I consider this to be a trivial change as it only impacts formatting within documentation. The current table is malformed (link below) and makes interpreting the documentation difficult. I am proposing this correction. There is no change to the content.
[- https://hop.apache.org/manual/latest/workflow/actions/pipeline.html](https://hop.apache.org/manual/latest/workflow/actions/pipeline.html#_parameters_tab)

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)