### PR TITLE
Fixed flaky test

### DIFF
--- a/core/src/test/java/org/apache/hop/core/row/value/ValueMetaAvroRecordTest.java
+++ b/core/src/test/java/org/apache/hop/core/row/value/ValueMetaAvroRecordTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.hop.core.row.value;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -27,7 +29,6 @@ import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -166,21 +167,22 @@ public class ValueMetaAvroRecordTest {
 
     JSONObject jValue = new JSONObject();
     valueMeta.storeMetaInJson(jValue);
-
-    String valueJson = jValue.toJSONString();
-    assertEquals(
-        "{\"schema\":{\"name\":\"all_values\",\"namespace\":\"hop.apache.org\",\"doc\":" +
-                "\"No documentation URL for now\",\"type\":\"record\",\"fields\":[{\"name\":\"id\",\"type\":" +
-                "[\"long\",\"null\"]},{\"name\":\"sysdate\",\"type\":[\"string\",\"null\"]}," +
-                "{\"name\":\"num\",\"type\":[\"double\",\"null\"]},{\"name\":\"int\",\"type\":" +
-                "[\"long\",\"null\"]},{\"name\":\"str\",\"type\":[\"string\",\"null\"]}," +
-                "{\"name\":\"uuid\",\"type\":[\"string\",\"null\"]}]},\"precision\":-1,\"name\":" +
-                "\"test\",\"length\":-1,\"conversionMask\":null,\"type\":20}",
-        valueJson);
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode valueNode = mapper.readTree(jValue.toJSONString());
+    JsonNode expectJsonNode = mapper.readTree(
+            "{\"schema\":{\"name\":\"all_values\",\"namespace\":\"hop.apache.org\",\"doc\":" +
+            "\"No documentation URL for now\",\"type\":\"record\",\"fields\":[{\"name\":\"id\",\"type\":" +
+            "[\"long\",\"null\"]},{\"name\":\"sysdate\",\"type\":[\"string\",\"null\"]}," +
+            "{\"name\":\"num\",\"type\":[\"double\",\"null\"]},{\"name\":\"int\",\"type\":" +
+            "[\"long\",\"null\"]},{\"name\":\"str\",\"type\":[\"string\",\"null\"]}," +
+            "{\"name\":\"uuid\",\"type\":[\"string\",\"null\"]}]},\"precision\":-1,\"name\":" +
+            "\"test\",\"length\":-1,\"conversionMask\":null,\"type\":20}"
+    );
+    assertEquals(valueNode,expectJsonNode);
 
     // Read it back...
     //
-    JSONObject jLoaded = (JSONObject) new JSONParser().parse(valueJson);
+    JSONObject jLoaded = (JSONObject) new JSONParser().parse(valueNode.toString());
 
     ValueMetaAvroRecord loaded = (ValueMetaAvroRecord) ValueMetaFactory.loadValueMetaFromJson(jLoaded);
 


### PR DESCRIPTION
### Issue
The root issue is that `JSONObject.toJSONString()` use `HashMap` to convert json data into strings. In this case, `toJSONString()` was called on `jvalue` and then the output string is compared to a fixed string.  Because `HashMap` does not guarantee the order of elements returned, the two strings could have the same content but in different order, thus the flakiness. 

## Fix
This flaky test has been fixed through leveraging the Jackson library, which incorporates the JsonNode and ObjectMapper classes. These components are employed for parsing two JSON strings into tree models, which are subsequently compared node by node when assertion is called. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
