### PR TITLE
Neo4j IT test fix

### DIFF
--- a/docker/integration-tests/integration-tests-neo4j.yaml
+++ b/docker/integration-tests/integration-tests-neo4j.yaml
@@ -28,7 +28,7 @@ services:
       - neo4j
 
   neo4j:
-    image: neo4j:latest
+    image: neo4j:4.4-community
     ports:
       - "7474"
       - "7687"


### PR DESCRIPTION
Have IT Neo4j docker container use version 4.4 and not the latest 5.1.
We'll update that when we implement HOP-4516