### PR TITLE
fix #3294

### DIFF
--- a/plugins/transforms/getfilenames/src/main/java/org/apache/hop/pipeline/transforms/getfilenames/FileItem.java
+++ b/plugins/transforms/getfilenames/src/main/java/org/apache/hop/pipeline/transforms/getfilenames/FileItem.java
@@ -18,12 +18,52 @@
 package org.apache.hop.pipeline.transforms.getfilenames;
 
 import java.util.Objects;
-import org.apache.hop.core.util.Utils;
+import org.apache.hop.i18n.BaseMessages;
 import org.apache.hop.metadata.api.HopMetadataProperty;
+import org.apache.hop.metadata.api.IEnumHasCode;
 
 public class FileItem {
 
-  private static final String NO = "N";
+  private static final Class<?> PKG = FileItem.class;
+
+  public enum YesNoType implements IEnumHasCode {
+    YES("Y", BaseMessages.getString(PKG, "System.Combo.Yes")),
+    NO("N", BaseMessages.getString(PKG, "System.Combo.No"));
+
+    private String code;
+    private String description;
+
+    YesNoType(String code, String description) {
+      this.code = code;
+      this.description = description;
+    }
+
+
+    public String getCode() {
+      return code;
+    }
+
+    public static final String[] getDescriptions() {
+      String[] items = new String[values().length];
+      for (int i = 0; i < items.length; i++) {
+        items[i] = values()[i].description;
+      }
+      return items;
+    }
+
+    public static YesNoType getType(String value) {
+      for (YesNoType type : values()) {
+        if (value.equalsIgnoreCase(type.description)) {
+          return type;
+        }
+      }
+      return null;
+    }
+    
+    public String getDescription() {
+      return description;
+    }
+  }
 
   /** Array of filenames */
   @HopMetadataProperty(
@@ -46,14 +86,16 @@ public class FileItem {
   /** Array of boolean values as string, indicating if a file is required. */
   @HopMetadataProperty(
       key = "file_required",
+      storeWithCode = true,
       injectionKeyDescription = "GetFileNames.Injection.FileRequired.Label")
-  private String fileRequired;
+  private YesNoType fileRequired;
 
   /** Array of boolean values as string, indicating if we need to fetch sub folders. */
   @HopMetadataProperty(
       key = "include_subfolders",
+      storeWithCode = true,
       injectionKeyDescription = "GetFileNames.Injection.IncludeSubDirs.Label")
-  private String includeSubFolders;
+  private YesNoType includeSubFolders;
 
   public FileItem() {
     setDefault();
@@ -63,18 +105,18 @@ public class FileItem {
       String fileName,
       String fileMask,
       String excludeFileMask,
-      String fileRequired,
-      String includeSubFolders) {
+      YesNoType fileRequired,
+      YesNoType includeSubFolders) {
     this.fileName = fileName;
     this.fileMask = fileMask;
     this.excludeFileMask = excludeFileMask;
-    this.fileRequired = Utils.isEmpty(fileRequired) ? NO : fileRequired;
-    this.includeSubFolders = Utils.isEmpty(includeSubFolders) ? NO : includeSubFolders;
+    this.includeSubFolders = includeSubFolders;
+    this.fileRequired = fileRequired;
   }
 
   protected void setDefault() {
-    this.fileRequired = NO;
-    this.includeSubFolders = NO;
+    this.fileRequired = YesNoType.NO;
+    this.includeSubFolders = YesNoType.NO;
   }
 
   public String getFileName() {
@@ -101,19 +143,19 @@ public class FileItem {
     this.excludeFileMask = excludeFileMask;
   }
 
-  public String getFileRequired() {
+  public YesNoType getFileRequired() {
     return fileRequired;
   }
 
-  public void setFileRequired(String fileRequired) {
+  public void setFileRequired(YesNoType fileRequired) {
     this.fileRequired = fileRequired;
   }
 
-  public String getIncludeSubFolders() {
+  public YesNoType getIncludeSubFolders() {
     return includeSubFolders;
   }
 
-  public void setIncludeSubFolders(String includeSubFolders) {
+  public void setIncludeSubFolders(YesNoType includeSubFolders) {
     this.includeSubFolders = includeSubFolders;
   }
 

--- a/plugins/transforms/getfilenames/src/main/java/org/apache/hop/pipeline/transforms/getfilenames/GetFileNamesDialog.java
+++ b/plugins/transforms/getfilenames/src/main/java/org/apache/hop/pipeline/transforms/getfilenames/GetFileNamesDialog.java
@@ -64,12 +64,6 @@ import org.eclipse.swt.widgets.Text;
 public class GetFileNamesDialog extends BaseTransformDialog implements ITransformDialog {
   private static final Class<?> PKG = GetFileNamesMeta.class; // For Translator
 
-  private static final String[] YES_NO_COMBO =
-      new String[] {
-        BaseMessages.getString(PKG, "System.Combo.No"),
-        BaseMessages.getString(PKG, "System.Combo.Yes")
-      };
-
   private Button wDoNotFailIfNoFile;
   private Label wlDoNotFailIfNoFile;
 
@@ -476,11 +470,11 @@ public class GetFileNamesDialog extends BaseTransformDialog implements ITransfor
           new ColumnInfo(
               BaseMessages.getString(PKG, "GetFileNamesDialog.Required.Column"),
               ColumnInfo.COLUMN_TYPE_CCOMBO,
-              YES_NO_COMBO),
+              FileItem.YesNoType.getDescriptions()),
           new ColumnInfo(
               BaseMessages.getString(PKG, "GetFileNamesDialog.IncludeSubDirs.Column"),
               ColumnInfo.COLUMN_TYPE_CCOMBO,
-              YES_NO_COMBO)
+              FileItem.YesNoType.getDescriptions())
         };
 
     colinfo[0].setUsingVariables(true);
@@ -985,7 +979,12 @@ public class GetFileNamesDialog extends BaseTransformDialog implements ITransfor
 
       for (int i = 0; i < meta.getFilesList().size(); i++) {
         FileItem fi = meta.getFilesList().get(i);
-        wFilenameList.add(fi.getFileName(), fi.getFileMask(), fi.getExcludeFileMask(), fi.getFileRequired(), fi.getIncludeSubFolders());
+        wFilenameList.add(
+            fi.getFileName(),
+            fi.getFileMask(),
+            fi.getExcludeFileMask(),
+            fi.getFileRequired().getDescription(),
+            fi.getIncludeSubFolders().getDescription());
       }
     }
 
@@ -1049,13 +1048,17 @@ public class GetFileNamesDialog extends BaseTransformDialog implements ITransfor
 
     for (int i = 0; i < itemsNum; i++) {
 
+      FileItem.YesNoType fileRequired = FileItem.YesNoType.getType(wFilenameList.getItem(i, 4));
+      FileItem.YesNoType includeSubfolders =
+          FileItem.YesNoType.getType(wFilenameList.getItem(i, 5));
+
       FileItem fi =
           new FileItem(
               wFilenameList.getItem(i, 1),
               wFilenameList.getItem(i, 2),
               wFilenameList.getItem(i, 3),
-              wFilenameList.getItem(i, 4),
-              wFilenameList.getItem(i, 5));
+              fileRequired,
+              includeSubfolders);
       in.getFilesList().add(fi);
     }
 

--- a/plugins/transforms/getfilenames/src/main/java/org/apache/hop/pipeline/transforms/getfilenames/GetFileNamesMeta.java
+++ b/plugins/transforms/getfilenames/src/main/java/org/apache/hop/pipeline/transforms/getfilenames/GetFileNamesMeta.java
@@ -74,8 +74,8 @@ public class GetFileNamesMeta extends BaseTransformMeta<GetFileNames, GetFileNam
   @HopMetadataProperty(
       key = "file",
       injectionKeyDescription = "GetFileNames.Injection.File.Label",
-          injectionGroupKey = "FILE",
-          injectionGroupDescription = "GetFileNames.Injection.Group.FileTab.Label",
+      injectionGroupKey = "FILE",
+      injectionGroupDescription = "GetFileNames.Injection.Group.FileTab.Label",
       inlineListTags = {
         "name",
         "filemask",
@@ -516,7 +516,10 @@ public class GetFileNamesMeta extends BaseTransformMeta<GetFileNames, GetFileNam
   protected String[] buildFileRequiredArray() {
     String[] required = new String[filesList.size()];
     for (int i = 0; i < filesList.size(); i++) {
-      required[i] = filesList.get(i).getFileRequired();
+      required[i] =
+          filesList.get(i).getFileRequired() == null
+              ? FileItem.YesNoType.NO.getCode()
+              : filesList.get(i).getFileRequired().getCode();
     }
     return required;
   }
@@ -524,7 +527,11 @@ public class GetFileNamesMeta extends BaseTransformMeta<GetFileNames, GetFileNam
   private boolean[] includeSubFolderBoolean() {
     boolean[] includeSubFolderBoolean = new boolean[filesList.size()];
     for (int i = 0; i < filesList.size(); i++) {
-      includeSubFolderBoolean[i] = YES.equalsIgnoreCase(filesList.get(i).getIncludeSubFolders());
+      includeSubFolderBoolean[i] =
+          FileItem.YesNoType.YES.equals(
+              filesList.get(i).getIncludeSubFolders() == null
+                  ? FileItem.YesNoType.NO
+                  : filesList.get(i).getIncludeSubFolders());
     }
     return includeSubFolderBoolean;
   }

--- a/plugins/transforms/getfilenames/src/test/java/org/apache/hop/pipeline/transforms/getfilenames/GetFileNamesMetaTest.java
+++ b/plugins/transforms/getfilenames/src/test/java/org/apache/hop/pipeline/transforms/getfilenames/GetFileNamesMetaTest.java
@@ -180,11 +180,11 @@ public class GetFileNamesMetaTest implements IInitializer<ITransformMeta> {
           .getFilesList()
           .addAll(
               Arrays.asList(
-                  new FileItem("Filename1", "w1", "ew1", "Y", "N"),
-                  new FileItem("Filename2", "w2", "ew2", "Y", "N"),
-                  new FileItem("Filename3", "w3", "ew3", "Y", "N"),
-                  new FileItem("Filename4", "w4", "ew4", "Y", "N"),
-                  new FileItem("Filename5", "w5", "ew5", "Y", "N")));
+                  new FileItem("Filename1", "w1", "ew1", FileItem.YesNoType.YES, FileItem.YesNoType.NO),
+                  new FileItem("Filename2", "w2", "ew2", FileItem.YesNoType.YES, FileItem.YesNoType.NO),
+                  new FileItem("Filename3", "w3", "ew3", FileItem.YesNoType.YES, FileItem.YesNoType.NO),
+                  new FileItem("Filename4", "w4", "ew4", FileItem.YesNoType.YES, FileItem.YesNoType.NO),
+                  new FileItem("Filename5", "w5", "ew5", FileItem.YesNoType.YES, FileItem.YesNoType.NO)));
       ((GetFileNamesMeta) someMeta).getFilterItemList().clear();
       ((GetFileNamesMeta) someMeta)
           .getFilterItemList()
@@ -234,10 +234,10 @@ public class GetFileNamesMetaTest implements IInitializer<ITransformMeta> {
               UUID.randomUUID().toString(),
               UUID.randomUUID().toString(),
               UUID.randomUUID().toString(),
-              GetFileNamesMeta.RequiredFilesCode[
-                  new Random().nextInt(GetFileNamesMeta.RequiredFilesCode.length)],
-              GetFileNamesMeta.RequiredFilesCode[
-                  new Random().nextInt(GetFileNamesMeta.RequiredFilesCode.length)]);
+              FileItem.YesNoType.getType(GetFileNamesMeta.RequiredFilesCode[
+                  new Random().nextInt(GetFileNamesMeta.RequiredFilesCode.length)]),
+              FileItem.YesNoType.getType(GetFileNamesMeta.RequiredFilesCode[
+                  new Random().nextInt(GetFileNamesMeta.RequiredFilesCode.length)]));
 
       return field;
     }


### PR DESCRIPTION
fix #3294 Get filename: Y/N flags not working properly when language is not English

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
