### PR TITLE
[HOP-4090] - Force limit to parameter split

### DIFF
--- a/engine/src/main/java/org/apache/hop/run/HopRun.java
+++ b/engine/src/main/java/org/apache/hop/run/HopRun.java
@@ -159,7 +159,7 @@ public class HopRun implements Runnable, IHasHopMetadataProvider {
     //
     if (systemProperties != null) {
       for (String parameter : systemProperties) {
-        String[] split = parameter.split("=");
+        String[] split = parameter.split("=", 2);
         String key = split.length > 0 ? split[0] : null;
         String value = split.length > 1 ? split[1] : null;
         if (StringUtils.isNotEmpty(key) && StringUtils.isNotEmpty(value)) {
@@ -403,7 +403,7 @@ public class HopRun implements Runnable, IHasHopMetadataProvider {
       String[] availableParameters = namedParams.listParameters();
       if (parameters != null) {
         for (String parameter : parameters) {
-          String[] split = parameter.split("=");
+          String[] split = parameter.split("=", 2);
           String key = split.length > 0 ? split[0] : null;
           String value = split.length > 1 ? split[1] : null;
 


### PR DESCRIPTION
Force limit to parameter split so if a paramter value contains an = sign, the data after it doesnt get deleted.
