### PR TITLE
fix duplicate and wrong keys in multiway merge join combobox #3584

### DIFF
--- a/plugins/transforms/multimerge/src/main/java/org/apache/hop/pipeline/transforms/multimerge/MultiMergeJoinDialog.java
+++ b/plugins/transforms/multimerge/src/main/java/org/apache/hop/pipeline/transforms/multimerge/MultiMergeJoinDialog.java
@@ -352,6 +352,7 @@ public class MultiMergeJoinDialog extends BaseTransformDialog implements ITransf
                   inputFields.add(prev.getValueMeta(i).getName());
                 }
                 setComboBoxes();
+                inputFields.clear();
               }
             }
           } catch (HopException e) {


### PR DESCRIPTION
See #3584 Simply clear the inputfields list once we've set the combo box. Before we would just keep appending to the same list so it would have duplicates and wrong keys from other input streams.
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
