### PR TITLE
transform SwitchCaseMeta bug fix

### DIFF
--- a/plugins/transforms/switchcase/src/main/java/org/apache/hop/pipeline/transforms/switchcase/SwitchCaseMeta.java
+++ b/plugins/transforms/switchcase/src/main/java/org/apache/hop/pipeline/transforms/switchcase/SwitchCaseMeta.java
@@ -119,7 +119,7 @@ public class SwitchCaseMeta extends BaseTransformMeta<SwitchCase, SwitchCaseData
     this.caseValueGroup = m.caseValueGroup;
     this.defaultTargetTransformName = m.defaultTargetTransformName;
     this.usingContains = m.usingContains;
-    for (SwitchCaseTarget target : this.caseTargets) {
+    for (SwitchCaseTarget target : m.caseTargets) {
       this.caseTargets.add(new SwitchCaseTarget(target));
     }
   }


### PR DESCRIPTION
…argets

bug_fix:transform SwitchCaseMeta. when new,should use input parameter's  caseTargets.
when use it clone function,the old code can not clone `caseTargets` info.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [ ] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [ ] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
