### PR TITLE
HOP-3974: Disable preview feature when hop-server don't support graphic environment

### DIFF
--- a/engine/src/main/java/org/apache/hop/www/BaseHttpServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/BaseHttpServlet.java
@@ -38,6 +38,7 @@ public class BaseHttpServlet extends HttpServlet {
   protected WorkflowMap workflowMap;
   protected HopServerConfig serverConfig;
   protected IVariables variables;
+  protected boolean supportGraphicEnvironment;
 
   private boolean jettyMode = false;
 
@@ -91,6 +92,10 @@ public class BaseHttpServlet extends HttpServlet {
       throws ServletException, IOException {
     if (req.getContentLength() > 0 && req.getContentType() != null) {
       req.setCharacterEncoding(getContentEncoding(req.getContentType()));
+    }
+    if ("GET".equals(req.getMethod())) {
+      supportGraphicEnvironment =
+          Boolean.TRUE.equals(req.getServletContext().getAttribute("GraphicsEnvironment"));
     }
     super.service(req, resp);
   }

--- a/engine/src/main/java/org/apache/hop/www/GetPipelineImageServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/GetPipelineImageServlet.java
@@ -47,6 +47,10 @@ public class GetPipelineImageServlet extends BaseHttpServlet implements IHopServ
     if (isJettyMode() && !request.getContextPath().startsWith(CONTEXT_PATH)) {
       return;
     }
+    if (!supportGraphicEnvironment){
+      response.setStatus(HttpServletResponse.SC_NO_CONTENT);
+      return;
+    }
 
     if (log.isDebug()) {
       logDebug(BaseMessages.getString(PKG, "GetPipelineImageServlet.Log.PipelineImageRequested"));

--- a/engine/src/main/java/org/apache/hop/www/GetPipelineStatusServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/GetPipelineStatusServlet.java
@@ -504,28 +504,30 @@ public class GetPipelineStatusServlet extends BaseHttpServlet implements IHopSer
           out.println("</table>");
           out.println("</div>");
 
-          out.print("<div class=\"row\" style=\"padding: 0px 0px 75px 0px;\">");
-          out.print(
-              "<div class=\"workspaceHeading\" style=\"padding: 0px 0px 30px 0px;\">Canvas preview</div>");
-          // Get the pipeline image
-          Point max = pipeline.getPipelineMeta().getMaximum();
-          max.x = (int) (max.x * GetPipelineImageServlet.ZOOM_FACTOR) + 100;
-          max.y = (int) (max.y * GetPipelineImageServlet.ZOOM_FACTOR) + 50;
-          out.print(
-              "<iframe height=\""
-                  + (max.y + 100)
-                  + "px\" width=\""
-                  + (max.x + 100)
-                  + "px\" "
-                  + "src=\""
-                  + convertContextPath(GetPipelineImageServlet.CONTEXT_PATH)
-                  + "?name="
-                  + URLEncoder.encode(pipelineName, "UTF-8")
-                  + "&id="
-                  + URLEncoder.encode(id, "UTF-8")
-                  + "\" frameborder=\"0\"></iframe>");
-          ;
-          out.print("</div>");
+          if (supportGraphicEnvironment) {
+            out.print("<div class=\"row\" style=\"padding: 0px 0px 75px 0px;\">");
+            out.print(
+                "<div class=\"workspaceHeading\" style=\"padding: 0px 0px 30px 0px;\">Canvas preview</div>");
+            // Get the pipeline image
+            Point max = pipeline.getPipelineMeta().getMaximum();
+            max.x = (int) (max.x * GetPipelineImageServlet.ZOOM_FACTOR) + 100;
+            max.y = (int) (max.y * GetPipelineImageServlet.ZOOM_FACTOR) + 50;
+            out.print(
+                "<iframe height=\""
+                    + (max.y + 100)
+                    + "px\" width=\""
+                    + (max.x + 100)
+                    + "px\" "
+                    + "src=\""
+                    + convertContextPath(GetPipelineImageServlet.CONTEXT_PATH)
+                    + "?name="
+                    + URLEncoder.encode(pipelineName, "UTF-8")
+                    + "&id="
+                    + URLEncoder.encode(id, "UTF-8")
+                    + "\" frameborder=\"0\"></iframe>");
+            ;
+            out.print("</div>");
+          }
 
           // Put the logging below that.
           out.print("<div class=\"row\" style=\"padding: 0px 0px 30px 0px;\">");

--- a/engine/src/main/java/org/apache/hop/www/GetWorkflowImageServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/GetWorkflowImageServlet.java
@@ -47,6 +47,10 @@ public class GetWorkflowImageServlet extends BaseHttpServlet implements IHopServ
     if (isJettyMode() && !request.getContextPath().startsWith(CONTEXT_PATH)) {
       return;
     }
+    if (!supportGraphicEnvironment){
+      response.setStatus(HttpServletResponse.SC_NO_CONTENT);
+      return;
+    }
 
     if (log.isDebug()) {
       logDebug(BaseMessages.getString(PKG, "GetWorkflowImageServlet.Log.WorkflowImageRequested"));

--- a/engine/src/main/java/org/apache/hop/www/GetWorkflowStatusServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/GetWorkflowStatusServlet.java
@@ -348,26 +348,28 @@ public class GetWorkflowStatusServlet extends BaseHttpServlet implements IHopSer
           out.print("</div>");
           out.print("</div>");
 
-          out.print("<div class=\"row\" style=\"padding: 0px 0px 75px 0px;\">");
-          out.print("<div class=\"workspaceHeading\">Canvas preview</div>");
-          // Show workflow image?
-          //
-          Point max = workflow.getWorkflowMeta().getMaximum();
-          max.x += (int) (max.x * GetWorkflowImageServlet.ZOOM_FACTOR) + 100;
-          max.y += (int) (max.y + GetWorkflowImageServlet.ZOOM_FACTOR) + 50;
-          out.print(
-              "<iframe height=\""
-                  + (max.y + 100)
-                  + "px\" width=\""
-                  + (max.x + 100)
-                  + "px\" src=\""
-                  + convertContextPath(GetWorkflowImageServlet.CONTEXT_PATH)
-                  + "?name="
-                  + URLEncoder.encode(workflowName, "UTF-8")
-                  + "&id="
-                  + URLEncoder.encode(id, "UTF-8")
-                  + "\"></iframe>");
-          out.print("</div>");
+          if (supportGraphicEnvironment) {
+            out.print("<div class=\"row\" style=\"padding: 0px 0px 75px 0px;\">");
+            out.print("<div class=\"workspaceHeading\">Canvas preview</div>");
+            // Show workflow image?
+            //
+            Point max = workflow.getWorkflowMeta().getMaximum();
+            max.x += (int) (max.x * GetWorkflowImageServlet.ZOOM_FACTOR) + 100;
+            max.y += (int) (max.y + GetWorkflowImageServlet.ZOOM_FACTOR) + 50;
+            out.print(
+                "<iframe height=\""
+                    + (max.y + 100)
+                    + "px\" width=\""
+                    + (max.x + 100)
+                    + "px\" src=\""
+                    + convertContextPath(GetWorkflowImageServlet.CONTEXT_PATH)
+                    + "?name="
+                    + URLEncoder.encode(workflowName, "UTF-8")
+                    + "&id="
+                    + URLEncoder.encode(id, "UTF-8")
+                    + "\"></iframe>");
+            out.print("</div>");
+          }
 
           // Put the logging below that.
 

--- a/engine/src/main/java/org/apache/hop/www/WebServer.java
+++ b/engine/src/main/java/org/apache/hop/www/WebServer.java
@@ -233,6 +233,7 @@ public class WebServer {
               contexts, getContextPath(servlet), ServletContextHandler.SESSIONS);
       ServletHolder servletHolder = new ServletHolder((Servlet) servlet);
       servletContext.addServlet(servletHolder, "/*");
+      servletContext.setAttribute("GraphicsEnvironment", graphicsEnvironment);
     }
 
     // setup jersey (REST)

--- a/engine/src/main/java/org/apache/hop/www/WebServer.java
+++ b/engine/src/main/java/org/apache/hop/www/WebServer.java
@@ -49,6 +49,7 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.glassfish.jersey.servlet.ServletContainer;
 
 import javax.servlet.Servlet;
+import java.awt.GraphicsEnvironment;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -218,6 +219,7 @@ public class WebServer {
     rootServlet.setJettyMode(true);
     root.addServlet(new ServletHolder(rootServlet), "/*");
 
+    boolean graphicsEnvironment = supportGraphicEnvironment();
     PluginRegistry pluginRegistry = PluginRegistry.getInstance();
     List<IPlugin> plugins = pluginRegistry.getPlugins(HopServerPluginType.class);
     for (IPlugin plugin : plugins) {
@@ -510,5 +512,13 @@ public class WebServer {
     } else {
       return DEFAULT_DETECTION_TIMER;
     }
+  }
+
+  private boolean supportGraphicEnvironment() {
+    try {
+      return GraphicsEnvironment.getLocalGraphicsEnvironment() != null;
+    } catch (Error ignored) {
+    }
+    return false;
   }
 }


### PR DESCRIPTION
SVG and Font both dependency graphic environment.
On macOS, like jvm option: -XstartOnFirstThread, we should load graphic environment at main thread.

GUI environment usually works fine on the default jdk unless the java.desktop module is removed  or custom module list.

Hop-Server as rest api service, maybe the preview feature is better as an optional feature.