### PR TITLE
HOP-4198, HOP-4005

### DIFF
--- a/docs/hop-user-manual/modules/ROOT/pages/hop-server/rest-api.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/hop-server/rest-api.adoc
@@ -66,6 +66,7 @@ Add a pipeline for execution
 
 endPoint::
 GET `hop/addPipeline`
+* Content-Type: text/xml;charset=UTF-8
 
 parameters::
 * xml Request body should contain xml containing pipeline_configuration (pipeline and pipeline_execution_configuration wrapped in pipeline_configuration tag).
@@ -86,6 +87,7 @@ Add a workflow for execution
 
 endPoint::
 GET `hop/addWorkflow`
+* Content-Type: text/xml;charset=UTF-8
 
 parameters::
 * xml Request body should contain xml containing workflow_configuration (pipeline and workflow_execution_configuration wrapped in pipeline_configuration tag).
@@ -309,6 +311,7 @@ Register a pipeline for execution
 
 endPoint::
 GET `hop/registerPipeline`
+* Content-Type: text/xml;charset=UTF-8
 
 parameters::
 * xml Request body should contain xml containing pipeline_configuration (pipeline and pipeline_execution_configuration wrapped in pipeline_configuration tag).
@@ -507,6 +510,7 @@ Register a workflow on the server
 
 endPoint::
 GET `/hop/registerWorkflow`
+* Content-Type: text/xml;charset=UTF-8
 
 parameters::
 * xml:

--- a/engine/src/main/java/org/apache/hop/resource/ResourceUtil.java
+++ b/engine/src/main/java/org/apache/hop/resource/ResourceUtil.java
@@ -25,6 +25,7 @@ import org.apache.hop.core.metadata.SerializableMetadataProvider;
 import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.core.vfs.HopVfs;
 import org.apache.hop.core.xml.IXml;
+import org.apache.hop.core.xml.XmlHandler;
 import org.apache.hop.i18n.BaseMessages;
 import org.apache.hop.metadata.api.IHopMetadataProvider;
 import org.apache.hop.pipeline.PipelineMeta;
@@ -123,8 +124,11 @@ public class ResourceUtil {
         // We add an extra file definition which gets picked up below and zipped up.
         //
         if (executionConfiguration != null) {
+          String encoding = Const.getEnvironmentVariable("file.encoding", Const.XML_ENCODING);
           ResourceDefinition resourceDefinition =
-              new ResourceDefinition(injectFilename, executionConfiguration.getXml(variables));
+              new ResourceDefinition(
+                  injectFilename,
+                  XmlHandler.getXmlHeader(encoding) + executionConfiguration.getXml(variables));
           definitions.put(injectFilename, resourceDefinition);
         }
 

--- a/engine/src/main/java/org/apache/hop/server/HopServer.java
+++ b/engine/src/main/java/org/apache/hop/server/HopServer.java
@@ -438,8 +438,14 @@ public class HopServer extends HopMetadataBase implements Cloneable, IXml, IHopM
     return result;
   }
 
-  // Method is defined as package-protected in order to be accessible by unit tests
   HttpPost buildSendXmlMethod(IVariables variables, byte[] content, String service)
+      throws Exception {
+    String encoding = Const.getEnvironmentVariable("file.encoding", Const.XML_ENCODING);
+    return buildSendXmlMethod(variables, content, encoding, service);
+  }
+
+  // Method is defined as package-protected in order to be accessible by unit tests
+  HttpPost buildSendXmlMethod(IVariables variables, byte[] content, String encoding, String service)
       throws Exception {
     // Prepare HTTP put
     //
@@ -454,14 +460,14 @@ public class HopServer extends HopMetadataBase implements Cloneable, IXml, IHopM
     HttpEntity entity = new ByteArrayEntity(content);
 
     postMethod.setEntity(entity);
-    String encoding = Const.getEnvironmentVariable("file.encoding", Const.XML_ENCODING);
     postMethod.addHeader(new BasicHeader("Content-Type", "text/xml;charset=" + encoding));
 
     return postMethod;
   }
 
   public String sendXml(IVariables variables, String xml, String service) throws Exception {
-    HttpPost method = buildSendXmlMethod(variables, xml.getBytes(getXmlEncoding(xml)), service);
+    String encoding = getXmlEncoding(xml);
+    HttpPost method = buildSendXmlMethod(variables, xml.getBytes(encoding), encoding, service);
     try {
       return executeAuth(variables, method);
     } finally {

--- a/engine/src/main/java/org/apache/hop/server/HopServer.java
+++ b/engine/src/main/java/org/apache/hop/server/HopServer.java
@@ -17,6 +17,8 @@
 
 package org.apache.hop.server;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hop.core.Const;
 import org.apache.hop.core.Result;
@@ -452,13 +454,14 @@ public class HopServer extends HopMetadataBase implements Cloneable, IXml, IHopM
     HttpEntity entity = new ByteArrayEntity(content);
 
     postMethod.setEntity(entity);
-    postMethod.addHeader(new BasicHeader("Content-Type", "text/xml;charset=" + Const.XML_ENCODING));
+    String encoding = Const.getEnvironmentVariable("file.encoding", Const.XML_ENCODING);
+    postMethod.addHeader(new BasicHeader("Content-Type", "text/xml;charset=" + encoding));
 
     return postMethod;
   }
 
   public String sendXml(IVariables variables, String xml, String service) throws Exception {
-    HttpPost method = buildSendXmlMethod(variables, xml.getBytes(Const.XML_ENCODING), service);
+    HttpPost method = buildSendXmlMethod(variables, xml.getBytes(getXmlEncoding(xml)), service);
     try {
       return executeAuth(variables, method);
     } finally {
@@ -470,6 +473,15 @@ public class HopServer extends HopMetadataBase implements Cloneable, IXml, IHopM
                 PKG, "HopServer.DETAILED_SentXmlToService", service, variables.resolve(hostname)));
       }
     }
