### PR TITLE
[Feature 36936] Updated documentation to warn the user about mixing meta types in row…

### DIFF
--- a/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/rownormaliser.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/rownormaliser.adoc
@@ -29,6 +29,8 @@ The Row Normaliser transform converts the columns of an input stream into rows.
 
 You can use this transform to normalize repeating groups of columns.
 
+*Important*: When combining multiple columns with different meta types (e.g., String and Integer) into a new field, no automatic type conversion is performed. Instead the first meta type is set. This lack of conversion may lead to issues with subsequent transformations on the resulting data rows. It is strongly advised to ensure that the data types of values being put into the same field are aligned before normalization.
+
 |
 == Supported Engines
 [%noheader,cols="2,1a",frame=none, role="table-supported-engines"]


### PR DESCRIPTION
… normaliser

This is the first step, a minor update of the documentation of the row normalizer to warn the user about mixing meta types.