### PR TITLE
Fix for issue #2766 : Data orchestration perspective doesn't remember tabs

### DIFF
--- a/plugins/misc/projects/src/main/java/org/apache/hop/projects/xp/HopGuiStartProjectLoad.java
+++ b/plugins/misc/projects/src/main/java/org/apache/hop/projects/xp/HopGuiStartProjectLoad.java
@@ -116,13 +116,13 @@ public class HopGuiStartProjectLoad implements IExtensionPoint {
             }
 
             // Set system variables for HOP_HOME, HOP_METADATA_FOLDER, ...
-            // Sets the namespace in HopGui to the name of the project
+            // Sets the namespace in HopGui to the name of the project.
             //
             ProjectsGuiPlugin.enableHopGuiProject(lastProjectName, project, lastEnvironment);
 
-            // Don't open the files twice
+            // Don't open the files again in the HopGui startup code.
             //
-            HopGui.getInstance().setOpeningLastFiles(false);
+            hopGui.setOpeningLastFiles(false);
           }
         }
       } else {

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/HopGui.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/HopGui.java
@@ -259,6 +259,7 @@ public class HopGui
   public HopGuiFileRefreshDelegate fileRefreshDelegate;
 
   private boolean openingLastFiles;
+  private boolean reOpeningFiles;
 
   protected HopGui() {
     this(Display.getCurrent());
@@ -418,7 +419,12 @@ public class HopGui
         () -> {
           openingLastFiles = true;
 
-          // Here the projects plugin opens up the last project/environment.
+          // We keep track of the fact that we might be re-opening files at this time.
+          // If we change the open files list while we're re-opening files things get chaotic and buggy.
+          //
+          reOpeningFiles = true;
+
+          // Here the 'projects' plugin opens up the last project/environment.
           // It sets openingLastFiles to false so the block below is not executed.
           //
           try {
@@ -437,6 +443,10 @@ public class HopGui
           if (openingLastFiles) {
             auditDelegate.openLastFiles();
           }
+
+          // We need to start tracking file history again.
+          //
+          reOpeningFiles = false;
         });
 
     // See if we need to show the Welcome dialog
@@ -1904,5 +1914,23 @@ public class HopGui
    */
   public void setEventsHandler(HopGuiEventsHandler eventsHandler) {
     this.eventsHandler = eventsHandler;
+  }
+
+  /**
+   * Gets reOpeningFiles
+   *
+   * @return value of reOpeningFiles
+   */
+  public boolean isReOpeningFiles() {
+    return reOpeningFiles;
+  }
+
+  /**
+   * Sets reOpeningFiles
+   *
+   * @param reOpeningFiles value of reOpeningFiles
+   */
+  public void setReOpeningFiles(boolean reOpeningFiles) {
+    this.reOpeningFiles = reOpeningFiles;
   }
 }

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/delegates/HopGuiFileDelegate.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/delegates/HopGuiFileDelegate.java
@@ -17,6 +17,13 @@
 
 package org.apache.hop.ui.hopgui.delegates;
 
+import java.io.File;
+import java.io.OutputStream;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.hop.core.Const;
@@ -48,14 +55,6 @@ import org.apache.hop.ui.util.EnvironmentUtils;
 import org.apache.hop.workflow.WorkflowMeta;
 import org.apache.hop.workflow.WorkflowSvgPainter;
 import org.eclipse.swt.SWT;
-
-import java.io.File;
-import java.io.OutputStream;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 public class HopGuiFileDelegate {
 
@@ -112,9 +111,10 @@ public class HopGuiFileDelegate {
         // Do it again to test
         hopGui.handleFileCapabilities(hopFile, fileTypeHandler.hasChanged(), false, false);
       }
-        // Also save the state of Hop GUI
-        //
-        hopGui.auditDelegate.writeLastOpenFiles();
+
+      // Also save the state of Hop GUI
+      //
+      hopGui.auditDelegate.writeLastOpenFiles();
     }
 
     return fileTypeHandler;


### PR DESCRIPTION
Caused by over-writing the files lists in the audit folder while the GUI was re-opening files.