### PR TITLE
HOP-4197 MySQL Driver deprecated

### DIFF
--- a/plugins/databases/mysql/src/main/java/org/apache/hop/databases/mysql/MySqlDatabaseMeta.java
+++ b/plugins/databases/mysql/src/main/java/org/apache/hop/databases/mysql/MySqlDatabaseMeta.java
@@ -147,7 +147,7 @@ public class MySqlDatabaseMeta extends BaseDatabaseMeta implements IDatabase {
       case "Mysql":
         return "org.gjt.mm.mysql.Driver";
       case "Mysql 8+":
-        return "com.mysql.jdbc.Driver";
+        return "com.mysql.cj.jdbc.Driver";
       default:
         return "org.gjt.mm.mysql.Driver";
     }


### PR DESCRIPTION
This driver class is available in version 8.0.28 provided with Hop.