### PR TITLE
bump jersey to 2.38 to suppress repeating WARNs by HTTPPost and others #2682

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -40,7 +40,7 @@
         <!-- Third-party dependencies -->
         <commons-validator.version>1.3.1</commons-validator.version>
         <commons-collections4.version>4.4</commons-collections4.version>
-        <jersey2.version>2.34</jersey2.version>
+        <jersey2.version>2.38</jersey2.version>
         <jaxrs.version>2.1.6</jaxrs.version>
         <olap4j.version>1.2.0</olap4j.version>
         <olap4j-xmla.version>1.2.0</olap4j-xmla.version>
@@ -127,7 +127,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- Jersey 2.19 -->
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet</artifactId>


### PR DESCRIPTION
- #2682 HTTPPost repeats jersey warn on every request
- https://github.com/eclipse-ee4j/jersey/pull/5165 addresses it and made fix available in jersey 2.38

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
