### PR TITLE
Moved TikaOutput initialisation so it occurs in both standard and dynamic filename mode

### DIFF
--- a/integration-tests/transforms/0037-apache-tika-from-getfilenames.hpl
+++ b/integration-tests/transforms/0037-apache-tika-from-getfilenames.hpl
@@ -1,0 +1,245 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<pipeline>
+  <info>
+    <name>0037-apache-tika-from-getfilenames</name>
+    <name_sync_with_filename>Y</name_sync_with_filename>
+    <description/>
+    <extended_description/>
+    <pipeline_version/>
+    <pipeline_type>Normal</pipeline_type>
+    <pipeline_status>0</pipeline_status>
+    <parameters>
+    </parameters>
+    <capture_transform_performance>N</capture_transform_performance>
+    <transform_performance_capturing_delay>1000</transform_performance_capturing_delay>
+    <transform_performance_capturing_size_limit>100</transform_performance_capturing_size_limit>
+    <created_user>-</created_user>
+    <created_date>2021/12/10 11:50:34.956</created_date>
+    <modified_user>-</modified_user>
+    <modified_date>2021/12/10 11:50:34.956</modified_date>
+  </info>
+  <notepads>
+  </notepads>
+  <order>
+    <hop>
+      <from>Apache Tika</from>
+      <to>contentChecksum</to>
+      <enabled>Y</enabled>
+    </hop>
+    <hop>
+      <from>contentChecksum</from>
+      <to>remove content</to>
+      <enabled>Y</enabled>
+    </hop>
+    <hop>
+      <from>remove content</from>
+      <to>validate</to>
+      <enabled>Y</enabled>
+    </hop>
+    <hop>
+      <from>Get file names</from>
+      <to>Select values</to>
+      <enabled>Y</enabled>
+    </hop>
+    <hop>
+      <from>Select values</from>
+      <to>Apache Tika</to>
+      <enabled>Y</enabled>
+    </hop>
+  </order>
+  <transform>
+    <name>Apache Tika</name>
+    <type>Tika</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <add-result-file>N</add-result-file>
+    <content-field>content</content-field>
+    <dynamic-filename-field>source_filename</dynamic-filename-field>
+    <encoding>UTF-8</encoding>
+    <extension-field>extension</extension-field>
+    <file-in-field>Y</file-in-field>
+    <file-size-field>fileSize</file-size-field>
+    <files>
+      <file>
+        <exclude-mask>.*testLotusEml.eml$</exclude-mask>
+        <include-sub-folders>Y</include-sub-folders>
+        <mask>.*</mask>
+        <name>zip:s3://apache-hop/tika-test-files.zip</name>
+        <required>Y</required>
+      </file>
+    </files>
+    <hidden-field>hiddenFlag</hidden-field>
+    <ignore-empty-file>N</ignore-empty-file>
+    <include-filename-field>filename</include-filename-field>
+    <include-row-number-field>rowNumber</include-row-number-field>
+    <last-modification-time-field>lastModificationDate</last-modification-time-field>
+    <metadata-field>metadata</metadata-field>
+    <output-format>Plain text</output-format>
+    <path-field>path</path-field>
+    <root-uri-field>rootUri</root-uri-field>
+    <row-limit>0</row-limit>
+    <short-filename-field>shortFilename</short-filename-field>
+    <uri-field>uri</uri-field>
+    <attributes/>
+    <GUI>
+      <xloc>434</xloc>
+      <yloc>96</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>Get file names</name>
+    <type>GetFileNames</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <doNotFailIfNoFile>N</doNotFailIfNoFile>
+    <dynamic_include_subfolders>N</dynamic_include_subfolders>
+    <file>
+      <exclude_filemask>.*testLotusEml.eml$</exclude_filemask>
+      <file_required>Y</file_required>
+      <filemask>.*</filemask>
+      <include_subfolders>Y</include_subfolders>
+      <name>zip:s3://apache-hop/tika-test-files.zip</name>
+    </file>
+    <filefield>N</filefield>
+    <filter>
+      <filterfiletype>all_files</filterfiletype>
+    </filter>
+    <isaddresult>Y</isaddresult>
+    <limit>0</limit>
+    <raiseAnExceptionIfNoFile>N</raiseAnExceptionIfNoFile>
+    <rownum>N</rownum>
+    <attributes/>
+    <GUI>
+      <xloc>96</xloc>
+      <yloc>96</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>Select values</name>
+    <type>SelectValues</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <fields>
+      <field>
+        <name>filename</name>
+        <rename>source_filename</rename>
+      </field>
+      <select_unspecified>N</select_unspecified>
+    </fields>
+    <attributes/>
+    <GUI>
+      <xloc>265</xloc>
+      <yloc>96</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>contentChecksum</name>
+    <type>CheckSum</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <checksumtype>SHA-512</checksumtype>
+    <fields>
+      <field>
+        <name>content</name>
+      </field>
+    </fields>
+    <resultType>string</resultType>
+    <resultfieldName>checksum</resultfieldName>
+    <attributes/>
+    <GUI>
+      <xloc>603</xloc>
+      <yloc>96</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>remove content</name>
+    <type>SelectValues</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <fields>
+      <select_unspecified>N</select_unspecified>
+      <remove>
+        <name>content</name>
+      </remove>
+      <remove>
+        <name>metadata</name>
+      </remove>
+      <remove>
+        <name>lastModificationDate</name>
+      </remove>
+    </fields>
+    <attributes/>
+    <GUI>
+      <xloc>772</xloc>
+      <yloc>96</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>validate</name>
+    <type>Dummy</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <attributes/>
+    <GUI>
+      <xloc>941</xloc>
+      <yloc>96</yloc>
+    </GUI>
+  </transform>
+  <transform_error_handling>
+  </transform_error_handling>
+  <attributes/>
+</pipeline>

