### PR TITLE
Fixed flaky test in XmlInputStreamTest

### DIFF
--- a/plugins/transforms/xml/src/test/java/org/apache/hop/pipeline/transforms/xml/xmlinputstream/XmlInputStreamTest.java
+++ b/plugins/transforms/xml/src/test/java/org/apache/hop/pipeline/transforms/xml/xmlinputstream/XmlInputStreamTest.java
@@ -37,9 +37,11 @@ import java.io.PrintWriter;
 import java.io.Writer;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
@@ -123,6 +125,12 @@ public class XmlInputStreamTest {
         rl.getWritten().get(expectedRowNum)[dataNamePos]);
 
     // attributes
+    HashSet<String> expectedAttributeNames = new HashSet<>();
+    HashSet<String> expectedAttributeValues = new HashSet<>();
+    expectedAttributeNames.add("Fruits:attribute");
+    expectedAttributeNames.add("Fish:attribute");
+    expectedAttributeValues.add(ATTRIBUTE_1);
+    expectedAttributeValues.add(ATTRIBUTE_2);
     // ATTRIBUTE_1
     expectedRowNum++;
     assertEquals(
@@ -133,14 +141,10 @@ public class XmlInputStreamTest {
         INCORRECT_XML_PATH_MESSAGE,
         "/Products/Product/Fruits:ProductGroup",
         rl.getWritten().get(expectedRowNum)[pathPos]);
-    assertEquals(
-        INCORRECT_XML_DATA_NAME_MESSAGE,
-        "Fruits:attribute",
-        rl.getWritten().get(expectedRowNum)[dataNamePos]);
-    assertEquals(
-        INCORRECT_XML_DATA_VALUE_MESSAGE,
-        ATTRIBUTE_1,
-        rl.getWritten().get(expectedRowNum)[dataValue]);
+    assertTrue(INCORRECT_XML_DATA_NAME_MESSAGE,
+            expectedAttributeNames.contains(rl.getWritten().get(expectedRowNum)[dataNamePos]));
+    assertTrue(INCORRECT_XML_DATA_VALUE_MESSAGE,
+            expectedAttributeValues.contains(rl.getWritten().get(expectedRowNum)[dataValue]));
     // ATTRIBUTE_2
     expectedRowNum++;
     assertEquals(
@@ -151,14 +155,10 @@ public class XmlInputStreamTest {
         INCORRECT_XML_PATH_MESSAGE,
         "/Products/Product/Fruits:ProductGroup",
         rl.getWritten().get(expectedRowNum)[pathPos]);
-    assertEquals(
-        INCORRECT_XML_DATA_NAME_MESSAGE,
-        "Fish:attribute",
-        rl.getWritten().get(expectedRowNum)[dataNamePos]);
-    assertEquals(
-        INCORRECT_XML_DATA_VALUE_MESSAGE,
-        ATTRIBUTE_2,
-        rl.getWritten().get(expectedRowNum)[dataValue]);
+    assertTrue(INCORRECT_XML_DATA_NAME_MESSAGE,
+            expectedAttributeNames.contains(rl.getWritten().get(expectedRowNum)[dataNamePos]));
+    assertTrue(INCORRECT_XML_DATA_VALUE_MESSAGE,
+            expectedAttributeValues.contains(rl.getWritten().get(expectedRowNum)[dataValue]));
 
     // check EndElement for the ProductGroup element
     expectedRowNum = expectedRowNum + 2;
@@ -201,6 +201,9 @@ public class XmlInputStreamTest {
         rl.getWritten().get(expectedRowNum)[dataNamePos]);
 
     // attributes
+    HashSet<String> expectedAttributeValues = new HashSet<>();
+    expectedAttributeValues.add(ATTRIBUTE_1);
+    expectedAttributeValues.add(ATTRIBUTE_2);
     // ATTRIBUTE_1
     expectedRowNum++;
     assertEquals(
@@ -215,10 +218,8 @@ public class XmlInputStreamTest {
         INCORRECT_XML_DATA_NAME_MESSAGE,
         "attribute",
         rl.getWritten().get(expectedRowNum)[dataNamePos]);
-    assertEquals(
-        INCORRECT_XML_DATA_VALUE_MESSAGE,
-        ATTRIBUTE_1,
-        rl.getWritten().get(expectedRowNum)[dataValue]);
+    assertTrue(INCORRECT_XML_DATA_VALUE_MESSAGE,
+            expectedAttributeValues.contains(rl.getWritten().get(expectedRowNum)[dataValue]));
     // ATTRIBUTE_2
     expectedRowNum++;
     assertEquals(
@@ -233,10 +234,8 @@ public class XmlInputStreamTest {
         INCORRECT_XML_DATA_NAME_MESSAGE,
         "attribute",
         rl.getWritten().get(expectedRowNum)[dataNamePos]);
-    assertEquals(
-        INCORRECT_XML_DATA_VALUE_MESSAGE,
-        ATTRIBUTE_2,
-        rl.getWritten().get(expectedRowNum)[dataValue]);
+    assertTrue(INCORRECT_XML_DATA_VALUE_MESSAGE,
+            expectedAttributeValues.contains(rl.getWritten().get(expectedRowNum)[dataValue]));
 
     // check EndElement for the ProductGroup element
     expectedRowNum = expectedRowNum + 2;
@@ -280,6 +279,12 @@ public class XmlInputStreamTest {
         rl.getWritten().get(expectedRowNum)[dataNamePos]);
 
     // attributes
+    HashSet<String> expectedAttributeNames = new HashSet<>();
+    HashSet<String> expectedAttributeValues = new HashSet<>();
+    expectedAttributeNames.add("attribute1");
+    expectedAttributeNames.add("attribute2");
+    expectedAttributeValues.add(ATTRIBUTE_1);
+    expectedAttributeValues.add(ATTRIBUTE_2);
     // ATTRIBUTE_1
     expectedRowNum++;
     assertEquals(
@@ -290,14 +295,10 @@ public class XmlInputStreamTest {
         INCORRECT_XML_PATH_MESSAGE,
         "/Products/Product/ProductGroup",
         rl.getWritten().get(expectedRowNum)[pathPos]);
-    assertEquals(
-        INCORRECT_XML_DATA_NAME_MESSAGE,
-        "attribute1",
-        rl.getWritten().get(expectedRowNum)[dataNamePos]);
-    assertEquals(
-        INCORRECT_XML_DATA_VALUE_MESSAGE,
-        ATTRIBUTE_1,
-        rl.getWritten().get(expectedRowNum)[dataValue]);
+    assertTrue(INCORRECT_XML_DATA_NAME_MESSAGE,
+            expectedAttributeNames.contains(rl.getWritten().get(expectedRowNum)[dataNamePos]));
+    assertTrue(INCORRECT_XML_DATA_VALUE_MESSAGE,
+            expectedAttributeValues.contains(rl.getWritten().get(expectedRowNum)[dataValue]));
     // ATTRIBUTE_2
     expectedRowNum++;
     assertEquals(
@@ -308,14 +309,10 @@ public class XmlInputStreamTest {
         INCORRECT_XML_PATH_MESSAGE,
         "/Products/Product/ProductGroup",
         rl.getWritten().get(expectedRowNum)[pathPos]);
-    assertEquals(
-        INCORRECT_XML_DATA_NAME_MESSAGE,
-        "attribute2",
-        rl.getWritten().get(expectedRowNum)[dataNamePos]);
-    assertEquals(
-        INCORRECT_XML_DATA_VALUE_MESSAGE,
-        ATTRIBUTE_2,
-        rl.getWritten().get(expectedRowNum)[dataValue]);
+    assertTrue(INCORRECT_XML_DATA_NAME_MESSAGE,
+            expectedAttributeNames.contains(rl.getWritten().get(expectedRowNum)[dataNamePos]));
+    assertTrue(INCORRECT_XML_DATA_VALUE_MESSAGE,
+            expectedAttributeValues.contains(rl.getWritten().get(expectedRowNum)[dataValue]));
 
     // check EndElement for the ProductGroup element
     expectedRowNum = expectedRowNum + 2;


### PR DESCRIPTION
### Issue

In 3 tests in `org.apache.hop.pipeline.transforms.xml.xmlinputstream.XmlInputStreamTest`, when attributes are added to the `rowListner`, `pipeline.transforms.xml.xmlinputstream.XmlInputStream.parseAttributes` is called. It calls `getAttributes`, which internally uses a `HashMap` to populate the iterator. 
https://github.com/apache/hop/blob/45df66294437da0a8dbb1d611b34afda48408d3b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xmlinputstream/XmlInputStream.java#L553
Due to the unpredictable nature of `HashMap`, the order of attributes in `rowListener` could be nondeterministic but the pairing of name and value in each attribute will not change. 


### Proposed fix
Add all attribute names and values to a `HashSet` and see if the expected name or value is in the `HashSet`.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
