### PR TITLE
fix for HOP-4644

### DIFF
--- a/plugins/transforms/rest/src/main/java/org/apache/hop/pipeline/transforms/rest/Rest.java
+++ b/plugins/transforms/rest/src/main/java/org/apache/hop/pipeline/transforms/rest/Rest.java
@@ -32,6 +32,7 @@ import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.HttpUrlConnectorProvider;
+import org.glassfish.jersey.client.RequestEntityProcessing;
 import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
 import org.glassfish.jersey.uri.UriComponent;
 import org.json.simple.JSONObject;
@@ -293,6 +294,7 @@ public class Rest extends BaseTransform<RestMeta, RestData> {
       // Use ApacheHttpClient for supporting proxy authentication.
       data.config = new ClientConfig();
       data.config.connectorProvider(new ApacheConnectorProvider());
+      data.config.property(ClientProperties.REQUEST_ENTITY_PROCESSING, RequestEntityProcessing.BUFFERED);
       if (!Utils.isEmpty(data.realProxyHost)) {
         // PROXY CONFIGURATION
         data.config.property(ClientProperties.PROXY_URI,"http://"+ data.realProxyHost + ":" + data.realProxyPort);


### PR DESCRIPTION
ApacheConnector in REST client is set to BUFFERED mode HOP-4644

this settings returns client behaviour to be compatible with older servers
as worked in 2.0.0

there is no need to indeterminate length of content as data are already
in memory

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [X] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [X] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [X] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