--- a/integration-tests/transforms/main-0037-apache-tika.hwf
+++ b/integration-tests/transforms/main-0037-apache-tika.hwf
@@ -35,14 +35,14 @@ limitations under the License.
       <description/>
       <type>SPECIAL</type>
       <attributes/>
+      <DayOfMonth>1</DayOfMonth>
+      <hour>12</hour>
+      <intervalMinutes>60</intervalMinutes>
+      <intervalSeconds>0</intervalSeconds>
+      <minutes>0</minutes>
       <repeat>N</repeat>
       <schedulerType>0</schedulerType>
-      <intervalSeconds>0</intervalSeconds>
-      <intervalMinutes>60</intervalMinutes>
-      <hour>12</hour>
-      <minutes>0</minutes>
       <weekDay>1</weekDay>
-      <DayOfMonth>1</DayOfMonth>
       <parallel>N</parallel>
       <xloc>128</xloc>
       <yloc>112</yloc>
@@ -56,6 +56,9 @@ limitations under the License.
       <test_names>
         <test_name>
           <name>0037-apache-tika UNIT</name>
+        </test_name>
+        <test_name>
+          <name>0037-apache-tika-from-getfilenames UNIT</name>
         </test_name>
       </test_names>
       <parallel>N</parallel>
@@ -96,24 +99,24 @@ true;</script>
   </hops>
   <notepads>
     <notepad>
-      <note>Test data is saved in Central European Time</note>
-      <xloc>224</xloc>
-      <yloc>192</yloc>
-      <width>234</width>
-      <heigth>26</heigth>
+      <backgroundcolorblue>210</backgroundcolorblue>
+      <backgroundcolorgreen>136</backgroundcolorgreen>
+      <backgroundcolorred>15</backgroundcolorred>
+      <bordercolorblue>250</bordercolorblue>
+      <bordercolorgreen>231</bordercolorgreen>
+      <bordercolorred>200</bordercolorred>
+      <fontbold>N</fontbold>
+      <fontcolorblue>250</fontcolorblue>
+      <fontcolorgreen>231</fontcolorgreen>
+      <fontcolorred>200</fontcolorred>
+      <fontitalic>N</fontitalic>
       <fontname>Inter</fontname>
       <fontsize>11</fontsize>
