### PR TITLE
fix #2820

### DIFF
--- a/plugins/transforms/salesforce/src/main/java/org/apache/hop/pipeline/transforms/salesforceupsert/SalesforceUpsert.java
+++ b/plugins/transforms/salesforce/src/main/java/org/apache/hop/pipeline/transforms/salesforceupsert/SalesforceUpsert.java
@@ -138,22 +138,25 @@ public class SalesforceUpsert
         for (int i = 0; i < data.nrFields; i++) {
           IValueMeta valueMeta = data.inputRowMeta.getValueMeta(data.fieldnrs[i]);
           Object object = rowData[data.fieldnrs[i]];
-
-          if (valueMeta.isNull(object)) {
-            // The value is null
-            // We need to keep track of this field
-            fieldsToNull.add(
-                SalesforceUtils.getFieldToNullName(
-                    log, meta.getUpdateLookup()[i], meta.getUseExternalId()[i]));
-          } else {
-            Object normalObject = normalizeValue(valueMeta, rowData[data.fieldnrs[i]]);
-            if (data.mapData && data.dataTypeMap != null) {
-              normalObject =
-                  mapDataTypes(valueMeta.getType(), meta.getUpdateLookup()[i], normalObject);
+          // Only if the upsert field's value is null do not consider that field in this loop at all (Issue #2820)
+          if (!(valueMeta.isNull(object)
+              & meta.getUpsertField().equals(meta.getUpdateLookup()[i]))) {
+            if (valueMeta.isNull(object)) {
+              // The value is null
+              // We need to keep track of this field
+              fieldsToNull.add(
+                  SalesforceUtils.getFieldToNullName(
+                      log, meta.getUpdateLookup()[i], meta.getUseExternalId()[i]));
+            } else {
+              Object normalObject = normalizeValue(valueMeta, rowData[data.fieldnrs[i]]);
+              if (data.mapData && data.dataTypeMap != null) {
+                normalObject =
+                    mapDataTypes(valueMeta.getType(), meta.getUpdateLookup()[i], normalObject);
+              }
+              upsertfields.add(
+                  SalesforceConnection.createMessageElement(
+                      meta.getUpdateLookup()[i], normalObject, meta.getUseExternalId()[i]));
             }
-            upsertfields.add(
-                SalesforceConnection.createMessageElement(
-                    meta.getUpdateLookup()[i], normalObject, meta.getUseExternalId()[i]));
           }
         }
 

--- a/plugins/transforms/salesforce/src/main/java/org/apache/hop/pipeline/transforms/salesforceupsert/SalesforceUpsert.java
+++ b/plugins/transforms/salesforce/src/main/java/org/apache/hop/pipeline/transforms/salesforceupsert/SalesforceUpsert.java
@@ -138,25 +138,30 @@ public class SalesforceUpsert
         for (int i = 0; i < data.nrFields; i++) {
           IValueMeta valueMeta = data.inputRowMeta.getValueMeta(data.fieldnrs[i]);
           Object object = rowData[data.fieldnrs[i]];
-          // Only if the upsert field's value is null do not consider that field in this loop at all (Issue #2820)
-          if (!(valueMeta.isNull(object)
-              & meta.getUpsertField().equals(meta.getUpdateLookup()[i]))) {
-            if (valueMeta.isNull(object)) {
-              // The value is null
-              // We need to keep track of this field
-              fieldsToNull.add(
-                  SalesforceUtils.getFieldToNullName(
-                      log, meta.getUpdateLookup()[i], meta.getUseExternalId()[i]));
-            } else {
-              Object normalObject = normalizeValue(valueMeta, rowData[data.fieldnrs[i]]);
-              if (data.mapData && data.dataTypeMap != null) {
-                normalObject =
-                    mapDataTypes(valueMeta.getType(), meta.getUpdateLookup()[i], normalObject);
-              }
-              upsertfields.add(
-                  SalesforceConnection.createMessageElement(
-                      meta.getUpdateLookup()[i], normalObject, meta.getUseExternalId()[i]));
+
+          // Only if the upsert field's value is null do not consider that field in this loop at all
+          // (Issue #2820)
+          if (meta.getUpsertField() != null
+              && valueMeta.isNull(object)
+                  & meta.getUpsertField().equals(meta.getUpdateLookup()[i])) {
+            continue;
+          }
+
+          if (valueMeta.isNull(object)) {
+            // The value is null
+            // We need to keep track of this field
+            fieldsToNull.add(
+                SalesforceUtils.getFieldToNullName(
+                    log, meta.getUpdateLookup()[i], meta.getUseExternalId()[i]));
+          } else {
+            Object normalObject = normalizeValue(valueMeta, rowData[data.fieldnrs[i]]);
+            if (data.mapData && data.dataTypeMap != null) {
+              normalObject =
+                  mapDataTypes(valueMeta.getType(), meta.getUpdateLookup()[i], normalObject);
             }
+            upsertfields.add(
+                SalesforceConnection.createMessageElement(
+                    meta.getUpdateLookup()[i], normalObject, meta.getUseExternalId()[i]));
           }
         }
 


### PR DESCRIPTION
fix #2820 Salesforce upsert using internal id: the id field tuple not  to be sent if stream field is empty (insert)

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
