### PR TITLE
Fix for issues: #3169 : No more project reload after env change

### DIFF
--- a/plugins/misc/debug/src/main/java/org/apache/hop/debug/action/ActionDebugGuiPlugin.java
+++ b/plugins/misc/debug/src/main/java/org/apache/hop/debug/action/ActionDebugGuiPlugin.java
@@ -83,7 +83,7 @@ public class ActionDebugGuiPlugin {
         debugLevel = new ActionDebugLevel();
       }
 
-      ActionDebugLevelDialog dialog = new ActionDebugLevelDialog(hopGui.getDisplay().getActiveShell(), debugLevel);
+      ActionDebugLevelDialog dialog = new ActionDebugLevelDialog(hopGui.getActiveShell(), debugLevel);
       if (dialog.open()) {
         DebugLevelUtil.storeActionDebugLevel(
             debugGroupAttributesMap, action.toString(), debugLevel);
@@ -91,7 +91,7 @@ public class ActionDebugGuiPlugin {
 
       workflowMeta.setChanged();
     } catch (Exception e) {
-      new ErrorDialog(hopGui.getDisplay().getActiveShell(), "Error", "Error changing action log settings", e);
+      new ErrorDialog(hopGui.getActiveShell(), "Error", "Error changing action log settings", e);
     }
   }
 }

--- a/plugins/misc/debug/src/main/java/org/apache/hop/debug/transform/TransformDebugGuiPlugin.java
+++ b/plugins/misc/debug/src/main/java/org/apache/hop/debug/transform/TransformDebugGuiPlugin.java
@@ -88,7 +88,7 @@ public class TransformDebugGuiPlugin {
 
       IRowMeta inputRowMeta = pipelineMeta.getPrevTransformFields(variables, transformMeta);
       TransformDebugLevelDialog dialog =
-          new TransformDebugLevelDialog(hopGui.getDisplay().getActiveShell(), debugLevel, inputRowMeta);
+          new TransformDebugLevelDialog(hopGui.getActiveShell(), debugLevel, inputRowMeta);
       if (dialog.open()) {
         DebugLevelUtil.storeTransformDebugLevel(
             debugGroupAttributesMap, transformMeta.getName(), debugLevel);
@@ -96,7 +96,7 @@ public class TransformDebugGuiPlugin {
 
       pipelineMeta.setChanged();
     } catch (Exception e) {
-      new ErrorDialog(hopGui.getDisplay().getActiveShell(), "Error", "Error changing transform log settings", e);
+      new ErrorDialog(hopGui.getActiveShell(), "Error", "Error changing transform log settings", e);
     }
   }
 }

