### PR TITLE
Updated ExcelWriterTransform to use posY relative to the starting cell provided, where provided.

### DIFF
--- a/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelwriter/ExcelWriterTransform.java
+++ b/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelwriter/ExcelWriterTransform.java
@@ -980,9 +980,12 @@ public class ExcelWriterTransform
       } else {
         baseFileName = file.getName().toString();
       }
+
+      // If starting cell provided, use the posY derived above, otherwise use default behaviour
+      int startY = !Utils.isEmpty(data.realStartingCell) ? posY : Math.max(posY, sheet.getLastRowNum());
+
       ExcelWriterWorkbookDefinition workbookDefinition =
-          new ExcelWriterWorkbookDefinition(
-              baseFileName, file, wb, sheet, posX, Math.max(posY, sheet.getLastRowNum()));
+          new ExcelWriterWorkbookDefinition(baseFileName, file, wb, sheet, posX, startY);
       workbookDefinition.setSplitNr(splitNr);
       data.usedFiles.add(workbookDefinition);
       data.currentWorkbookDefinition = workbookDefinition;


### PR DESCRIPTION
We've observed that even when a starting-cell is set the transform will continue to skip down to the last row in the Excel where the Excel file has other non-empty rows (values or style) in. This changes sets the start position relative to the cell provided based on the other settings.

I've added this here given this feels like it's behaving not as one would expect, though given this is current behaviour and others may be configuring settings based on it, was thinking it may be better added as parameterised option. Happy to update to this if you would prefer that.

I've ran the existing unit and integration test suite for the transforms project, which all continue to pass.

------------------------
- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
------------------------
