### PR TITLE
Fix wrong Docker ENV Var in index.adoc

### DIFF
--- a/docs/hop-user-manual/modules/ROOT/pages/hop-server/index.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/hop-server/index.adoc
@@ -394,7 +394,7 @@ docker run \
   -e HOP_SERVER_PORT=8080 \
   -e HOP_SERVER_SHUTDOWNPORT=8079 \
   -e HOP_SERVER_USER=username \
-  -e HOP_SERVER_USER=password \
+  -e HOP_SERVER_PASS=password \
   apache/hop
 ----
 


### PR DESCRIPTION
The sample docker statement to start the Hop Server from docker had the wrong environment variable for the HOP_SERVER_PASS.  This prevented login of the server without first finding the error.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [ ] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [ ] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
