### PR TITLE
fix #3056

### DIFF
--- a/engine/src/main/java/org/apache/hop/pipeline/transform/BaseTransform.java
+++ b/engine/src/main/java/org/apache/hop/pipeline/transform/BaseTransform.java
@@ -1005,13 +1005,17 @@ public class BaseTransform<Meta extends ITransformMeta, Data extends ITransformD
           }
         }
       }
-    }
-    getRowHandler().putRow(rowMeta, row);
+      
+      // Put row only if rowMeta is not null...
+      getRowHandler().putRow(rowMeta, row);
 
-    // This transform is not reading data, only writing
-    //
-    if (firstRowReadDate == null) {
-      firstRowReadDate = new Date();
+      // This transform is not reading data, only writing
+      //
+      if (firstRowReadDate == null) {
+        firstRowReadDate = new Date();
+      }
+    } else {
+      logBasic("WARNING: Trying to perform a putRow with rowMeta NULL!");
     }
   }
 
@@ -1704,7 +1708,7 @@ public class BaseTransform<Meta extends ITransformMeta, Data extends ITransformD
         inputRowMeta = inputRowSet.getRowMeta();
       }
     } else {
-      logBasic("WARNING: Trying to assign inputRowMeta to a NULL reference.");  
+      logBasic("WARNING: Trying to assign inputRowMeta to a NULL reference. PrevTransform: " + inputRowSet.getOriginTransformName());
     }
     
     if (row != null) {

--- a/engine/src/test/java/org/apache/hop/pipeline/transform/BaseTransformTest.java
+++ b/engine/src/test/java/org/apache/hop/pipeline/transform/BaseTransformTest.java
@@ -446,7 +446,7 @@ public class BaseTransformTest {
     rowSet.putRow(rowMeta, row);
 
     baseTransformSpy.setInputRowSets(Arrays.asList(rowSet));
-    doReturn(rowSet).when(baseTransformSpy).currentInputStream();
+    doReturn(rowSet).when(baseTransformSpy).currentInputStream("OriginTransform");
 
     baseTransformSpy.getRow();
 


### PR DESCRIPTION
fix #3056 NullPointerException on pipelines with transforms receiving more than one flow in input

The following considerations applies to this PR:

1. This fix start from the assumption when we arrive to a transform, we arrive there because we have a flow that takes us there otherwise we never arrive there. 
2. We definitely verified that the problem arises because, at the time the issue is raised, the inputRowMeta reference is null
3. The place where this change acts is the only place where, in the engine,  the inputRowMeta reference is set during the lifecycle of the transform 
4. If we have more than one flow that is entering a transform, the change keeps only the RowMeta references that are valid and we suppose that at least one of these must be valid because of the assumption made at point 1 above


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
