### PR TITLE
[HOP-FieldSplit] issue in FieldSplit transform

### DIFF
--- a/plugins/transforms/fieldsplitter/src/main/java/org/apache/hop/pipeline/transforms/fieldsplitter/FieldSplitter.java
+++ b/plugins/transforms/fieldsplitter/src/main/java/org/apache/hop/pipeline/transforms/fieldsplitter/FieldSplitter.java
@@ -64,6 +64,14 @@ public class FieldSplitter extends BaseTransform<FieldSplitterMeta, FieldSplitte
                 PKG, "FieldSplitter.Log.SplitFieldNotValid", meta.getSplitField())));
       }
 
+      //check if the new field is empty or not
+      int newFieldsCount = meta.getFieldsCount();
+
+      if (newFieldsCount <= 0) {
+        throw new HopValueException(
+                (BaseMessages.getString(
+                        PKG, "FieldSplitter.Log.SplitMetaNameNotValid")));
+      }
       // prepare the outputMeta
       //
       data.outputMeta = getInputRowMeta().clone();

--- a/plugins/transforms/fieldsplitter/src/main/java/org/apache/hop/pipeline/transforms/fieldsplitter/FieldSplitterDialog.java
+++ b/plugins/transforms/fieldsplitter/src/main/java/org/apache/hop/pipeline/transforms/fieldsplitter/FieldSplitterDialog.java
@@ -395,6 +395,16 @@ public class FieldSplitterDialog extends BaseTransformDialog implements ITransfo
 
     input.allocate(nrFields);
 
+    //check if the new field is empty or not
+
+    if (input.getFieldName().length <= 0) {
+      new ErrorDialog(
+              shell,
+              BaseMessages.getString(PKG, "FieldSplitterDialog.FailedToGetFields.DialogTitle"),
+              BaseMessages.getString(PKG, "FieldSplitter.Log.SplitMetaNameNotValid"),null);
+      return;
+    }
+
     // CHECKSTYLE:Indentation:OFF
     for (int i = 0; i < input.getFieldName().length; i++) {
       final TableItem ti = wFields.getNonEmpty(i);

--- a/plugins/transforms/fieldsplitter/src/main/resources/org/apache/hop/pipeline/transforms/fieldsplitter/messages/messages_en_US.properties
+++ b/plugins/transforms/fieldsplitter/src/main/resources/org/apache/hop/pipeline/transforms/fieldsplitter/messages/messages_en_US.properties
@@ -73,3 +73,5 @@ FieldSplitter.Injection.NULL_IF=Value to convert to null
 FieldSplitter.Injection.DEFAULT=The default value in case of null
 FieldSplitter.Injection.TRIM_TYPE=The trim type (none, left, right, both)
 FieldSplitterMeta.keyword=field,splitter
+FieldSplitter.Log.SplitMetaNameNotValid=The new field's list can not be empty
+

--- a/plugins/transforms/fieldsplitter/src/main/resources/org/apache/hop/pipeline/transforms/fieldsplitter/messages/messages_zh_CN.properties
+++ b/plugins/transforms/fieldsplitter/src/main/resources/org/apache/hop/pipeline/transforms/fieldsplitter/messages/messages_zh_CN.properties
@@ -59,3 +59,5 @@ FieldSplitterMeta.Exception.UnableToLoadTransformMetaFromXML=Unable to load tran
 FieldSplitterMeta.keyword=field,splitter
 SplitFields.Description=\u8BE5 Transform \u5141\u8BB8\u60A8\u62C6\u5206\u5355\u4E2A\u5B57\u6BB5\u5230\u591A\u4E2A\u5B57\u6BB5\u4E2D
 SplitFields.Name=\u62C6\u5206\u5B57\u6BB5
+FieldSplitter.Log.SplitMetaNameNotValid=\u65b0\u5b57\u6bb5\u5217\u8868\u4e0d\u80fd\u4e3a\u7a7a
+


### PR DESCRIPTION
There is a issue in the split fields plugin that tields are read out of order  when the new fields list is empty .

I don't think it makes sense for the new fields list to be empty and we should check the list can not be empty before submitting.

the example's pictures as below

csv input data :
     
<img width="361" alt="1660810089227" src="https://user-images.githubusercontent.com/12055463/185343969-504c4660-6bce-4bfb-ad90-60ce74269db7.png">

the flow image:

<img width="466" alt="07538f704a8d724cef5514bf9211505" src="https://user-images.githubusercontent.com/12055463/185344149-dffaf1d9-43bf-462c-a0d5-406b9d5c8ae4.png">


<img width="398" alt="1b5d3eb4834cd1f79ad553798ad3373" src="https://user-images.githubusercontent.com/12055463/185344260-96454618-cbd9-4767-9878-bfd0644108fc.png">

<img width="862" alt="241ef0a719b6239699843ae31e9390f" src="https://user-images.githubusercontent.com/12055463/185344385-c4f42966-cbdd-4fde-92ed-daad93b23c98.png">

<img width="415" alt="8754daa0768f4fdeecadf50a046c403" src="https://user-images.githubusercontent.com/12055463/185344480-1a18dd17-53a6-4284-84cb-5d1d69b98b58.png">

