### PR TITLE
Fixed flaky test due to use of HashSet in DatabaseLookupMetaTest#testProvidesModelerMeta

### DIFF
--- a/plugins/transforms/databaselookup/src/main/java/org/apache/hop/pipeline/transforms/databaselookup/DatabaseLookupMeta.java
+++ b/plugins/transforms/databaselookup/src/main/java/org/apache/hop/pipeline/transforms/databaselookup/DatabaseLookupMeta.java
@@ -44,7 +44,7 @@ import org.apache.hop.pipeline.transform.ITransformData;
 import org.apache.hop.pipeline.transform.TransformMeta;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -444,7 +444,7 @@ public class DatabaseLookupMeta extends BaseTransformMeta<DatabaseLookup, Databa
 
   @Override
   public List<String> getDatabaseFields() {
-    Set<String> fields = new HashSet<>();
+    Set<String> fields = new LinkedHashSet<>();
     for (KeyField keyField : lookup.getKeyFields()) {
       if (StringUtils.isNotEmpty(keyField.getTableField())) {
         fields.add(keyField.getTableField());
@@ -460,7 +460,7 @@ public class DatabaseLookupMeta extends BaseTransformMeta<DatabaseLookup, Databa
 
   @Override
   public List<String> getStreamFields() {
-    Set<String> fields = new HashSet<>();
+    Set<String> fields = new LinkedHashSet<>();
     for (KeyField keyField : lookup.getKeyFields()) {
       if (StringUtils.isNotEmpty(keyField.getStreamField1())) {
         fields.add(keyField.getStreamField1());


### PR DESCRIPTION
### Issue
`org.apache.hop.pipeline.transforms.databaselookup.DatabaseLookupMetaTest#testProvidesModelerMeta` calls `meta.getDatabaseFields()` and `meta.getStreamFields()` to get the database fields nad streamfields in as a list, and the order in the list is the insertion order in to the lookup. However, inside `meta.getDatabaseFields()` and `meta.getStreamFields()`, a `HashSet` was used to insert the data before returned as an `ArrayList`. However, order in `HashSet` is not predictable when it is converted to `ArrayList` (fist `toArray` is called and the `HashSet` iterator has undeterministic order). Therefore, tests could fail when the fields are checking according to the insertion order.

https://github.com/apache/hop/blob/fbb0eb49e87f471d0ce847f1f92f00c910578dac/plugins/transforms/databaselookup/src/test/java/org/apache/hop/pipeline/transforms/databaselookup/DatabaseLookupMetaTest.java#L164-L171

### Fix

Use `LinkedHashSet` in `meta.getDatabaseFields()` and `meta.getStreamFields()` to keep track of the insertion order. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
