### PR TITLE
Dimension lookup does not load/store "type of return field" in read only mode #2221

### DIFF
--- a/plugins/transforms/dimensionlookup/src/main/java/org/apache/hop/pipeline/transforms/dimensionlookup/DimensionLookupDialog.java
+++ b/plugins/transforms/dimensionlookup/src/main/java/org/apache/hop/pipeline/transforms/dimensionlookup/DimensionLookupDialog.java
@@ -1108,8 +1108,7 @@ public class DimensionLookupDialog extends BaseTransformDialog implements ITrans
         DimensionUpdateType updateType = field.getUpdateType();
         item.setText(3, updateType == null ? "" : updateType.getDescription());
       } else {
-        // String -> int -> String
-        item.setText(3, ValueMetaFactory.getValueMetaName(field.getReturnType()));
+        item.setText(3, Const.NVL(field.getReturnType(),""));
       }
     }
 
@@ -1227,10 +1226,15 @@ public class DimensionLookupDialog extends BaseTransformDialog implements ITrans
       DLField field = new DLField();
       field.setLookup(item.getText(1));
       field.setName(item.getText(2));
-      DimensionUpdateType updateType = DimensionUpdateType.lookupDescription(item.getText(3));       
-      if ( updateType!=null) {
-        field.setUpdate(updateType.getCode());
+      if (in.isUpdate()) {
+        DimensionUpdateType updateType = DimensionUpdateType.lookupDescription(item.getText(3));
+        if (updateType != null) {
+          field.setUpdate(updateType.getCode());
+        }
+      } else {
+        field.setReturnType(item.getText(3));
       }
+
       f.getFields().add(field);
     }
     if (log.isDebug()) {

--- a/plugins/transforms/dimensionlookup/src/main/java/org/apache/hop/pipeline/transforms/dimensionlookup/DimensionLookupMeta.java
+++ b/plugins/transforms/dimensionlookup/src/main/java/org/apache/hop/pipeline/transforms/dimensionlookup/DimensionLookupMeta.java
@@ -37,7 +37,6 @@ import org.apache.hop.core.row.value.ValueMetaBoolean;
 import org.apache.hop.core.row.value.ValueMetaDate;
 import org.apache.hop.core.row.value.ValueMetaFactory;
 import org.apache.hop.core.row.value.ValueMetaInteger;
-import org.apache.hop.core.util.Utils;
 import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.i18n.BaseMessages;
 import org.apache.hop.metadata.api.HopMetadataProperty;
@@ -643,7 +642,7 @@ public class DimensionLookupMeta extends BaseTransformMeta<DimensionLookup, Dime
               new CheckResult(
                   ICheckResult.TYPE_RESULT_ERROR,
                   "The update type specified is not valid for field '"
-                      + field.getName()
+                      + Const.NVL(field.getName(), field.getLookup())
                       + "' : '"
                       + field.getUpdate()
                       + "'",
@@ -653,14 +652,15 @@ public class DimensionLookupMeta extends BaseTransformMeta<DimensionLookup, Dime
       } else {
         // Check the type of the dimension field to look up
         //
-        if (field.getReturnType() <= 0) {
+        int type = ValueMetaFactory.getIdForValueMeta(field.getReturnType());
+        if (type == IValueMeta.TYPE_NONE) {
           remarks.add(
               new CheckResult(
                   ICheckResult.TYPE_RESULT_ERROR,
                   "The return type specified is not valid for field '"
-                      + field.getName()
+                      + Const.NVL(field.getName(), field.getLookup())
                       + "' : '"
-                      + field.getUpdate()
+                      + field.getReturnType()
                       + "'",
                   transformMeta));
           allOk = false;
@@ -1510,14 +1510,18 @@ public class DimensionLookupMeta extends BaseTransformMeta<DimensionLookup, Dime
         injectionKeyDescription = "DimensionLookup.Injection.UPDATE_TYPE")
     private String update;
 
+    @HopMetadataProperty(        
+        key = "type",
+        injectionKey = "TYPE_OF_RETURN_FIELD",
+        injectionKeyDescription = "DimensionLookup.Injection.TYPE_OF_RETURN_FIELD")
+    private String returnType;
+    
     /** Not serialized. This is used to cache the lookup of the dimension type */
     private DimensionUpdateType updateType;
-    /** Not serialized. This is used to cache the lookup of the Hop value return type */
-    private int returnType;
 
     public DLField() {
       this.updateType = null;
-      this.returnType = -1;
+      this.returnType = null;
     }
 
     public DLField(DLField f) {
@@ -1525,7 +1529,7 @@ public class DimensionLookupMeta extends BaseTransformMeta<DimensionLookup, Dime
       this.lookup = f.lookup;
       this.update = f.update;
       this.updateType = null;
-      this.returnType = -1;
+      this.returnType = f.returnType;
     }
 
     public DimensionUpdateType getUpdateType() {
@@ -1539,14 +1543,6 @@ public class DimensionLookupMeta extends BaseTransformMeta<DimensionLookup, Dime
         }
       }
       return null;
-    }
-
-    public int getReturnType() {
-      if (returnType >= 0) {
-        return returnType;
-      }
-      returnType = ValueMetaFactory.getIdForValueMeta(update);
-      return returnType;
     }
 
     /**
@@ -1586,7 +1582,7 @@ public class DimensionLookupMeta extends BaseTransformMeta<DimensionLookup, Dime
     }
 
     /**
-     * Gets update
+     * Gets update type code
      *
      * @return value of update
      */
@@ -1595,14 +1591,31 @@ public class DimensionLookupMeta extends BaseTransformMeta<DimensionLookup, Dime
     }
 
     /**
-     * Sets update
+     * Sets update type code
      *
      * @param update value of update
      */
     public void setUpdate(String update) {
       this.update = update;
       this.updateType = null;
-      this.returnType = -1;
+    }
+    
+    /**
+     * Gets return type for read only lookup
+     *
+     * @return type of 
+     */
+    public String getReturnType() {
+      return returnType;
+    }
+    
+    /**
+     * Sets return type for read only lookup
+     *
+     * @param type the return type
+     */
+    public void setReturnType(String type) {
+      this.returnType = type;
     }
   }
 

