### PR TITLE
issue #3335 : Underline the name of a transform or action to mimic a hyperlink

### DIFF
--- a/engine/src/main/java/org/apache/hop/core/gui/BasePainter.java
+++ b/engine/src/main/java/org/apache/hop/core/gui/BasePainter.java
@@ -79,6 +79,7 @@ public abstract class BasePainter<Hop extends BaseHopMeta<?>, Part extends IBase
   protected float screenMagnification;
   protected Rectangle graphPort;
   protected Rectangle viewPort;
+  protected String mouseOverName;
 
   public BasePainter(
       IGc gc,
@@ -94,7 +95,8 @@ public abstract class BasePainter<Hop extends BaseHopMeta<?>, Part extends IBase
       String noteFontName,
       int noteFontHeight,
       double zoomFactor,
-      boolean drawingEditIcons) {
+      boolean drawingEditIcons,
+      String mouseOverName) {
     this.gc = gc;
     this.variables = variables;
     this.subject = subject;
@@ -121,6 +123,7 @@ public abstract class BasePainter<Hop extends BaseHopMeta<?>, Part extends IBase
     this.noteFontHeight = noteFontHeight;
 
     this.screenMagnification = 1.0f;
+    this.mouseOverName = mouseOverName;
   }
 
   public static EImage getStreamIconImage(StreamIcon streamIcon, boolean enabled) {
@@ -671,5 +674,23 @@ public abstract class BasePainter<Hop extends BaseHopMeta<?>, Part extends IBase
    */
   public void setViewPort(Rectangle viewPort) {
     this.viewPort = viewPort;
+  }
+
+  /**
+   * Gets mouseOverName
+   *
+   * @return value of mouseOverName
+   */
+  public String getMouseOverName() {
+    return mouseOverName;
+  }
+
+  /**
+   * Sets mouseOverName
+   *
+   * @param mouseOverName value of mouseOverName
+   */
+  public void setMouseOverName(String mouseOverName) {
+    this.mouseOverName = mouseOverName;
   }
 }

--- a/engine/src/main/java/org/apache/hop/pipeline/PipelinePainter.java
+++ b/engine/src/main/java/org/apache/hop/pipeline/PipelinePainter.java
@@ -100,6 +100,7 @@ public class PipelinePainter extends BasePainter<PipelineHopMeta, TransformMeta>
       double zoomFactor,
       Map<String, RowBuffer> outputRowsMap,
       boolean drawingEditIcons,
+      String mouseOverName,
       Map<String, Object> stateMap) {
     super(
         gc,
@@ -115,7 +116,8 @@ public class PipelinePainter extends BasePainter<PipelineHopMeta, TransformMeta>
         noteFontName,
         noteFontHeight,
         zoomFactor,
-        drawingEditIcons);
+        drawingEditIcons,
+        mouseOverName);
     this.pipelineMeta = pipelineMeta;
 
     this.candidate = candidate;
@@ -146,6 +148,7 @@ public class PipelinePainter extends BasePainter<PipelineHopMeta, TransformMeta>
       int noteFontHeight,
       double zoomFactor,
       boolean drawingEditIcons,
+      String mouseOverName,
       Map<String, Object> stateMap) {
     this(
         gc,
@@ -166,6 +169,7 @@ public class PipelinePainter extends BasePainter<PipelineHopMeta, TransformMeta>
         zoomFactor,
         new HashMap<>(),
         drawingEditIcons,
+        mouseOverName,
         stateMap);
   }
 
@@ -801,13 +805,11 @@ public class PipelinePainter extends BasePainter<PipelineHopMeta, TransformMeta>
     }
 
     Point namePosition = getNamePosition(name, screen, iconSize);
+    Point nameExtent = gc.textExtent(name);
 
     // Help out the user working in single-click mode by allowing the name to be clicked to edit
     //
     if (isDrawingEditIcons()) {
-
-      Point nameExtent = gc.textExtent(name);
-
       int tmpAlpha = gc.getAlpha();
       gc.setAlpha(230);
 
@@ -822,23 +824,35 @@ public class PipelinePainter extends BasePainter<PipelineHopMeta, TransformMeta>
           BasePainter.CORNER_RADIUS_5 + 15,
           BasePainter.CORNER_RADIUS_5 + 15);
       gc.setAlpha(tmpAlpha);