+  }
+
+  private String getXmlEncoding(String xml) {
+    Pattern xmlHeadPattern = Pattern.compile("<\\?xml.* encoding=\"(.*)\"");
+    Matcher matcher = xmlHeadPattern.matcher(xml);
+    if (matcher.find()) {
+      return matcher.group();
+    }
+    return Const.getEnvironmentVariable("file.encoding", Const.XML_ENCODING);
   }
 
   /** Throws if not ok */

--- a/engine/src/main/java/org/apache/hop/www/BaseHttpServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/BaseHttpServlet.java
@@ -17,10 +17,12 @@
 
 package org.apache.hop.www;
 
+import org.apache.hop.core.Const;
 import org.apache.hop.core.logging.ILogChannel;
 import org.apache.hop.core.logging.LogChannel;
 import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.core.variables.Variables;
+import org.apache.http.entity.ContentType;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -82,6 +84,15 @@ public class BaseHttpServlet extends HttpServlet {
     } else {
       this.variables = serverConfig.getVariables();
     }
+  }
+
+  @Override
+  protected void service(HttpServletRequest req, HttpServletResponse resp)
+      throws ServletException, IOException {
+    if (req.getContentLength() > 0 && req.getContentType() != null) {
+      req.setCharacterEncoding(getContentEncoding(req.getContentType()));
+    }
+    super.service(req, resp);
   }
 
   @Override
@@ -207,5 +218,16 @@ public class BaseHttpServlet extends HttpServlet {
   /** @param log The log to set */
   public void setLog(ILogChannel log) {
     this.log = log;
+  }
+
+  private String getContentEncoding(String contentTypeValue) {
+    ContentType contentType = ContentType.parse(contentTypeValue);
+    if ("text/xml".equals(contentType.getMimeType())) {
+      if (contentType.getCharset() != null) {
+        return contentType.getCharset().name();
+      }
+      return Const.XML_ENCODING;
+    }
+    return null;
   }
 }

--- a/engine/src/main/java/org/apache/hop/www/RegisterPipelineServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/RegisterPipelineServlet.java
@@ -48,7 +48,7 @@ public class RegisterPipelineServlet extends BaseWorkflowServlet {
       IVariables variables)
       throws IOException, HopException, HopException, ParseException {
 
-    final String xml = IOUtils.toString(request.getInputStream());
+    final String xml = IOUtils.toString(request.getInputStream(), request.getCharacterEncoding());
 
     // Parse the XML, create a pipeline configuration
     PipelineConfiguration pipelineConfiguration = PipelineConfiguration.fromXml(xml);

--- a/engine/src/main/java/org/apache/hop/www/RegisterWorkflowServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/RegisterWorkflowServlet.java
@@ -48,7 +48,7 @@ public class RegisterWorkflowServlet extends BaseWorkflowServlet {
       IVariables variables)
       throws IOException, HopException, HopException, ParseException {
 
-    final String xml = IOUtils.toString(request.getInputStream());
+    final String xml = IOUtils.toString(request.getInputStream(), request.getCharacterEncoding());
 
     // Parse the XML, create a workflow configuration
     WorkflowConfiguration workflowConfiguration = WorkflowConfiguration.fromXml(xml, variables);


### PR DESCRIPTION
When add pipeline/workflow to hop-server, the xml content maybe could not be parsed using the correct encoding.

Many times, it is difficult to guarantee the same encoding used in http-client and hop-server.
For example, Chinese Windows systems usually use gbk as the default encoding for the system. But hop-server may run on Linux and use UTF-8 as the default encoding.

If there are Chinese characters in the pipeline name, it may only show that there is a problem.
However, if Chinese characters are used in a path (ps: PipelineExecutor's hpl location), the file may not be loaded