### PR TITLE
2110, 2135, 2136

### DIFF
--- a/core/src/main/java/org/apache/hop/core/Condition.java
+++ b/core/src/main/java/org/apache/hop/core/Condition.java
@@ -17,12 +17,6 @@
 
 package org.apache.hop.core;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hop.core.exception.HopException;
 import org.apache.hop.core.exception.HopPluginException;
@@ -41,10 +35,10 @@ import org.apache.hop.metadata.api.IEnumHasCodeAndDescription;
 import org.apache.hop.metadata.serializer.xml.XmlMetadataUtil;
 import org.w3c.dom.Node;
 
-import static org.apache.hop.core.Condition.Function.EQUAL;
-import static org.apache.hop.core.Condition.Function.NOT_NULL;
-import static org.apache.hop.core.Condition.Function.NULL;
-import static org.apache.hop.core.Condition.Function.TRUE;
+import java.util.*;
+import java.util.regex.Pattern;
+
+import static org.apache.hop.core.Condition.Function.*;
 import static org.apache.hop.core.Condition.Operator.AND;
 import static org.apache.hop.core.Condition.Operator.NONE;
 
@@ -163,6 +157,7 @@ public class Condition implements Cloneable {
     this.operator = NONE;
     this.negated = false;
     this.rightValue = null;
+    this.function = EQUAL;
 
     leftFieldIndex = -2;
     rightFieldIndex = -2;


### PR DESCRIPTION
2110 - Unexpected error evaluation condition on Filter Rows transform
2136 - Filter String comparisons using the = operator do not work, while using IN LIST will. 
2135 - Filter - Fails comparing Boolean using = against Boolean with a True value.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).