-
-      areaOwners.add(
-          new AreaOwner(
-              AreaType.TRANSFORM_NAME,
-              namePosition.x - 8,
-              namePosition.y - 2,
-              nameExtent.x + 15,
-              nameExtent.y + 8,
-              offset,
-              transformMeta,
-              name));
     }
+
+    // Add the area owner for the transform name
+    //
+    areaOwners.add(
+        new AreaOwner(
+            AreaType.TRANSFORM_NAME,
+            namePosition.x - 8,
+            namePosition.y - 2,
+            nameExtent.x + 15,
+            nameExtent.y + 8,
+            offset,
+            transformMeta,
+            name));
 
     gc.setForeground(EColor.BLACK);
     gc.setFont(EFont.GRAPH);
     gc.drawText(name, namePosition.x, namePosition.y + 2, true);
     boolean partitioned = false;
+
+    // See if we need to draw a line under the name to make the name look like a hyperlink.
+    //
+    if (name.equals(mouseOverName)) {
+      gc.drawLine(
+          namePosition.x,
+          namePosition.y + nameExtent.y,
+          namePosition.x + nameExtent.x ,
+          namePosition.y + nameExtent.y);
+    }
 
     TransformPartitioningMeta meta = transformMeta.getTransformPartitioningMeta();
     if (transformMeta.isPartitioned() && meta != null) {

--- a/engine/src/main/java/org/apache/hop/pipeline/PipelineSvgPainter.java
+++ b/engine/src/main/java/org/apache/hop/pipeline/PipelineSvgPainter.java
@@ -65,6 +65,7 @@ public class PipelineSvgPainter {
               10,
               zoomFactor,
               false,
+              null,
               new HashMap<>());
       pipelinePainter.setMagnification(magnification);
       pipelinePainter.drawPipelineImage();

--- a/engine/src/main/java/org/apache/hop/workflow/WorkflowPainter.java
+++ b/engine/src/main/java/org/apache/hop/workflow/WorkflowPainter.java
@@ -17,6 +17,9 @@
 
 package org.apache.hop.workflow;
 
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
 import org.apache.hop.core.NotePadMeta;
 import org.apache.hop.core.Result;
 import org.apache.hop.core.exception.HopException;
@@ -37,10 +40,6 @@ import org.apache.hop.core.logging.LogChannel;
 import org.apache.hop.core.util.Utils;
 import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.workflow.action.ActionMeta;
-
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
 
 public class WorkflowPainter extends BasePainter<WorkflowHopMeta, ActionMeta> {
 
@@ -68,7 +67,8 @@ public class WorkflowPainter extends BasePainter<WorkflowHopMeta, ActionMeta> {
       String noteFontName,
       int noteFontHeight,
       double zoomFactor,
-      boolean drawingEditIcons) {
+      boolean drawingEditIcons,
+      String mouseOverName) {
     super(
         gc,
         variables,
@@ -83,7 +83,8 @@ public class WorkflowPainter extends BasePainter<WorkflowHopMeta, ActionMeta> {
         noteFontName,
         noteFontHeight,
         zoomFactor,
-        drawingEditIcons);
+        drawingEditIcons,
+        mouseOverName);
     this.workflowMeta = workflowMeta;
 
     this.candidate = candidate;
@@ -99,7 +100,7 @@ public class WorkflowPainter extends BasePainter<WorkflowHopMeta, ActionMeta> {
     // Draw the pipeline onto the image
     //
     gc.setAlpha(255);
-    gc.setTransform((float)offset.x, (float)offset.y, magnification);
+    gc.setTransform((float) offset.x, (float) offset.y, magnification);
     drawActions();
 
     // Draw the navigation view in native pixels to make calculation a bit easier.
@@ -211,10 +212,10 @@ public class WorkflowPainter extends BasePainter<WorkflowHopMeta, ActionMeta> {
           round(offset.x + n.x + iconSize + 5),
           round(offset.y + n.y + iconSize + 5));
       gc.drawLine(
-              round(offset.x + n.x - 5),
-              round(offset.y + n.y + iconSize + 5),
-              round(offset.x + n.x + iconSize + 5),
-              round(offset.y + n.y - 5));
+          round(offset.x + n.x - 5),
+          round(offset.y + n.y + iconSize + 5),
+          round(offset.x + n.x + iconSize + 5),
+          round(offset.y + n.y - 5));
     }
 
     try {
@@ -274,10 +275,8 @@ public class WorkflowPainter extends BasePainter<WorkflowHopMeta, ActionMeta> {
 
     // Help out the user working in single-click mode by allowing the name to be clicked to edit
     //
+    Point nameExtent = gc.textExtent(name);
     if (isDrawingEditIcons()) {
-
-      Point nameExtent = gc.textExtent(name);
-
       int tmpAlpha = gc.getAlpha();
       gc.setAlpha(230);
 
@@ -292,20 +291,30 @@ public class WorkflowPainter extends BasePainter<WorkflowHopMeta, ActionMeta> {
           BasePainter.CORNER_RADIUS_5 + 15,
           BasePainter.CORNER_RADIUS_5 + 15);
       gc.setAlpha(tmpAlpha);
-
-      areaOwners.add(
-          new AreaOwner(
-              AreaType.ACTION_NAME,
-              xPos - 8,
-              yPos - 2,
-              nameExtent.x + 15,
-              nameExtent.y + 4,
-              offset,
-              actionMeta,
-              name));
     }
 
+    // Add the area owner for the action name
+    //
+    areaOwners.add(
+        new AreaOwner(
+            AreaType.ACTION_NAME,
+            xPos - 8,
+            yPos - 2,
+            nameExtent.x + 15,
+            nameExtent.y + 4,
+            offset,
+            actionMeta,
+            name));
+
+    gc.setForeground(EColor.BLACK);
+    gc.setFont(EFont.GRAPH);
     gc.drawText(name, xPos, yPos, true);
+
+    // See if we need to draw a line under the name to make the name look like a hyperlink.
+    //
+    if (name.equals(mouseOverName)) {
+      gc.drawLine(xPos, yPos + nameExtent.y, xPos + nameExtent.x, yPos + nameExtent.y);
+    }
 
     if (activeActions != null && activeActions.contains(actionMeta)) {
       gc.setForeground(EColor.BLUE);
@@ -325,10 +334,10 @@ public class WorkflowPainter extends BasePainter<WorkflowHopMeta, ActionMeta> {
     } else {
       gc.setForeground(EColor.BLACK);
     }
-    
+
     // Show an information icon in the upper left corner of the action...
     //
-    if ( !Utils.isEmpty(actionMeta.getDescription()) ) {
+    if (!Utils.isEmpty(actionMeta.getDescription())) {
       int xInfo = x - (miniIconSize / 2) - 1;
       int yInfo = y - (miniIconSize / 2) - 1;
       gc.drawImage(EImage.INFO_DISABLED, xInfo, yInfo, magnification);
@@ -642,12 +651,16 @@ public class WorkflowPainter extends BasePainter<WorkflowHopMeta, ActionMeta> {
     this.activeActions = activeActions;
   }
 
-  /** @return the actionResults */
+  /**
+   * @return the actionResults
+   */
   public List<ActionResult> getActionResults() {
     return actionResults;
   }
 
-  /** @param actionResults Sets AND sorts the action results by name and number */
+  /**
+   * @param actionResults Sets AND sorts the action results by name and number
+   */
   public void setActionResults(List<ActionResult> actionResults) {
     this.actionResults = actionResults;
     Collections.sort(this.actionResults);

--- a/engine/src/main/java/org/apache/hop/workflow/WorkflowSvgPainter.java
+++ b/engine/src/main/java/org/apache/hop/workflow/WorkflowSvgPainter.java
@@ -43,7 +43,7 @@ public class WorkflowSvgPainter {
               variables,
               workflowMeta,
               maximum,
-              new DPoint(0,0),
+              new DPoint(0, 0),
               null,
               null,
               new ArrayList<>(),
@@ -53,7 +53,8 @@ public class WorkflowSvgPainter {
               "Arial",
               10,
               1.0d,
-              false);
+              false,
+              null);
       workflowPainter.setMagnification(magnification);
       workflowPainter.drawWorkflow();
 

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/HopGuiPipelineGraph.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/HopGuiPipelineGraph.java
@@ -785,10 +785,10 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
       if (hop != null) {
         // Delete hop with on click
         if (e.button == 1 && shift && control) {
-          // Delete the hop            
+          // Delete the hop
           pipelineHopDelegate.delHop(pipelineMeta, hop);
           updateGui();
-        }        
+        }
         // User held control and clicked a hop between steps - We want to flip the active state of
         // the hop.
         //
@@ -863,6 +863,7 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
     PipelineHopMeta selectedHop = findPipelineHop(e.x, e.y);
     updateErrorMetaForHop(selectedHop);
     boolean singleClick = false;
+    mouseOverName = null;
     viewDrag = false;
     viewDragStart = null;
     SingleClickType singleClickType = null;
@@ -1222,7 +1223,8 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
             previewRowsDialog.setTitleMessage(title, prefix + message);
             previewRowsDialog.open();
           } catch (Exception ex) {
-            new ErrorDialog(hopGui.getDisplay().getActiveShell(), "Error", "Error showing preview dialog", ex);
+            new ErrorDialog(
+                hopGui.getDisplay().getActiveShell(), "Error", "Error showing preview dialog", ex);
           }
         }
       }
@@ -1368,6 +1370,7 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
     boolean shift = (e.stateMask & SWT.SHIFT) != 0;
     noInputTransform = null;
     mouseMovedSinceClick = true;
+    boolean doRedraw = false;
 
     // disable the tooltip
     //
@@ -1414,6 +1417,22 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
       LogChannel.GENERAL.logError("Error calling PipelineGraphMouseMoved extension point", ex);
     }
 
+    // Mouse over the name of the transform
+    //
+    if (!PropsUi.getInstance().useDoubleClick()) {
+      if (areaOwner != null && areaOwner.getAreaType() == AreaType.TRANSFORM_NAME) {
+        if (mouseOverName == null) {
+          doRedraw = true;
+        }
+        mouseOverName = (String) areaOwner.getOwner();
+      } else {
+        if (mouseOverName != null) {
+          doRedraw = true;
+        }
+        mouseOverName = null;
+      }
+    }
+
     //
     // First see if the icon we clicked on was selected.
     // If the icon was not selected, we should un-select all other
@@ -1425,20 +1444,20 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
       selectedTransforms = new ArrayList<>();
       selectedTransforms.add(selectedTransform);
       previousTransformLocations = new Point[] {selectedTransform.getLocation()};
-      redraw();
+      doRedraw = true;
     } else if (selectedNote != null && !selectedNote.isSelected()) {
       pipelineMeta.unselectAll();
       selectedNote.setSelected(true);
       selectedNotes = new ArrayList<>();
       selectedNotes.add(selectedNote);
       previousNoteLocations = new Point[] {selectedNote.getLocation()};
-      redraw();
+      doRedraw = true;
     } else if (selectionRegion != null && startHopTransform == null) {
       // Did we select a region...?
       //
       selectionRegion.width = real.x - selectionRegion.x;
       selectionRegion.height = real.y - selectionRegion.y;
-      redraw();
+      doRedraw = true;
     } else if (selectedTransform != null
         && lastButton == 1
         && !shift
@@ -1494,7 +1513,7 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
         }
       }
 
-      redraw();
+      doRedraw = true;
     } else if ((startHopTransform != null && endHopTransform == null)
         || (endHopTransform != null && startHopTransform == null)) {
       // Are we creating a new hop with the middle button or pressing SHIFT?
@@ -1533,11 +1552,11 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
       } else {
         if (candidate != null) {
           candidate = null;
-          redraw();
+          doRedraw = true;
         }
       }
 
-      redraw();
+      doRedraw = true;
     } else {
       // Drag the view around with middle button on the background?
       //
@@ -1579,8 +1598,11 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
           }
         }
 
