### PR TITLE
fix #3058 Excel Writer: inherit date format mask from ValueMeta

### DIFF
--- a/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelwriter/ExcelWriterTransform.java
+++ b/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelwriter/ExcelWriterTransform.java
@@ -17,6 +17,11 @@
 
 package org.apache.hop.pipeline.transforms.excelwriter;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.hop.core.Const;
 import org.apache.hop.core.ResultFile;
@@ -25,9 +30,7 @@ import org.apache.hop.core.exception.HopFileException;
 import org.apache.hop.core.row.IRowMeta;
 import org.apache.hop.core.row.IValueMeta;
 import org.apache.hop.core.row.RowMeta;
-import org.apache.hop.core.row.value.ValueMetaDate;
 import org.apache.hop.core.row.value.ValueMetaString;
-import org.apache.hop.core.row.value.ValueMetaTimestamp;
 import org.apache.hop.core.util.Utils;
 import org.apache.hop.core.vfs.HopVfs;
 import org.apache.hop.i18n.BaseMessages;
@@ -59,12 +62,6 @@ import org.apache.poi.xssf.streaming.SXSSFSheet;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
-
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 
 public class ExcelWriterTransform
     extends BaseTransform<ExcelWriterTransformMeta, ExcelWriterTransformData> {
@@ -543,7 +540,7 @@ public class ExcelWriterTransform
                   && excelField != null
                   && Utils.isEmpty(excelField.getFormat())) {
 
-            if (vMeta instanceof ValueMetaDate || vMeta instanceof ValueMetaTimestamp) {
+            if (vMeta.getType() == IValueMeta.TYPE_DATE || vMeta.getType() == IValueMeta.TYPE_TIMESTAMP) {
 
               String format = vMeta.getFormatMask();
               if (!Utils.isEmpty(format)) {
@@ -770,7 +767,7 @@ public class ExcelWriterTransform
 
       // clear style cache
       int numOfFields =
-          meta.getOutputFields() != null && meta.getOutputFields().size() > 0
+          meta.getOutputFields() != null && !meta.getOutputFields().isEmpty()
               ? meta.getOutputFields().size()
               : 0;
       if (numOfFields == 0) {

--- a/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelwriter/ExcelWriterTransform.java
+++ b/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelwriter/ExcelWriterTransform.java
@@ -25,7 +25,9 @@ import org.apache.hop.core.exception.HopFileException;
 import org.apache.hop.core.row.IRowMeta;
 import org.apache.hop.core.row.IValueMeta;
 import org.apache.hop.core.row.RowMeta;
+import org.apache.hop.core.row.value.ValueMetaDate;
 import org.apache.hop.core.row.value.ValueMetaString;
+import org.apache.hop.core.row.value.ValueMetaTimestamp;
 import org.apache.hop.core.util.Utils;
 import org.apache.hop.core.vfs.HopVfs;
 import org.apache.hop.i18n.BaseMessages;
@@ -535,6 +537,19 @@ public class ExcelWriterTransform
               && !Utils.isEmpty(excelField.getFormat())
               && !excelField.getFormat().startsWith("Image")) {
             setDataFormat(workbookDefinition, excelField.getFormat(), cell);
+          }
+
+          if (!isTitle
+                  && excelField != null
+                  && Utils.isEmpty(excelField.getFormat())) {
+
+            if (vMeta instanceof ValueMetaDate || vMeta instanceof ValueMetaTimestamp) {
+
+              String format = vMeta.getFormatMask();
+              if (!Utils.isEmpty(format)) {
+                setDataFormat(workbookDefinition, format, cell);
+              }
+            }
           }
           // cache it for later runs
           if (!isTitle) {

--- a/plugins/transforms/excel/src/test/java/org/apache/hop/pipeline/transforms/excelwriter/ExcelWriterTransformTest.java
+++ b/plugins/transforms/excel/src/test/java/org/apache/hop/pipeline/transforms/excelwriter/ExcelWriterTransformTest.java
@@ -17,7 +17,27 @@
 
 package org.apache.hop.pipeline.transforms.excelwriter;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.google.common.io.Files;
+import java.io.File;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.hop.core.exception.HopException;
 import org.apache.hop.core.logging.ILoggingObject;
@@ -42,27 +62,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-
-import java.io.File;
-import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class ExcelWriterTransformTest {
 
@@ -307,7 +306,7 @@ public class ExcelWriterTransformTest {
   @Test
   public void testValueDate() throws Exception {
 
-    IValueMeta vmi = mock(ValueMetaDate.class, new DefaultAnswerThrowsException());
+    IValueMeta vmi = mock(ValueMetaDate.class);
     Object vObj = new Object();
     doReturn(IValueMeta.TYPE_DATE).when(vmi).getType();
     doReturn("value_date").when(vmi).getName();
@@ -367,9 +366,9 @@ public class ExcelWriterTransformTest {
   @Test
   public void testValueTimestamp() throws Exception {
 
-    IValueMeta vmi = mock(ValueMetaTimestamp.class, new DefaultAnswerThrowsException());
+    IValueMeta vmi = mock(ValueMetaTimestamp.class);
     Object vObj = new Object();
-    doReturn(IValueMeta.TYPE_INET).when(vmi).getType();
+    doReturn(IValueMeta.TYPE_TIMESTAMP).when(vmi).getType();
     doReturn("value_timestamp").when(vmi).getName();
     doReturn("127.0.0.1").when(vmi).getString(vObj);
 
@@ -379,10 +378,10 @@ public class ExcelWriterTransformTest {
   @Test
   public void test_Xlsx_Stream_NoTemplate() throws Exception {
 
-    IValueMeta vmi = mock(ValueMetaTimestamp.class, new DefaultAnswerThrowsException());
+    IValueMeta vmi = mock(ValueMetaInternetAddress.class, new DefaultAnswerThrowsException());
     Object vObj = new Object();
     doReturn(IValueMeta.TYPE_INET).when(vmi).getType();
-    doReturn("value_timestamp").when(vmi).getName();
+    doReturn("value_internetAddress").when(vmi).getName();
     doReturn("127.0.0.1").when(vmi).getString(vObj);
 
     testBaseXlsx(vmi, vObj, true, false);
@@ -391,10 +390,10 @@ public class ExcelWriterTransformTest {
   @Test
   public void test_Xlsx_NoStream_NoTemplate() throws Exception {
 
-    IValueMeta vmi = mock(ValueMetaTimestamp.class, new DefaultAnswerThrowsException());
+    IValueMeta vmi = mock(ValueMetaInternetAddress.class, new DefaultAnswerThrowsException());
     Object vObj = new Object();
     doReturn(IValueMeta.TYPE_INET).when(vmi).getType();
-    doReturn("value_timestamp").when(vmi).getName();
+    doReturn("value_internetAddress").when(vmi).getName();
     doReturn("127.0.0.1").when(vmi).getString(vObj);
 
     testBaseXlsx(vmi, vObj, false, false);
@@ -403,10 +402,10 @@ public class ExcelWriterTransformTest {
   @Test
   public void test_Xlsx_Stream_Template() throws Exception {
 
-    IValueMeta vmi = mock(ValueMetaTimestamp.class, new DefaultAnswerThrowsException());
+    IValueMeta vmi = mock(ValueMetaInternetAddress.class, new DefaultAnswerThrowsException());
     Object vObj = new Object();
     doReturn(IValueMeta.TYPE_INET).when(vmi).getType();
-    doReturn("value_timestamp").when(vmi).getName();
+    doReturn("value_internetAddress").when(vmi).getName();
     doReturn("127.0.0.1").when(vmi).getString(vObj);
 
     testBaseXlsx(vmi, vObj, true, true);
@@ -415,10 +414,10 @@ public class ExcelWriterTransformTest {
   @Test
   public void test_Xlsx_NoStream_Template() throws Exception {
 
-    IValueMeta vmi = mock(ValueMetaTimestamp.class, new DefaultAnswerThrowsException());
+    IValueMeta vmi = mock(ValueMetaInternetAddress.class, new DefaultAnswerThrowsException());
     Object vObj = new Object();
     doReturn(IValueMeta.TYPE_INET).when(vmi).getType();
-    doReturn("value_timestamp").when(vmi).getName();
+    doReturn("value_internetAddress").when(vmi).getName();
     doReturn("127.0.0.1").when(vmi).getString(vObj);
 
     testBaseXlsx(vmi, vObj, false, true);
@@ -430,7 +429,7 @@ public class ExcelWriterTransformTest {
     IValueMeta vmi = mock(ValueMetaTimestamp.class, new DefaultAnswerThrowsException());
     Object vObj = new Object();
     doReturn(IValueMeta.TYPE_INET).when(vmi).getType();
-    doReturn("value_timestamp").when(vmi).getName();
+    doReturn("value_internetAddress").when(vmi).getName();
     doReturn("127.0.0.1").when(vmi).getString(vObj);
 
     testBaseXls(vmi, vObj, false);
@@ -442,7 +441,7 @@ public class ExcelWriterTransformTest {
     IValueMeta vmi = mock(ValueMetaTimestamp.class, new DefaultAnswerThrowsException());
     Object vObj = new Object();
     doReturn(IValueMeta.TYPE_INET).when(vmi).getType();
-    doReturn("value_timestamp").when(vmi).getName();
+    doReturn("value_internetAddress").when(vmi).getName();
     doReturn("127.0.0.1").when(vmi).getString(vObj);
 
     testBaseXls(vmi, vObj, true);


### PR DESCRIPTION
fix #3058 Excel Writer: inherit date format mask from ValueMeta

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
