### PR TITLE
ExcelWriterTransform: POI temporary files are not disposed in streami…

### DIFF
--- a/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelwriter/ExcelWriterTransform.java
+++ b/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelwriter/ExcelWriterTransform.java
@@ -328,6 +328,12 @@ public class ExcelWriterTransform
       // This closes the output stream as well
       file.getWorkbook().write(out);
       file.getWorkbook().close();
+
+      // deleting the temporary files
+      if (file.getWorkbook() instanceof SXSSFWorkbook ) {
+        ((SXSSFWorkbook ) file.getWorkbook()).dispose();
+      }
+
     } catch (IOException e) {
       throw new HopException(e);
     } finally {


### PR DESCRIPTION
ExcelWriterTransform: POI temporary files are not disposed in streaming mode

If streaming mode is enabled in ExcelWriterTransform a temporary file might remain in the temp directory. Given large amounts of data those files can grow pretty fast.
To get rid of these temp files calling SXSSFWorkbook.dispose() after useage should be called