-        redraw();
+        doRedraw = true;
       }
+    }
+    if (doRedraw) {
+      redraw();
     }
   }
 
@@ -2770,7 +2792,7 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
     pipelineClipboardDelegate.copySelected(
         pipelineMeta, Collections.emptyList(), Arrays.asList(context.getNotePadMeta()));
   }
-  
+
   @GuiContextAction(
       id = "pipeline-graph-edit-pipeline",
       parentId = HopGuiPipelineContext.CONTEXT_ID,
@@ -3316,6 +3338,7 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
               propsUi.getZoomFactor(),
               outputRowsMap,
               !propsUi.useDoubleClick(),
+              mouseOverName,
               stateMap);
 
       pipelinePainter.setMagnification((float) (magnification * PropsUi.getNativeZoomFactor()));
@@ -3354,7 +3377,8 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
         }
 
       } catch (Exception e) {
-        new ErrorDialog(hopGui.getDisplay().getActiveShell(), "Error", "Error drawing pipeline image", e);
+        new ErrorDialog(
+            hopGui.getDisplay().getActiveShell(), "Error", "Error drawing pipeline image", e);
       }
     } finally {
       gc.dispose();
@@ -3621,10 +3645,7 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
     return pipelineMeta;
   }
 
-
-  /**
-   * Use method hasChanged()
-   */
+  /** Use method hasChanged() */
   @Deprecated
   public boolean hasContentChanged() {
     return pipelineMeta.hasChanged();
@@ -3673,11 +3694,10 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
     }
 
     Shell shell = hopGui.getDisplay().getActiveShell();
