### PR TITLE
(DOC) fix ref from action to transform

### DIFF
--- a/docs/hop-user-manual/modules/ROOT/pages/workflow/actions/xsdvalidator.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/workflow/actions/xsdvalidator.adoc
@@ -31,7 +31,7 @@ As such, there are 2 entities at work here:
 * The XML you want to validate the layout for
 * The XSD (Schema) file that describes what the XML file should look like.
 
-See also the XSD Validator action.
+See also the xref:pipeline/transforms/xsdvalidator[XSD Validator pipeline transform].
 
 == Options
 


### PR DESCRIPTION
Make a reference from `workflow/actions/xsdvalidator` to `pipeline/transforms/xsdvalidator` (not to itself).

I glimpsed the xref syntax at https://github.com/apache/hop/edit/master/docs/hop-user-manual/modules/ROOT/pages/workflow/workflows.adoc, might be wrong.