--- a/plugins/transforms/dimensionlookup/src/main/resources/org/apache/hop/pipeline/transforms/dimensionlookup/messages/messages_en_US.properties
+++ b/plugins/transforms/dimensionlookup/src/main/resources/org/apache/hop/pipeline/transforms/dimensionlookup/messages/messages_en_US.properties
@@ -188,6 +188,7 @@ DimensionLookupDialog.DateField.Label=Stream Datefield
 DimensionLookupDialog.UseCache.Label=Enable the cache?
 DimensionLookup.Exception.NullDimensionUpdatedDate=Invalid data - dimension updated date cannot be null - {0}
 DimensionLookup.Exception.ErrorDetectedInComparingFields=Error comparing fields - cannot find lookup field [{0}]
+DimensionLookup.Exception.MissingUpdateTypeField=Please specify an update type for field [{0}]
 DimensionLookup.Injection.TARGET_SCHEMA=The name of the database schema to use.
 DimensionLookup.Injection.TARGET_TABLE=The name of the target table to write data to.
 DimensionLookup.Injection.CONNECTION_NAME=The name of the database connection.

--- a/plugins/transforms/dimensionlookup/src/test/java/org/apache/hop/pipeline/transforms/dimensionlookup/DimensionLookupMetaTest.java
+++ b/plugins/transforms/dimensionlookup/src/test/java/org/apache/hop/pipeline/transforms/dimensionlookup/DimensionLookupMetaTest.java
@@ -18,7 +18,6 @@
 package org.apache.hop.pipeline.transforms.dimensionlookup;
 
 import org.apache.hop.core.HopClientEnvironment;
-import org.apache.hop.core.HopEnvironment;
 import org.apache.hop.core.database.DatabaseMeta;
 import org.apache.hop.metadata.serializer.memory.MemoryMetadataProvider;
 import org.apache.hop.pipeline.transform.TransformSerializationTestUtil;
@@ -26,7 +25,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class DimensionLookupMetaTest {
 
@@ -44,11 +45,12 @@ public class DimensionLookupMetaTest {
 
     DimensionLookupMeta meta =
         TransformSerializationTestUtil.testSerialization(
-            "/dimension-lookup-transform.xml", DimensionLookupMeta.class, metadataProvider);
+            "/dimension-update-transform.xml", DimensionLookupMeta.class, metadataProvider);
 
     assertNotNull(meta.getDatabaseMeta());
     assertNotNull(meta.getTableName());
     assertNotNull(meta.getSchemaName());
+    assertTrue(meta.isUpdate());
     assertEquals(100, meta.getCommitSize());
     assertEquals(5000, meta.getCacheSize());
     assertEquals(1, meta.getFields().getKeys().size());
@@ -63,5 +65,13 @@ public class DimensionLookupMetaTest {
     assertEquals("lastVersionLookup", meta.getFields().getFields().get(1).getLookup());
     assertEquals("LastVersion", meta.getFields().getFields().get(1).getUpdate());
     assertEquals(DimensionLookupMeta.DimensionUpdateType.LAST_VERSION, meta.getFields().getFields().get(1).getUpdateType());
+    
+    meta =
+        TransformSerializationTestUtil.testSerialization(
+            "/dimension-lookup-transform.xml", DimensionLookupMeta.class, metadataProvider);
+
+    assertFalse(meta.isUpdate());
+    assertEquals("Number", meta.getFields().getFields().get(0).getReturnType());
+    assertEquals("String", meta.getFields().getFields().get(1).getReturnType());
   }
 }

--- a/plugins/transforms/dimensionlookup/src/test/resources/dimension-update-transform.xml
+++ b/plugins/transforms/dimensionlookup/src/test/resources/dimension-update-transform.xml
@@ -31,7 +31,7 @@
     <table>dimension</table>
     <connection>unit-test-db</connection>
     <commit>100</commit>
-    <update>N</update>
+    <update>Y</update>
     <fields>
         <key>
             <name>key</name>
@@ -43,14 +43,14 @@
             <to>date_to</to>
         </date>
         <field>
-            <name>valueNumber</name>
-            <lookup>fieldNumber</lookup>
-            <type>Number</type>
+            <name>value</name>
+            <lookup>valueLookup</lookup>
+            <update>Insert</update>
         </field>
         <field>
-            <name>valueString</name>
-            <lookup>fieldString</lookup>
-            <type>String</type>
+            <name>lastVersion</name>
+            <lookup>lastVersionLookup</lookup>
+            <update>LastVersion</update>
         </field>
         <return>
             <name>dimension_id</name>


### PR DESCRIPTION
Before v2.2 ReturnType is stored in update property but are never used, for now I only fix the bug. In futur we could remove return type or use it to change the ValueMeta.