-    if(shell == null){
+    if (shell == null) {
       shell = hopGui.getShell();
     }
-    PipelineDialog tid =
-        new PipelineDialog(shell, SWT.NONE, variables, pipelineMeta, currentTab);
+    PipelineDialog tid = new PipelineDialog(shell, SWT.NONE, variables, pipelineMeta, currentTab);
     if (tid.open() != null) {
       hopGui.setParametersAsVariablesInUI(pipelineMeta, variables);
       updateGui();
@@ -3696,7 +3716,7 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
   public void setChanged() {
     pipelineMeta.setChanged();
   }
-  
+
   @Override
   public synchronized void save() throws HopException {
     try {
@@ -5229,7 +5249,7 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
     pipelineClipboardDelegate.copySelected(
         pipelineMeta, Arrays.asList(context.getTransformMeta()), Collections.emptyList());
   }
-  
+
   @GuiKeyboardShortcut(key = ' ')
   @GuiOsxKeyboardShortcut(key = ' ')
   public void showOutputFields() {

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/HopGuiWorkflowGraph.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/HopGuiWorkflowGraph.java
@@ -624,18 +624,18 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
         if (hop != null) {
           // Delete hop with on click
           if (e.button == 1 && shift && control) {
-            // Delete the hop            
+            // Delete the hop
             workflowHopDelegate.delHop(workflowMeta, hop);
             updateGui();
           }
-          // User held control and clicked a hop between actions - We want to flip the active state of
+          // User held control and clicked a hop between actions - We want to flip the active state
+          // of
           // the hop.
           //
           else if (e.button == 2 || (e.button == 1 && control)) {
             hop.setEnabled(!hop.isEnabled());
             updateGui();
-          }
-          else {
+          } else {
             // A hop: show the hop context menu in the mouseUp() listener
             //
             clickedWorkflowHop = hop;
@@ -707,6 +707,7 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
     WorkflowHopMeta singleClickHop = null;
     viewDrag = false;
     viewDragStart = null;
+    mouseOverName = null;
 
     if (iconOffset == null) {
       iconOffset = new Point(0, 0);
@@ -1078,6 +1079,7 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
   public void mouseMove(MouseEvent e) {
     boolean shift = (e.stateMask & SWT.SHIFT) != 0;
     noInputAction = null;
+    boolean doRedraw = false;
 
     // disable the tooltip
     //
@@ -1119,6 +1121,22 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
       }
     }
 
+    // Mouse over the name of the transform
+    //
+    if (!PropsUi.getInstance().useDoubleClick()) {
+      if (areaOwner != null && areaOwner.getAreaType() == AreaOwner.AreaType.ACTION_NAME) {
+        if (mouseOverName == null) {
+          doRedraw = true;
+        }
+        mouseOverName = (String) areaOwner.getOwner();
+      } else {
+        if (mouseOverName != null) {
+          doRedraw = true;
+        }
+        mouseOverName = null;
+      }
+    }
+
     //
     // First see if the icon we clicked on was selected.
     // If the icon was not selected, we should un-select all other
@@ -1130,20 +1148,20 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
       selectedActions = new ArrayList<>();
       selectedActions.add(selectedAction);
       previousTransformLocations = new Point[] {selectedAction.getLocation()};
-      redraw();
+      doRedraw = true;
     } else if (selectedNote != null && !selectedNote.isSelected()) {
       workflowMeta.unselectAll();
       selectedNote.setSelected(true);
       selectedNotes = new ArrayList<>();
       selectedNotes.add(selectedNote);
       previousNoteLocations = new Point[] {selectedNote.getLocation()};
-      redraw();
+      doRedraw = true;
     } else if (selectionRegion != null && startHopAction == null) {
       // Did we select a region...?
       //
       selectionRegion.width = real.x - selectionRegion.x;
       selectionRegion.height = real.y - selectionRegion.y;
-      redraw();
+      doRedraw = true;
     } else if (selectedAction != null && lastButton == 1 && !shift && startHopAction == null) {
       // Move around transforms & notes
       //
@@ -1195,7 +1213,7 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
         }
       }
 
-      redraw();
+      doRedraw = true;
     } else if ((startHopAction != null && endHopAction == null)
         || (endHopAction != null && startHopAction == null)) {
       // Are we creating a new hop with the middle button or pressing SHIFT?
@@ -1226,11 +1244,11 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
       } else {
         if (hopCandidate != null) {
           hopCandidate = null;
-          redraw();
+          doRedraw = true;
         }
       }
 
-      redraw();
+      doRedraw = true;
     } else {
       // Drag the view around with middle button on the background?
       //
@@ -1270,8 +1288,11 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
           }
         }
 
-        redraw();
+        doRedraw = true;
       }
