### PR TITLE
Filter "Specify copies" GuiAction if transform doesn't support it #3439

### DIFF
--- a/engine/src/main/java/org/apache/hop/pipeline/transform/BaseTransformMeta.java
+++ b/engine/src/main/java/org/apache/hop/pipeline/transform/BaseTransformMeta.java
@@ -408,6 +408,11 @@ public class BaseTransformMeta<Main extends ITransform, Data extends ITransformD
     return false;
   }
 
+  @Override
+  public boolean supportsMultiCopyExecution() {
+    return true;
+  }
+  
   /** This method is added to exclude certain transforms from layout checking. */
   public boolean excludeFromRowLayoutVerification() {
     return false;

--- a/engine/src/main/java/org/apache/hop/pipeline/transform/ITransformMeta.java
+++ b/engine/src/main/java/org/apache/hop/pipeline/transform/ITransformMeta.java
@@ -331,6 +331,11 @@ public interface ITransformMeta {
   boolean supportsErrorHandling();
 
   /**
+   * @return true if this transform supports multi-copies execution. By default return true.
+   */
+  boolean supportsMultiCopyExecution();
+  
+  /**
    * Get a list of all the resource dependencies that the transform is depending on.
    *
    * @param transformMeta

--- a/engine/src/main/java/org/apache/hop/pipeline/transform/TransformMeta.java
+++ b/engine/src/main/java/org/apache/hop/pipeline/transform/TransformMeta.java
@@ -665,6 +665,10 @@ public class TransformMeta
     return null;
   }
 
+  public boolean supportsMultiCopyExecution() {
+    return transform.supportsMultiCopyExecution();
+  }
+  
   public boolean supportsErrorHandling() {
     return transform.supportsErrorHandling();
   }

--- a/plugins/transforms/abort/src/main/java/org/apache/hop/pipeline/transforms/abort/AbortMeta.java
+++ b/plugins/transforms/abort/src/main/java/org/apache/hop/pipeline/transforms/abort/AbortMeta.java
@@ -204,4 +204,9 @@ public class AbortMeta extends BaseTransformMeta<Abort, AbortData> {
   public void setAbortOption(AbortOption abortOption) {
     this.abortOption = abortOption;
   }
+
+  @Override
+  public boolean supportsMultiCopyExecution() {
+    return false;
+  }    
 }

--- a/plugins/transforms/analyticquery/src/main/java/org/apache/hop/pipeline/transforms/analyticquery/AnalyticQueryMeta.java
+++ b/plugins/transforms/analyticquery/src/main/java/org/apache/hop/pipeline/transforms/analyticquery/AnalyticQueryMeta.java
@@ -178,4 +178,9 @@ public class AnalyticQueryMeta extends BaseTransformMeta<AnalyticQuery, Analytic
   public void setQueryFields(List<QueryField> queryFields) {
     this.queryFields = queryFields;
   }
+
+  @Override
+  public boolean supportsMultiCopyExecution() {
+    return false;
+  }
 }

--- a/plugins/transforms/groupby/src/main/java/org/apache/hop/pipeline/transforms/groupby/GroupByMeta.java
+++ b/plugins/transforms/groupby/src/main/java/org/apache/hop/pipeline/transforms/groupby/GroupByMeta.java
@@ -442,4 +442,9 @@ public class GroupByMeta extends BaseTransformMeta<GroupBy, GroupByData> {
   public void setAggregations(List<Aggregation> aggregations) {
     this.aggregations = aggregations;
   }
+  
+  @Override
+  public boolean supportsMultiCopyExecution() {
+    return false;
+  }  
 }

--- a/plugins/transforms/memgroupby/src/main/java/org/apache/hop/pipeline/transforms/memgroupby/MemoryGroupByMeta.java
+++ b/plugins/transforms/memgroupby/src/main/java/org/apache/hop/pipeline/transforms/memgroupby/MemoryGroupByMeta.java
@@ -475,4 +475,9 @@ public class MemoryGroupByMeta extends BaseTransformMeta<MemoryGroupBy, MemoryGr
   public void setAlwaysGivingBackOneRow(boolean alwaysGivingBackOneRow) {
     this.alwaysGivingBackOneRow = alwaysGivingBackOneRow;
   }
+
+  @Override
+  public boolean supportsMultiCopyExecution() {
+    return false;
+  }  
 }

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/HopGuiPipelineGraph.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/HopGuiPipelineGraph.java
@@ -265,6 +265,8 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
       "pipeline-graph-transform-10650-rows-copy";
   public static final String ACTION_ID_PIPELINE_GRAPH_TRANSFORM_ROWS_DISTRIBUTE =
       "pipeline-graph-transform-10600-rows-distribute";
+  public static final String ACTION_ID_PIPELINE_GRAPH_TRANSFORM_SPECIFY_COPIES =
+  "pipeline-graph-transform-10100-copies";   
   public static final String ACTION_ID_PIPELINE_GRAPH_TRANSFORM_ERROR_HANDLING =
       "pipeline-graph-transform-10800-error-handling"; 
   public static final String ACTION_ID_PIPELINE_GRAPH_TRANSFORM_VIEW_EXECUTION_INFO =
@@ -2279,7 +2281,7 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
   }
 
   @GuiContextAction(
-      id = "pipeline-graph-transform-10100-copies",
+      id = ACTION_ID_PIPELINE_GRAPH_TRANSFORM_SPECIFY_COPIES,
       parentId = HopGuiPipelineTransformContext.CONTEXT_ID,
       type = GuiActionType.Modify,
       name = "i18n::HopGuiPipelineGraph.TransformAction.SpecifyCopies.Name",
@@ -2440,6 +2442,9 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
     }
     if (contextActionId.equals(ACTION_ID_PIPELINE_GRAPH_TRANSFORM_ROWS_COPY)) {
       return context.getTransformMeta().isDistributes();
+    }
+    if (contextActionId.equals(ACTION_ID_PIPELINE_GRAPH_TRANSFORM_SPECIFY_COPIES)) {
+      return context.getTransformMeta().supportsMultiCopyExecution();
     }
     if (contextActionId.equals(ACTION_ID_PIPELINE_GRAPH_TRANSFORM_ERROR_HANDLING)) {
       return context.getTransformMeta().supportsErrorHandling();


### PR DESCRIPTION
Disable multi-copy execution support for 4 transforms:
- Abort
- Analytic query
- Group by
- Memory group by