--- a/plugins/misc/projects/src/main/java/org/apache/hop/projects/gui/ProjectsGuiPlugin.java
+++ b/plugins/misc/projects/src/main/java/org/apache/hop/projects/gui/ProjectsGuiPlugin.java
@@ -135,7 +135,7 @@ public class ProjectsGuiPlugin {
     try {
       Project project = projectConfig.loadProject(hopGui.getVariables());
       ProjectDialog projectDialog =
-          new ProjectDialog(hopGui.getDisplay().getActiveShell(), project, projectConfig, hopGui.getVariables(), true);
+          new ProjectDialog(hopGui.getActiveShell(), project, projectConfig, hopGui.getVariables(), true);
       if (projectDialog.open() != null) {
         config.addProjectConfig(projectConfig);
 
@@ -169,7 +169,7 @@ public class ProjectsGuiPlugin {
       }
     } catch (Exception e) {
       new ErrorDialog(
-          hopGui.getDisplay().getActiveShell(),
+          hopGui.getActiveShell(),
           BaseMessages.getString(PKG, "ProjectGuiPlugin.EditProject.Error.Dialog.Header"),
           BaseMessages.getString(
               PKG, "ProjectGuiPlugin.EditProject.Error.Dialog.Message", projectName),
@@ -178,7 +178,7 @@ public class ProjectsGuiPlugin {
   }
 
   private boolean askAboutProjectRefresh(HopGui hopGui) {
-    MessageBox box = new MessageBox(hopGui.getDisplay().getActiveShell(), SWT.ICON_QUESTION | SWT.YES | SWT.NO);
+    MessageBox box = new MessageBox(hopGui.getShell(), SWT.ICON_QUESTION | SWT.YES | SWT.NO);
     box.setText(BaseMessages.getString(PKG, "ProjectGuiPlugin.ReloadProject.Dialog.Header"));
     box.setMessage(BaseMessages.getString(PKG, "ProjectGuiPlugin.ReloadProject.Dialog.Message"));
     int answer = box.open();
@@ -282,7 +282,7 @@ public class ProjectsGuiPlugin {
       }
     } catch (Exception e) {
       new ErrorDialog(
-          hopGui.getDisplay().getActiveShell(),
+          hopGui.getActiveShell(),
           BaseMessages.getString(PKG, "ProjectGuiPlugin.ChangeProject.Error.Dialog.Header"),
           BaseMessages.getString(
               PKG, "ProjectGuiPlugin.ChangeProject.Error.Dialog.Message", projectName),
@@ -319,7 +319,7 @@ public class ProjectsGuiPlugin {
       project.setParentProjectName(config.getStandardParentProject());
 
       ProjectDialog projectDialog =
-          new ProjectDialog(hopGui.getDisplay().getActiveShell(), project, projectConfig, variables, false);
+          new ProjectDialog(hopGui.getActiveShell(), project, projectConfig, variables, false);
       String projectName = projectDialog.open();
       if (projectName != null) {
         config.addProjectConfig(projectConfig);
@@ -334,7 +334,7 @@ public class ProjectsGuiPlugin {
           project.saveToFile();
         } else {
           // If projects exists load configuration
-          MessageBox box = new MessageBox(hopGui.getDisplay().getActiveShell(), SWT.ICON_QUESTION | SWT.OK);
+          MessageBox box = new MessageBox(hopGui.getActiveShell(), SWT.ICON_QUESTION | SWT.OK);
           box.setText(BaseMessages.getString(PKG, "ProjectGuiPlugin.ProjectExists.Dialog.Header"));
           box.setMessage(
               BaseMessages.getString(PKG, "ProjectGuiPlugin.ProjectExists.Dialog.Message"));
@@ -421,7 +421,7 @@ public class ProjectsGuiPlugin {
 
     } catch (Exception e) {
       new ErrorDialog(
-          hopGui.getDisplay().getActiveShell(),
+          hopGui.getActiveShell(),
           BaseMessages.getString(PKG, "ProjectGuiPlugin.AddProject.Error.Dialog.Header"),
           BaseMessages.getString(PKG, "ProjectGuiPlugin.AddProject.Error.Dialog.Message"),
           e);
@@ -553,7 +553,7 @@ public class ProjectsGuiPlugin {
 
     try {
       LifecycleEnvironmentDialog dialog =
-          new LifecycleEnvironmentDialog(hopGui.getDisplay().getActiveShell(), environment, hopGui.getVariables());
+          new LifecycleEnvironmentDialog(hopGui.getActiveShell(), environment, hopGui.getVariables());
       if (dialog.open() != null) {
         config.addEnvironment(environment);
         ProjectsConfigSingleton.saveConfig();
@@ -573,7 +573,7 @@ public class ProjectsGuiPlugin {
       }
     } catch (Exception e) {
       new ErrorDialog(
-          hopGui.getDisplay().getActiveShell(),
+          hopGui.getActiveShell(),
           BaseMessages.getString(PKG, "ProjectGuiPlugin.EditEnvironment.Error.Dialog.Header"),
           BaseMessages.getString(
               PKG, "ProjectGuiPlugin.EditEnvironment.Error.Dialog.Message", environmentName),
@@ -619,7 +619,7 @@ public class ProjectsGuiPlugin {
       }
     } catch (Exception e) {
       new ErrorDialog(
-          hopGui.getDisplay().getActiveShell(),
+          hopGui.getActiveShell(),
           BaseMessages.getString(PKG, "ProjectGuiPlugin.ChangeEnvironment.Error.Dialog.Header"),
           BaseMessages.getString(
               PKG, "ProjectGuiPlugin.ChangeEnvironment.Error.Dialog.Message", environmentName),
@@ -650,7 +650,7 @@ public class ProjectsGuiPlugin {
       LifecycleEnvironment environment =
           new LifecycleEnvironment(null, "", projectName, new ArrayList<>());
       LifecycleEnvironmentDialog dialog =
-          new LifecycleEnvironmentDialog(hopGui.getDisplay().getActiveShell(), environment, hopGui.getVariables());
+          new LifecycleEnvironmentDialog(hopGui.getActiveShell(), environment, hopGui.getVariables());
       String environmentName = dialog.open();
       if (environmentName != null) {
         config.addEnvironment(environment);
@@ -667,7 +667,7 @@ public class ProjectsGuiPlugin {
       }
     } catch (Exception e) {
       new ErrorDialog(
-          hopGui.getDisplay().getActiveShell(),
+          hopGui.getActiveShell(),
           BaseMessages.getString(PKG, "ProjectGuiPlugin.AddEnvironment.Error.Dialog.Header"),
           BaseMessages.getString(PKG, "ProjectGuiPlugin.AddEnvironment.Error.Dialog.Message"),
           e);

--- a/plugins/misc/projects/src/main/java/org/apache/hop/projects/xp/HopGuiStartProjectLoad.java
+++ b/plugins/misc/projects/src/main/java/org/apache/hop/projects/xp/HopGuiStartProjectLoad.java
@@ -129,7 +129,7 @@ public class HopGuiStartProjectLoad implements IExtensionPoint {
         logChannelInterface.logBasic("No last projects history found");
       }
     } catch (Exception e) {
-      new ErrorDialog(hopGui.getDisplay().getActiveShell(), "Error", "Error initializing the Projects system", e);
+      new ErrorDialog(hopGui.getActiveShell(), "Error", "Error initializing the Projects system", e);
     }
   }
 }

--- a/plugins/misc/testing/src/main/java/org/apache/hop/testing/xp/LocationMouseDoubleClickExtensionPoint.java
+++ b/plugins/misc/testing/src/main/java/org/apache/hop/testing/xp/LocationMouseDoubleClickExtensionPoint.java
@@ -100,7 +100,7 @@ public class LocationMouseDoubleClickExtensionPoint
             if (inputLocation != null) {
               PipelineUnitTestSetLocationDialog dialog =
                   new PipelineUnitTestSetLocationDialog(
-                      hopGui.getDisplay().getActiveShell(),
+                      hopGui.getActiveShell(),
                       variables,
                       hopGui.getMetadataProvider(),
                       inputLocation,
@@ -121,7 +121,7 @@ public class LocationMouseDoubleClickExtensionPoint
             if (goldenLocation != null) {
               PipelineUnitTestSetLocationDialog dialog =
                   new PipelineUnitTestSetLocationDialog(
-                      hopGui.getDisplay().getActiveShell(),
+                      hopGui.getActiveShell(),
                       variables,
                       hopGui.getMetadataProvider(),
                       goldenLocation,
@@ -162,7 +162,7 @@ public class LocationMouseDoubleClickExtensionPoint
         }
       }
     } catch (Exception e) {
-      new ErrorDialog(hopGui.getDisplay().getActiveShell(), "Error", "Error editing location", e);
+      new ErrorDialog(hopGui.getActiveShell(), "Error", "Error editing location", e);
     }
   }
 

--- a/ui/src/main/java/org/apache/hop/ui/core/metadata/MetadataManager.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/metadata/MetadataManager.java
@@ -96,12 +96,12 @@ public class MetadataManager<T extends IHopMetadata> {
       }
       return GuiContextUtil.getInstance()
           .handleActionSelection(
-              hopGui.getDisplay().getActiveShell(),
+              hopGui.getActiveShell(),
               "Select the " + hopMetadata.name() + " to edit",
               new GuiContextHandler("HopGuiMetadataContext", actions));
 
     } catch (Exception e) {
-      new ErrorDialog(hopGui.getDisplay().getActiveShell(), "Error", "Error editing metadata", e);
+      new ErrorDialog(hopGui.getActiveShell(), "Error", "Error editing metadata", e);
       return false;
     }
   }
@@ -140,7 +140,7 @@ public class MetadataManager<T extends IHopMetadata> {
               new GuiContextHandler("HopGuiMetadaContext", actions));
 
     } catch (Exception e) {
-      new ErrorDialog(hopGui.getDisplay().getActiveShell(), "Error", "Error deleting metadata", e);
+      new ErrorDialog(hopGui.getActiveShell(), "Error", "Error deleting metadata", e);
       return false;
     }
   }
@@ -203,7 +203,7 @@ public class MetadataManager<T extends IHopMetadata> {
       }
 
     } catch (Exception e) {
-      new ErrorDialog(hopGui.getDisplay().getActiveShell(), "Error", "Error editing metadata", e);
+      new ErrorDialog(hopGui.getActiveShell(), "Error", "Error editing metadata", e);
       return false;
     }
   }
@@ -240,7 +240,7 @@ public class MetadataManager<T extends IHopMetadata> {
         perspective.setActiveEditor(editor);
       }
     } catch (Exception e) {
-      new ErrorDialog(hopGui.getDisplay().getActiveShell(), "Error", "Error editing metadata", e);
+      new ErrorDialog(hopGui.getActiveShell(), "Error", "Error editing metadata", e);
     }
   }
 
@@ -462,7 +462,7 @@ public class MetadataManager<T extends IHopMetadata> {
 
       return element;
     } catch (Exception e) {
-      new ErrorDialog(hopGui.getDisplay().getActiveShell(), "Error", "Error creating new metadata element", e);
+      new ErrorDialog(hopGui.getActiveShell(), "Error", "Error creating new metadata element", e);
       return null;
     }
   }

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/HopGui.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/HopGui.java
@@ -1367,6 +1367,15 @@ public class HopGui
     }
   }
 
+  public Shell getActiveShell() {
+    Shell active = display.getActiveShell();
+    if (active!=null) {
+      return active;
+    } else {
+      return shell;
+    }
+  }
+
   /**
    * Gets metadataProvider
    *

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/delegates/HopGuiAuditDelegate.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/delegates/HopGuiAuditDelegate.java
@@ -120,7 +120,7 @@ public class HopGuiAuditDelegate {
               }
             }
           } catch (Exception e) {
-            new ErrorDialog(hopGui.getDisplay().getActiveShell(), "Error", "Error opening file '" + filename + "'", e);
+            new ErrorDialog(hopGui.getActiveShell(), "Error", "Error opening file '" + filename + "'", e);
           }
         }
 

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/delegates/HopGuiFileDelegate.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/delegates/HopGuiFileDelegate.java
@@ -87,7 +87,7 @@ public class HopGuiFileDelegate {
       }
       fileOpen(hopGui.getVariables().resolve(filename));
     } catch (Exception e) {
-      new ErrorDialog(hopGui.getDisplay().getActiveShell(), "Error", "Error opening file", e);
+      new ErrorDialog(hopGui.getActiveShell(), "Error", "Error opening file", e);
     }
   }
 
@@ -164,7 +164,7 @@ public class HopGuiFileDelegate {
 
       return filename;
     } catch (Exception e) {
-      new ErrorDialog(hopGui.getDisplay().getActiveShell(), "Error", "Error saving file", e);
+      new ErrorDialog(hopGui.getActiveShell(), "Error", "Error saving file", e);
       return null;
     }
   }
@@ -186,7 +186,7 @@ public class HopGuiFileDelegate {
         }
       }
     } catch (Exception e) {
-      new ErrorDialog(hopGui.getDisplay().getActiveShell(), "Error", "Error saving file", e);
+      new ErrorDialog(hopGui.getActiveShell(), "Error", "Error saving file", e);
     }
   }
 
@@ -199,7 +199,7 @@ public class HopGuiFileDelegate {
         perspective.remove(typeHandler);
       }
     } catch (Exception e) {
-      new ErrorDialog(hopGui.getDisplay().getActiveShell(), "Error", "Error saving/closing file", e);
+      new ErrorDialog(hopGui.getActiveShell(), "Error", "Error saving/closing file", e);
     }
     return false;
   }
@@ -288,7 +288,7 @@ public class HopGuiFileDelegate {
         hopGui.fileDelegate.fileOpen(filename);
       }
     } catch (Exception e) {
-      new ErrorDialog(hopGui.getDisplay().getActiveShell(), "Error", "Error getting list of recently opened files", e);
+      new ErrorDialog(hopGui.getActiveShell(), "Error", "Error getting list of recently opened files", e);
     }
   }
 
@@ -345,7 +345,7 @@ public class HopGuiFileDelegate {
           FileObject file = HopVfs.getFileObject(realFilename);
           if (file.exists()) {
             MessageBox box =
-                new MessageBox(hopGui.getDisplay().getActiveShell(), SWT.YES | SWT.NO | SWT.ICON_QUESTION);
+                new MessageBox(hopGui.getActiveShell(), SWT.YES | SWT.NO | SWT.ICON_QUESTION);
             box.setText("File exists");
             box.setMessage("This file already exists. Do you want to overwrite it?");
             int answer = box.open();
@@ -366,7 +366,7 @@ public class HopGuiFileDelegate {
       }
 
     } catch (Exception e) {
-      new ErrorDialog(hopGui.getDisplay().getActiveShell(), "Error", "Error exporting to SVG", e);
+      new ErrorDialog(hopGui.getActiveShell(), "Error", "Error exporting to SVG", e);
     }
   }
 }

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/HopGuiPipelineGraph.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/HopGuiPipelineGraph.java
@@ -1214,7 +1214,7 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
 
             PreviewRowsDialog previewRowsDialog =
                 new PreviewRowsDialog(
-                    hopGui.getDisplay().getActiveShell(),
+                    hopGui.getActiveShell(),
                     variables,
                     SWT.NONE,
                     dataTransformMeta.getName(),
@@ -1224,7 +1224,7 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
             previewRowsDialog.open();
           } catch (Exception ex) {
             new ErrorDialog(
-                hopGui.getDisplay().getActiveShell(), "Error", "Error showing preview dialog", ex);
+                hopGui.getActiveShell(), "Error", "Error showing preview dialog", ex);
           }
         }
       }
@@ -3378,7 +3378,7 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
 
       } catch (Exception e) {
         new ErrorDialog(
-            hopGui.getDisplay().getActiveShell(), "Error", "Error drawing pipeline image", e);
+            hopGui.getActiveShell(), "Error", "Error drawing pipeline image", e);
       }
     } finally {
       gc.dispose();
@@ -3693,7 +3693,7 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
       return false;
     }
 
-    Shell shell = hopGui.getDisplay().getActiveShell();
+    Shell shell = hopGui.getActiveShell();
     if (shell == null) {
       shell = hopGui.getShell();
     }
@@ -3827,7 +3827,7 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
             String filename =
                 BaseDialog.presentFileDialog(
                     true,
-                    hopGui.getDisplay().getActiveShell(),
+                    hopGui.getActiveShell(),
                     fileType.getFilterExtensions(),
                     fileType.getFilterNames(),
                     true);

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/delegates/HopGuiPipelineClipboardDelegate.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/delegates/HopGuiPipelineClipboardDelegate.java
@@ -63,7 +63,7 @@ public class HopGuiPipelineClipboardDelegate {
       GuiResource.getInstance().toClipboard(clipText);
     } catch (Throwable e) {
       new ErrorDialog(
-          hopGui.getDisplay().getActiveShell(),
+          hopGui.getActiveShell(),
           BaseMessages.getString(PKG, "HopGui.Dialog.ExceptionCopyToClipboard.Title"),
           BaseMessages.getString(PKG, "HopGui.Dialog.ExceptionCopyToClipboard.Message"),
           e);
@@ -75,7 +75,7 @@ public class HopGuiPipelineClipboardDelegate {
       return GuiResource.getInstance().fromClipboard();
     } catch (Throwable e) {
       new ErrorDialog(
-          hopGui.getDisplay().getActiveShell(),
+          hopGui.getActiveShell(),
           BaseMessages.getString(PKG, "HopGui.Dialog.ExceptionPasteFromClipboard.Title"),
           BaseMessages.getString(PKG, "HopGui.Dialog.ExceptionPasteFromClipboard.Message"),
           e);
@@ -273,7 +273,7 @@ public class HopGuiPipelineClipboardDelegate {
       // "Error pasting transforms...",
       // "I was unable to paste transforms to this pipeline"
       new ErrorDialog(
-          hopGui.getDisplay().getActiveShell(),
+          hopGui.getActiveShell(),
           BaseMessages.getString(PKG, "HopGui.Dialog.UnablePasteTransforms.Title"),
           BaseMessages.getString(PKG, "HopGui.Dialog.UnablePasteTransforms.Message"),
           e);
@@ -338,7 +338,7 @@ public class HopGuiPipelineClipboardDelegate {
 
       toClipboard(xml.toString());
     } catch (Exception ex) {
-      new ErrorDialog(hopGui.getDisplay().getActiveShell(), "Error", "Error encoding to XML", ex);
+      new ErrorDialog(hopGui.getActiveShell(), "Error", "Error encoding to XML", ex);
     }
   }
 

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/delegates/HopGuiPipelineHopDelegate.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/delegates/HopGuiPipelineHopDelegate.java
@@ -55,7 +55,7 @@ public class HopGuiPipelineHopDelegate {
   public void newHop(PipelineMeta pipelineMeta, TransformMeta fr, TransformMeta to) {
     PipelineHopMeta hi = new PipelineHopMeta(fr, to);
 
-    PipelineHopDialog hd = new PipelineHopDialog(hopGui.getDisplay().getActiveShell(), SWT.NONE, hi, pipelineMeta);
+    PipelineHopDialog hd = new PipelineHopDialog(hopGui.getActiveShell(), SWT.NONE, hi, pipelineMeta);
     if (hd.open() != null) {
       newHop(pipelineMeta, hi);
     }
@@ -90,7 +90,7 @@ public class HopGuiPipelineHopDelegate {
   public boolean checkIfHopAlreadyExists(PipelineMeta pipelineMeta, PipelineHopMeta newHop) {
     boolean ok = true;
     if (pipelineMeta.findPipelineHop(newHop.getFromTransform(), newHop.getToTransform()) != null) {
-      MessageBox mb = new MessageBox(hopGui.getDisplay().getActiveShell(), SWT.OK | SWT.ICON_ERROR);
+      MessageBox mb = new MessageBox(hopGui.getActiveShell(), SWT.OK | SWT.ICON_ERROR);
       mb.setMessage(
           BaseMessages.getString(
               PKG, "HopGui.Dialog.HopExists.Message")); // "This hop already exists!"
@@ -111,7 +111,7 @@ public class HopGuiPipelineHopDelegate {
     boolean ok = true;
 
     if (pipelineMeta.hasLoop(newHop.getToTransform())) {
-      MessageBox mb = new MessageBox(hopGui.getDisplay().getActiveShell(), SWT.OK | SWT.ICON_ERROR);
+      MessageBox mb = new MessageBox(hopGui.getActiveShell(), SWT.OK | SWT.ICON_ERROR);
       mb.setMessage(BaseMessages.getString(PKG, "PipelineGraph.Dialog.HopCausesLoop.Message"));
       mb.setText(BaseMessages.getString(PKG, "PipelineGraph.Dialog.HopCausesLoop.Title"));
       mb.open();
@@ -129,7 +129,7 @@ public class HopGuiPipelineHopDelegate {
       } catch (HopRowException re) {
         // Show warning about mixing rows with conflicting layouts...
         new ErrorDialog(
-            hopGui.getDisplay().getActiveShell(),
+            hopGui.getActiveShell(),
             BaseMessages.getString(PKG, "PipelineGraph.Dialog.HopCausesRowMixing.Title"),
             BaseMessages.getString(PKG, "PipelineGraph.Dialog.HopCausesRowMixing.Message"),
             re);
@@ -167,7 +167,7 @@ public class HopGuiPipelineHopDelegate {
           && !transformMeta.getTransform().excludeFromCopyDistributeVerification()) {
         MessageDialogWithToggle md =
             new MessageDialogWithToggle(
-                hopGui.getDisplay().getActiveShell(),
+                hopGui.getActiveShell(),
                 BaseMessages.getString(PKG, "System.Warning"),
                 BaseMessages.getString(
                     PKG,
@@ -275,7 +275,7 @@ public class HopGuiPipelineHopDelegate {
     PipelineHopMeta before = (PipelineHopMeta) pipelineHopMeta.clone();
 
     PipelineHopDialog hd =
-        new PipelineHopDialog(hopGui.getDisplay().getActiveShell(), SWT.NONE, pipelineHopMeta, pipelineMeta);
+        new PipelineHopDialog(hopGui.getActiveShell(), SWT.NONE, pipelineHopMeta, pipelineMeta);
     if (hd.open() != null) {
       // Backup situation for redo/undo:
       PipelineHopMeta after = (PipelineHopMeta) pipelineHopMeta.clone();

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/delegates/HopGuiPipelineTransformDelegate.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/delegates/HopGuiPipelineTransformDelegate.java
@@ -144,7 +144,7 @@ public class HopGuiPipelineTransformDelegate {
       String errorMsg =
           BaseMessages.getString(
               PKG, "HopGui.Dialog.ErrorCreatingTransformDialog.Message", dialogClassName);
-      new ErrorDialog(hopGui.getDisplay().getActiveShell(), errorTitle, errorMsg, e);
+      new ErrorDialog(hopGui.getActiveShell(), errorTitle, errorMsg, e);
       throw new HopException(e);
     }
   }
@@ -212,7 +212,7 @@ public class HopGuiPipelineTransformDelegate {
         }
         if (nr > 2) {
           transformName = newname;
-          MessageBox mb = new MessageBox(hopGui.getDisplay().getActiveShell(), SWT.OK | SWT.ICON_INFORMATION);
+          MessageBox mb = new MessageBox(hopGui.getActiveShell(), SWT.OK | SWT.ICON_INFORMATION);
           mb.setMessage(
               BaseMessages.getString(
                   PKG, "HopGui.Dialog.TransformnameExists.Message", transformName));
@@ -249,7 +249,7 @@ public class HopGuiPipelineTransformDelegate {
         return null;
       }
       new ErrorDialog(
-          hopGui.getDisplay().getActiveShell(),
+          hopGui.getActiveShell(),
           BaseMessages.getString(PKG, "HopGui.Dialog.UnableOpenDialog.Title"),
           BaseMessages.getString(PKG, "HopGui.Dialog.UnableOpenDialog.Message"),
           e);
@@ -316,7 +316,7 @@ public class HopGuiPipelineTransformDelegate {
             }
             if (nr > 2) {
               transformMeta.setName(newName);
-              MessageBox mb = new MessageBox(hopGui.getDisplay().getActiveShell(), SWT.OK | SWT.ICON_INFORMATION);
+              MessageBox mb = new MessageBox(hopGui.getActiveShell(), SWT.OK | SWT.ICON_INFORMATION);
               // "This transformName already exists.  HopGui changed the transformName to
               // ["+newName+"]"
               mb.setMessage(
@@ -370,7 +370,7 @@ public class HopGuiPipelineTransformDelegate {
             sbd.open();
           } catch (Exception ex) {
             new ErrorDialog(
-                hopGui.getDisplay().getActiveShell(),
+                hopGui.getActiveShell(),
                 BaseMessages.getString(PKG, "HopGui.Dialog.ErrorShowingHelpText.Title"),
                 BaseMessages.getString(PKG, "HopGui.Dialog.ErrorShowingHelpText.Message"),
                 ex);
@@ -385,7 +385,7 @@ public class HopGuiPipelineTransformDelegate {
           }
         } else {
           new ErrorDialog(
-              hopGui.getDisplay().getActiveShell(),
+              hopGui.getActiveShell(),
               // "Error creating transform"
               // "I was unable to create a new transform"
               BaseMessages.getString(PKG, "HopGui.Dialog.UnableCreateNewTransform.Title"),
@@ -396,7 +396,7 @@ public class HopGuiPipelineTransformDelegate {
       } catch (Throwable e) {
         if (!hopGui.getShell().isDisposed()) {
           new ErrorDialog(
-              hopGui.getDisplay().getActiveShell(),
+              hopGui.getActiveShell(),
               // "Error creating transform"
               BaseMessages.getString(PKG, "HopGui.Dialog.ErrorCreatingTransform.Title"),
               BaseMessages.getString(PKG, "HopGui.Dialog.UnableCreateNewTransform.Message"),
@@ -503,7 +503,7 @@ public class HopGuiPipelineTransformDelegate {
       schemaNames = hopGui.partitionManager.getNamesArray();
     } catch (HopException e) {
       new ErrorDialog(
-          hopGui.getDisplay().getActiveShell(),
+          hopGui.getActiveShell(),
           BaseMessages.getString(PKG, "HopGui.ErrorDialog.Title"),
           BaseMessages.getString(
               PKG, "HopGui.ErrorDialog.ErrorFetchingFromRepo.PartitioningSchemas"),
@@ -566,7 +566,7 @@ public class HopGuiPipelineTransformDelegate {
       }
     } catch (Exception e) {
       new ErrorDialog(
-          hopGui.getDisplay().getActiveShell(),
+          hopGui.getActiveShell(),
           "Error",
           "There was an unexpected error while editing the partitioning method specifics:",
           e);
@@ -576,7 +576,7 @@ public class HopGuiPipelineTransformDelegate {
   public boolean isDefinedSchemaExist(String[] schemaNames) {
     // Before we start, check if there are any partition schemas defined...
     if ((schemaNames == null) || (schemaNames.length == 0)) {
-      MessageBox box = new MessageBox(hopGui.getDisplay().getActiveShell(), SWT.ICON_ERROR | SWT.OK);
+      MessageBox box = new MessageBox(hopGui.getActiveShell(), SWT.ICON_ERROR | SWT.OK);
       box.setText("Create a partition schema");
       box.setMessage(
           "You first need to create one or more partition schemas before you can select one!");
@@ -628,7 +628,7 @@ public class HopGuiPipelineTransformDelegate {
       // now edit this transformErrorMeta object:
       TransformErrorMetaDialog dialog =
           new TransformErrorMetaDialog(
-              hopGui.getDisplay().getActiveShell(),
+              hopGui.getActiveShell(),
               pipelineGraph.getVariables(),
               transformErrorMeta,
               pipelineMeta,

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/HopGuiWorkflowGraph.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/HopGuiWorkflowGraph.java
@@ -1351,7 +1351,7 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
         if (workflowMeta.hasLoop(hopCandidate.getToAction())) {
           MessageBox mb =
               new MessageBox(
-                  hopGui.getDisplay().getActiveShell(), SWT.OK | SWT.CANCEL | SWT.ICON_WARNING);
+                  hopGui.getActiveShell(), SWT.OK | SWT.CANCEL | SWT.ICON_WARNING);
           mb.setMessage(BaseMessages.getString(PKG, "WorkflowGraph.Dialog.HopCausesLoop.Message"));
           mb.setText(BaseMessages.getString(PKG, "WorkflowGraph.Dialog.HopCausesLoop.Title"));
           int choice = mb.open();
@@ -1795,7 +1795,7 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
                         ServerPushSessionFacade.stop();
                       } catch (Exception e) {
                         new ErrorDialog(
-                            hopGui.getDisplay().getActiveShell(),
+                            hopGui.getActiveShell(),
                             "Execute workflow",
                             "There was an error during workflow execution",
                             e);
@@ -2813,7 +2813,7 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
 
     } catch (Exception ex) {
       new ErrorDialog(
-          hopGui.getDisplay().getActiveShell(),
+          hopGui.getActiveShell(),
           BaseMessages.getString(PKG, "HopGuiWorkflowGraph.ErrorDialog.WorkflowDrawing.Header"),
           BaseMessages.getString(PKG, "HopGuiWorkflowGraph.ErrorDialog.WorkflowDrawing.Message"),
           ex);
@@ -3233,7 +3233,7 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
       return false;
     }
 
-    Shell shell = hopGui.getDisplay().getActiveShell();
+    Shell shell = hopGui.getActiveShell();
     if (shell == null) {
       shell = hopGui.getShell();
     }
@@ -3300,7 +3300,7 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
       if (fileObject.exists()) {
         MessageBox box =
             new MessageBox(
-                hopGui.getDisplay().getActiveShell(), SWT.YES | SWT.NO | SWT.ICON_QUESTION);
+                hopGui.getActiveShell(), SWT.YES | SWT.NO | SWT.ICON_QUESTION);
         box.setText("Overwrite?");
         box.setMessage("Are you sure you want to overwrite file '" + filename + "'?");
         int answer = box.open();

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/delegates/HopGuiWorkflowActionDelegate.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/delegates/HopGuiWorkflowActionDelegate.java
@@ -95,7 +95,7 @@ public class HopGuiWorkflowActionDelegate {
         if (action.isStart()) {
           // Check if start is already on the canvas...
           if (workflowMeta.findStart() != null) {
-            HopGuiWorkflowGraph.showOnlyStartOnceMessage(hopGui.getDisplay().getActiveShell());
+            HopGuiWorkflowGraph.showOnlyStartOnceMessage(hopGui.getActiveShell());
             return null;
           }
         }
@@ -144,7 +144,7 @@ public class HopGuiWorkflowActionDelegate {
       }
     } catch (Throwable e) {
       new ErrorDialog(
-          hopGui.getDisplay().getActiveShell(),
+          hopGui.getActiveShell(),
           BaseMessages.getString(
               PKG, "HopGui.ErrorDialog.UnexpectedErrorCreatingNewJobGraphEntry.Title"),
           BaseMessages.getString(
@@ -205,7 +205,7 @@ public class HopGuiWorkflowActionDelegate {
 
     if (MissingAction.ID.equals(action.getPluginId())) {
       return new MissingActionDialog(
-          hopGui.getDisplay().getActiveShell(), action, workflowMeta, workflowGraph.getVariables());
+          hopGui.getActiveShell(), action, workflowMeta, workflowGraph.getVariables());
     }
 
     PluginRegistry registry = PluginRegistry.getInstance();
@@ -257,7 +257,7 @@ public class HopGuiWorkflowActionDelegate {
           BaseMessages.getString(
               PKG, "HopGui.Dialog.ErrorCreatingActionDialog.Message", dialogClassName);
       hopGui.getLog().logError(errorMsg);
-      new ErrorDialog(hopGui.getDisplay().getActiveShell(), errorTitle, errorMsg, t);
+      new ErrorDialog(hopGui.getActiveShell(), errorTitle, errorMsg, t);
       return null;
     }
   }
@@ -297,7 +297,7 @@ public class HopGuiWorkflowActionDelegate {
         }
         workflowGraph.updateGui();
       } else {
-        MessageBox mb = new MessageBox(hopGui.getDisplay().getActiveShell(), SWT.OK | SWT.ICON_INFORMATION);
+        MessageBox mb = new MessageBox(hopGui.getActiveShell(), SWT.OK | SWT.ICON_INFORMATION);
         mb.setMessage(BaseMessages.getString(PKG, "HopGui.Dialog.ActionCanNotBeChanged.Message"));
         mb.setText(BaseMessages.getString(PKG, "HopGui.Dialog.ActionCanNotBeChanged.Title"));
         mb.open();
@@ -306,7 +306,7 @@ public class HopGuiWorkflowActionDelegate {
     } catch (Exception e) {
       if (!hopGui.getShell().isDisposed()) {
         new ErrorDialog(
-            hopGui.getDisplay().getActiveShell(),
+            hopGui.getActiveShell(),
             BaseMessages.getString(PKG, "HopGui.ErrorDialog.ErrorEditingAction.Title"),
             BaseMessages.getString(PKG, "HopGui.ErrorDialog.ErrorEditingAction.Message"),
             e);
@@ -374,7 +374,7 @@ public class HopGuiWorkflowActionDelegate {
     }
 
     if (action.isStart()) {
-      MessageBox mb = new MessageBox(hopGui.getDisplay().getActiveShell(), SWT.OK | SWT.ICON_INFORMATION);
+      MessageBox mb = new MessageBox(hopGui.getActiveShell(), SWT.OK | SWT.ICON_INFORMATION);
       mb.setMessage(BaseMessages.getString(PKG, "HopGui.Dialog.OnlyUseStartOnce.Message"));
       mb.setText(BaseMessages.getString(PKG, "HopGui.Dialog.OnlyUseStartOnce.Title"));
       mb.open();

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/delegates/HopGuiWorkflowClipboardDelegate.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/delegates/HopGuiWorkflowClipboardDelegate.java
@@ -66,7 +66,7 @@ public class HopGuiWorkflowClipboardDelegate {
       GuiResource.getInstance().toClipboard(clipText);
     } catch (Throwable e) {
       new ErrorDialog(
-          hopGui.getDisplay().getActiveShell(),
+          hopGui.getActiveShell(),
           BaseMessages.getString(PKG, "HopGui.Dialog.ExceptionCopyToClipboard.Title"),
           BaseMessages.getString(PKG, "HopGui.Dialog.ExceptionCopyToClipboard.Message"),
           e);
@@ -78,7 +78,7 @@ public class HopGuiWorkflowClipboardDelegate {
       return GuiResource.getInstance().fromClipboard();
     } catch (Throwable e) {
       new ErrorDialog(
-          hopGui.getDisplay().getActiveShell(),
+          hopGui.getActiveShell(),
           BaseMessages.getString(PKG, "HopGui.Dialog.ExceptionPasteFromClipboard.Title"),
           BaseMessages.getString(PKG, "HopGui.Dialog.ExceptionPasteFromClipboard.Message"),
           e);
@@ -276,7 +276,7 @@ public class HopGuiWorkflowClipboardDelegate {
       // "Error pasting transforms...",
       // "I was unable to paste transforms to this pipeline"
       new ErrorDialog(
-          hopGui.getDisplay().getActiveShell(),
+          hopGui.getActiveShell(),
           BaseMessages.getString(PKG, "HopGui.Dialog.UnablePasteEntries.Title"),
           BaseMessages.getString(PKG, "HopGui.Dialog.UnablePasteEntries.Message"),
           e);
@@ -341,7 +341,7 @@ public class HopGuiWorkflowClipboardDelegate {
 
       toClipboard(xml.toString());
     } catch (Exception ex) {
-      new ErrorDialog(hopGui.getDisplay().getActiveShell(), "Error", "Error encoding to XML", ex);
+      new ErrorDialog(hopGui.getActiveShell(), "Error", "Error encoding to XML", ex);
     }
   }
 

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/execution/PipelineExecutionViewer.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/execution/PipelineExecutionViewer.java
@@ -360,7 +360,7 @@ public class PipelineExecutionViewer extends BaseExecutionViewer
           }
         } catch (Exception e) {
           new ErrorDialog(
-              hopGui.getDisplay().getActiveShell(),
+              hopGui.getActiveShell(),
               "Error",
               "Hop was unable to invoke @GuiTab method "
                   + tabItem.getMethod().getName()
@@ -734,7 +734,7 @@ public class PipelineExecutionViewer extends BaseExecutionViewer
         viewPort = pipelinePainter.getViewPort();
         graphPort = pipelinePainter.getGraphPort();
       } catch (Exception e) {
-        new ErrorDialog(hopGui.getDisplay().getActiveShell(), "Error", "Error drawing pipeline image", e);
+        new ErrorDialog(hopGui.getActiveShell(), "Error", "Error drawing pipeline image", e);
       }
     } finally {
       gc.dispose();

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/execution/WorkflowExecutionViewer.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/execution/WorkflowExecutionViewer.java
@@ -503,7 +503,7 @@ public class WorkflowExecutionViewer extends BaseExecutionViewer
           }
         } catch (Exception e) {
           new ErrorDialog(
-              hopGui.getDisplay().getActiveShell(),
+              hopGui.getActiveShell(),
               "Error",
               "Hop was unable to invoke @GuiTab method "
                   + tabItem.getMethod().getName()
@@ -684,7 +684,7 @@ public class WorkflowExecutionViewer extends BaseExecutionViewer
         graphPort = workflowPainter.getGraphPort();
       } catch (Exception e) {
         new ErrorDialog(
-            hopGui.getDisplay().getActiveShell(), "Error", "Error drawing workflow image", e);
+            hopGui.getActiveShell(), "Error", "Error drawing workflow image", e);
       }
     } finally {
       gc.dispose();

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/search/HopSearchPerspective.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/search/HopSearchPerspective.java
@@ -369,7 +369,7 @@ public class HopSearchPerspective implements IHopPerspective {
     try {
       searchable.getSearchCallback().callback(searchable, searchResult);
     } catch (Exception e) {
-      new ErrorDialog(hopGui.getDisplay().getActiveShell(), "Error", "Error opening " + searchable.getName(), e);
+      new ErrorDialog(hopGui.getActiveShell(), "Error", "Error opening " + searchable.getName(), e);
     }
   }
 
@@ -431,7 +431,7 @@ public class HopSearchPerspective implements IHopPerspective {
       wResults.setRowNums();
       wResults.optWidth(true);
     } catch (Exception e) {
-      new ErrorDialog(hopGui.getDisplay().getActiveShell(), "Error", "Error searching", e);
+      new ErrorDialog(hopGui.getActiveShell(), "Error", "Error searching", e);
     } finally {
       refreshLastUsedLocation();
       refreshLastUsedSearchStrings();

--- a/ui/src/main/java/org/apache/hop/ui/www/service/WebServiceEditor.java
+++ b/ui/src/main/java/org/apache/hop/ui/www/service/WebServiceEditor.java
@@ -465,7 +465,7 @@ public class WebServiceEditor extends MetadataEditor<WebService> {
 
       EnterSelectionDialog selectTransformDialog =
           new EnterSelectionDialog(
-              hopGui.getDisplay().getActiveShell(),
+              hopGui.getActiveShell(),
               pipelineMeta.getTransformNames(),
               "Select output transform",
               "Select the transform output for the web service");
@@ -476,7 +476,7 @@ public class WebServiceEditor extends MetadataEditor<WebService> {
       IRowMeta rowMeta = pipelineMeta.getTransformFields(variables, transformName);
       EnterSelectionDialog selectFieldDialog =
           new EnterSelectionDialog(
-              hopGui.getDisplay().getActiveShell(),
+              hopGui.getActiveShell(),
               rowMeta.getFieldNames(),
               "Select the output field",
               "Select the field to use as output for this web service");
@@ -487,7 +487,7 @@ public class WebServiceEditor extends MetadataEditor<WebService> {
       wTransform.setText(transformName);
       wField.setText(fieldName);
     } catch (Exception e) {
-      new ErrorDialog(hopGui.getDisplay().getActiveShell(), "Error", "Error selecting output field", e);
+      new ErrorDialog(hopGui.getActiveShell(), "Error", "Error selecting output field", e);
     }
   }
 }


### PR DESCRIPTION
#3169 : No more project reload after env change, did some code hardening around the idea of using an "active shell" in the Hop GUI to follow pop-up shells more closely.  In case this value isn't know we need to give back the default Hop GUI shell as reply.  More refinements would then be possible through the new `HopGui.getActiveShell()` method.