+    }
+    if (doRedraw) {
+      redraw();
     }
   }
 
@@ -1328,7 +1349,9 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
         boolean cancel = false;
         workflowMeta.addWorkflowHop(hopCandidate);
         if (workflowMeta.hasLoop(hopCandidate.getToAction())) {
-          MessageBox mb = new MessageBox(hopGui.getDisplay().getActiveShell(), SWT.OK | SWT.CANCEL | SWT.ICON_WARNING);
+          MessageBox mb =
+              new MessageBox(
+                  hopGui.getDisplay().getActiveShell(), SWT.OK | SWT.CANCEL | SWT.ICON_WARNING);
           mb.setMessage(BaseMessages.getString(PKG, "WorkflowGraph.Dialog.HopCausesLoop.Message"));
           mb.setText(BaseMessages.getString(PKG, "WorkflowGraph.Dialog.HopCausesLoop.Title"));
           int choice = mb.open();
@@ -1960,7 +1983,7 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
         workflowClipboardDelegate.fromClipboard(),
         lastMove == null ? new Point(50, 50) : lastMove);
   }
-  
+
   @GuiContextAction(
       id = "workflow-graph-workflow-clipboard-paste",
       parentId = HopGuiWorkflowContext.CONTEXT_ID,
@@ -2823,7 +2846,8 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
               propsUi.getNoteFont().getName(),
               propsUi.getNoteFont().getHeight(),
               propsUi.getZoomFactor(),
-              !propsUi.useDoubleClick());
+              !propsUi.useDoubleClick(),
+              mouseOverName);
 
       // correct the magnification with the overall zoom factor
       //