-      <fontbold>N</fontbold>
-      <fontitalic>N</fontitalic>
-      <fontcolorred>200</fontcolorred>
-      <fontcolorgreen>231</fontcolorgreen>
-      <fontcolorblue>250</fontcolorblue>
-      <backgroundcolorred>15</backgroundcolorred>
-      <backgroundcolorgreen>136</backgroundcolorgreen>
-      <backgroundcolorblue>210</backgroundcolorblue>
-      <bordercolorred>200</bordercolorred>
-      <bordercolorgreen>231</bordercolorgreen>
-      <bordercolorblue>250</bordercolorblue>
+      <height>23</height>
+      <xloc>224</xloc>
+      <yloc>192</yloc>
+      <note>Test data is saved in Central European Time</note>
+      <width>240</width>
     </notepad>
   </notepads>
   <attributes/>

--- a/integration-tests/transforms/metadata/unit-test/0037-apache-tika-from-getfilenames UNIT.json
+++ b/integration-tests/transforms/metadata/unit-test/0037-apache-tika-from-getfilenames UNIT.json
@@ -1,0 +1,73 @@
+{
+  "variableValues": [],
+  "database_replacements": [],
+  "autoOpening": true,
+  "basePath": "",
+  "golden_data_sets": [
+    {
+      "field_mappings": [
+        {
+          "transform_field": "fileSize",
+          "data_set_field": "fileSize"
+        },
+        {
+          "transform_field": "filename",
+          "data_set_field": "filename"
+        },
+        {
+          "transform_field": "rowNumber",
+          "data_set_field": "rowNumber"
+        },
+        {
+          "transform_field": "shortFilename",
+          "data_set_field": "shortFilename"
+        },
+        {
+          "transform_field": "extension",
+          "data_set_field": "extension"
+        },
+        {
+          "transform_field": "path",
+          "data_set_field": "path"
+        },
+        {
+          "transform_field": "hiddenFlag",
+          "data_set_field": "hiddenFlag"
+        },
+        {
+          "transform_field": "uri",
+          "data_set_field": "uri"
+        },
+        {
+          "transform_field": "rootUri",
+          "data_set_field": "rootUri"
+        },
+        {
+          "transform_field": "checksum",
+          "data_set_field": "checksum"
+        }
+      ],
+      "field_order": [
+        "fileSize",
+        "filename",
+        "rowNumber",
+        "shortFilename",
+        "extension",
+        "path",
+        "hiddenFlag",
+        "uri",
+        "rootUri",
+        "checksum"
+      ],
+      "data_set_name": "golden-apache-tika",
+      "transform_name": "validate"
+    }
+  ],
+  "input_data_sets": [],
+  "name": "0037-apache-tika-from-getfilenames UNIT",
+  "description": "",
+  "persist_filename": "",
+  "trans_test_tweaks": [],
+  "pipeline_filename": "./0037-apache-tika-from-getfilenames.hpl",
+  "test_type": "UNIT_TEST"
+}

--- a/plugins/transforms/tika/src/main/java/org/apache/hop/pipeline/transforms/tika/Tika.java
+++ b/plugins/transforms/tika/src/main/java/org/apache/hop/pipeline/transforms/tika/Tika.java
@@ -450,18 +450,14 @@ public class Tika extends BaseTransform<TikaMeta, TikaData> {
           logError(Const.getStackTracker(e));
           return false;
         }
-
-        try {
-          ClassLoader classLoader = meta.getClass().getClassLoader();
-
-          data.tikaOutput = new TikaOutput(classLoader, log, this);
-
-        } catch (Exception e) {
-          logError("Tika Error", e);
-        }
+      }
+      try {
+        ClassLoader classLoader = meta.getClass().getClassLoader();
+        data.tikaOutput = new TikaOutput(classLoader, log, this);
+      } catch (Exception e) {
+        logError("Tika Error", e);
       }
       data.rowNr = 1L;
-
       return true;
     }
     return false;


### PR DESCRIPTION
Moved TikaOutput initialisation so it occurs in both standard and dynamic filename mode. Fixes #2339 / HOP-4447.

------------------------
To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) you have to acknowledge this by using the following check-box.

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
