### PR TITLE
Fix wrong Docker ENV Var in index.adoc

### DIFF
--- a/docs/hop-user-manual/modules/ROOT/pages/hop-server/index.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/hop-server/index.adoc
@@ -394,7 +394,7 @@ docker run \
   -e HOP_SERVER_PORT=8080 \
   -e HOP_SERVER_SHUTDOWNPORT=8079 \
   -e HOP_SERVER_USER=username \
-  -e HOP_SERVER_USER=password \
+  -e HOP_SERVER_PASS=password \
   apache/hop
 ----
 


### PR DESCRIPTION
The sample docker statement to start the Hop Server from docker had the wrong environment variable for the HOP_SERVER_PASS.  This prevented login of the server without first finding the error.

Changed the **password** line from HOP_SERVER_USER to HOP_SERVER_PASS

------------------------

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