@@ -2882,7 +2906,7 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
     }
     CanvasFacade.setData(canvas, magnification, offset, workflowMeta);
   }
-  
+
   @Override
   public boolean hasChanged() {
     return workflowMeta.hasChanged();
@@ -2890,7 +2914,7 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
 
   @Override
   public void setChanged() {
-    workflowMeta.setChanged();    
+    workflowMeta.setChanged();
   }
 
   protected void newHop() {
@@ -3190,9 +3214,7 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
     return workflowMeta;
   }
 
-  /**
-   * Use method hasChanged()
-   */
+  /** Use method hasChanged() */
   @Deprecated
   public boolean hasContentChanged() {
     return workflowMeta.hasChanged();
@@ -3212,7 +3234,7 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
     }
 
     Shell shell = hopGui.getDisplay().getActiveShell();
-    if(shell == null){
+    if (shell == null) {
       shell = hopGui.getShell();
     }
     WorkflowDialog jd = new WorkflowDialog(shell, SWT.NONE, variables, workflowMeta);
@@ -3276,7 +3298,9 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
 
       FileObject fileObject = HopVfs.getFileObject(filename);
       if (fileObject.exists()) {
-        MessageBox box = new MessageBox(hopGui.getDisplay().getActiveShell(), SWT.YES | SWT.NO | SWT.ICON_QUESTION);
+        MessageBox box =
+            new MessageBox(
+                hopGui.getDisplay().getActiveShell(), SWT.YES | SWT.NO | SWT.ICON_QUESTION);
         box.setText("Overwrite?");
         box.setMessage("Are you sure you want to overwrite file '" + filename + "'?");
         int answer = box.open();
@@ -3666,7 +3690,8 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
 
           // Attach a listener to notify us that the pipeline has finished.
           //
-          workflow.addWorkflowFinishedListener(workflow -> HopGuiWorkflowGraph.this.workflowFinished());
+          workflow.addWorkflowFinishedListener(
+              workflow -> HopGuiWorkflowGraph.this.workflowFinished());
 
           // Show the execution results views
           //

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/dataorch/HopGuiAbstractGraph.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/dataorch/HopGuiAbstractGraph.java
@@ -17,6 +17,9 @@
 
 package org.apache.hop.ui.hopgui.perspective.dataorch;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 import org.apache.hop.core.gui.DPoint;
 import org.apache.hop.core.gui.Point;
 import org.apache.hop.core.gui.Rectangle;
@@ -39,10 +42,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.ToolTip;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
 
 /**
  * The beginnings of a common graph object, used by JobGraph and HopGuiPipelineGraph to share common
@@ -72,6 +71,8 @@ public abstract class HopGuiAbstractGraph extends DragViewZoomBase
   protected final String id;
 
   protected ToolTip toolTip;
+
+  protected String mouseOverName;
 
   /**
    * This is a state map which can be used by plugins to render extra states on top of pipelines and
@@ -374,5 +375,23 @@ public abstract class HopGuiAbstractGraph extends DragViewZoomBase
         HopGui.ID_MAIN_MENU_EDIT_DISTRIBUTE_VERTICAL,
         IHopFileType.CAPABILITY_DISTRIBUTE_VERTICAL,
         selectedTransform);
+  }
+
+  /**
+   * Gets mouseOverName
+   *
+   * @return value of mouseOverName
+   */
+  public String getMouseOverName() {
+    return mouseOverName;
+  }
+
+  /**
+   * Sets mouseOverName
+   *
+   * @param mouseOverName value of mouseOverName
+   */
+  public void setMouseOverName(String mouseOverName) {
+    this.mouseOverName = mouseOverName;
   }
 }

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/execution/PipelineExecutionViewer.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/execution/PipelineExecutionViewer.java
@@ -712,6 +712,7 @@ public class PipelineExecutionViewer extends BaseExecutionViewer
               propsUi.getZoomFactor(),
               Collections.emptyMap(),
               false,
+              null,
               Collections.emptyMap());
 
       // correct the magnification with the overall zoom factor

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/execution/WorkflowExecutionViewer.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/execution/WorkflowExecutionViewer.java
@@ -613,7 +613,8 @@ public class WorkflowExecutionViewer extends BaseExecutionViewer
               propsUi.getNoteFont().getName(),
               propsUi.getNoteFont().getHeight(),
               propsUi.getZoomFactor(),
-              false);
+              false,
+              null);
 
       // correct the magnification with the overall zoom factor
       //
@@ -682,7 +683,8 @@ public class WorkflowExecutionViewer extends BaseExecutionViewer
         viewPort = workflowPainter.getViewPort();
         graphPort = workflowPainter.getGraphPort();
       } catch (Exception e) {
-        new ErrorDialog(hopGui.getDisplay().getActiveShell(), "Error", "Error drawing workflow image", e);
+        new ErrorDialog(
+            hopGui.getDisplay().getActiveShell(), "Error", "Error drawing workflow image", e);
       }
     } finally {
       gc.dispose();


### PR DESCRIPTION
Implementation for issue #3335 

If you mouse over the name of a transform or action in the Hop GUI, it would be great if the name would be underlined.
This would mimic a hyperlink and indicate you can left click on it to edit.

