### PR TITLE
#2445: Upgrading mssqlnative jdbc driver to 11.2.3 and updating the docs

### DIFF
--- a/assemblies/plugins/databases/mssqlnative-assemblies/pom.xml
+++ b/assemblies/plugins/databases/mssqlnative-assemblies/pom.xml
@@ -35,7 +35,7 @@
     <description />
 
     <properties>
-        <mssqlnative.version>7.4.1.jre8</mssqlnative.version>
+        <mssqlnative.version>11.2.3.jre11</mssqlnative.version>
     </properties>
 
 

--- a/assemblies/static/src/main/resources/LICENSE
+++ b/assemblies/static/src/main/resources/LICENSE
@@ -1402,7 +1402,7 @@ This product bundles monetdb-jdbc 3.1, which is available under a
 This product bundles mongo-java-driver 3.12.8, which is available under a
 "Apache 2.0" license. For details, see LICENSE.
 
-This product bundles mssql-jdbc 7.4.1.jre8, which is available under a
+This product bundles mssql-jdbc 11.2.3.jre11, which is available under a
 "The MIT" license. For details, see licenses/LICENSE-MIT.
 
 This product bundles mvel2 2.4.14.Final, which is available under a

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/mssqlnative.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/mssqlnative.adoc
@@ -25,7 +25,7 @@ under the License.
 | Option | Info
 |Type | Relational
 |Driver | https://docs.microsoft.com/en-us/sql/connect/jdbc/download-microsoft-jdbc-driver-for-sql-server?view=sql-server-ver15[Driver Link]
-|Version Included | None
+|Version Included | 11.2.3
 |Hop Dependencies | None
 |Documentation | https://docs.microsoft.com/en-us/sql/connect/jdbc/setting-the-connection-properties?view=sql-server-ver15[Documentation Link]
 |JDBC Url | jdbc:sqlserver://[serverName[\instanceName][:portNumber]][;property=value[;property=value]]
@@ -37,20 +37,20 @@ under the License.
 The native Microsoft SQL JDBC driver ships with extra files that enables authentication using your current MS Windows credentials.
 When you download the JDBC drivers from Microsoft's site and unzip them, there will be a directory structure like the following:
 
-*sqljdbc_10.2.1.0_enu\sqljdbc_10.2_enu\auth\x64*  <- 64bit authentication support files.
+*sqljdbc_11.2.3.0_enu\sqljdbc_11.2_enu\auth\x64*  <- 64bit authentication support files.
 
-*sqljdbc_10.2.1.0_enu\sqljdbc_10.2_enu\auth\x86*  <- 32bit authentication support files.
+*sqljdbc_11.2.3.0_enu\sqljdbc_11.2_enu\auth\x86*  <- 32bit authentication support files.
 
 You would copy the file:
 
-*sqljdbc_10.2.1.0_enu\sqljdbc_10.2_enu\auth\x64\mssql-jdbc_auth-10.2.1.x64.dll*
+*sqljdbc_11.2.3.0_enu\sqljdbc_11.2_enu\auth\x64\mssql-jdbc_auth-11.2.3.x64.dll*
 
 to
 
-*hop\lib\mssql-jdbc_auth-10.2.1.x64.dll*
+*hop\lib\mssql-jdbc_auth-11.2.3.x64.dll*
 
-The JDBC driver itself *sqljdbc_10.2_enu\mssql-jdbc-10.2.1.jre11.jar* should be copied into
-*\hop\plugins\databases\mssqlnative\lib*
+The JDBC driver itself *sqljdbc_11.2_enu\mssql-jdbc-11.2.3.jre11.jar* should be copied into
+*\hop\plugins\databases\mssqlnative\lib*, replacing the version already provided.
 
 
 There is no need to rename the DLL to sqljdbc_auth.dll or place it in other locations.


### PR DESCRIPTION
Solves issue #2445 

Apache Hop is shipped with jdbc driver for mssqlnative, version 7.4.1. [The doc](https://hop.apache.org/manual/next/database/databases/mssqlnative.html) says otherwise, not provided.

This commit upgrades the jdbc driver to version 11.2.3 and updates the docs accordingly.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [X] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [ ] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [X] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
