### PR TITLE
Record action execution duration #3606

### DIFF
--- a/engine/src/main/java/org/apache/hop/workflow/Workflow.java
+++ b/engine/src/main/java/org/apache/hop/workflow/Workflow.java
@@ -655,6 +655,9 @@ public abstract class Workflow extends Variables
       newResult = cloneJei.execute(prevResult, nr);
       log.snap(Metrics.METRIC_ACTION_STOP, cloneJei.toString());
 
+      // Action execution duration
+      newResult.setElapsedTimeMillis(System.currentTimeMillis()-start);
+
       if (interactive) {
         getActiveActions().remove(actionMeta);
       }


### PR DESCRIPTION
Indirectly fix "actionDuration" always null in workflow logging
