### PR TITLE
Bugfix/2312 database join meta conversion fix

### DIFF
--- a/core/src/main/java/org/apache/hop/core/row/value/ValueMetaBase.java
+++ b/core/src/main/java/org/apache/hop/core/row/value/ValueMetaBase.java
@@ -1116,7 +1116,7 @@ public class ValueMetaBase implements IValueMeta {
     return new Date(number.longValue());
   }
 
-  public synchronized String convertNumberToString(Double number) throws HopValueException {
+  public synchronized String convertNumberToString(Number number) throws HopValueException {
     if (number == null) {
       if (!outputPaddingEnabled || length < 1) {
         return null;
@@ -2010,17 +2010,17 @@ public class ValueMetaBase implements IValueMeta {
         case TYPE_NUMBER:
           switch (storageType) {
             case STORAGE_TYPE_NORMAL:
-              string = convertNumberToString((Double) object);
+              string = convertNumberToString((Number) object);
               break;
             case STORAGE_TYPE_BINARY_STRING:
               string =
-                  convertNumberToString((Double) convertBinaryStringToNativeType((byte[]) object));
+                  convertNumberToString((Number) convertBinaryStringToNativeType((byte[]) object));
               break;
             case STORAGE_TYPE_INDEXED:
               string =
                   object == null
                       ? null
-                      : convertNumberToString((Double) index[((Integer) object).intValue()]);
+                      : convertNumberToString((Number) index[((Integer) object).intValue()]);
               break;
             default:
               throw new HopValueException(
@@ -2742,14 +2742,14 @@ public class ValueMetaBase implements IValueMeta {
         case TYPE_NUMBER:
           switch (storageType) {
             case STORAGE_TYPE_NORMAL:
-              return convertStringToBinaryString(convertNumberToString((Double) object));
+              return convertStringToBinaryString(convertNumberToString((Number) object));
             case STORAGE_TYPE_BINARY_STRING:
               String string =
-                  convertNumberToString((Double) convertBinaryStringToNativeType((byte[]) object));
+                  convertNumberToString((Number) convertBinaryStringToNativeType((byte[]) object));
               return convertStringToBinaryString(string);
             case STORAGE_TYPE_INDEXED:
               return convertStringToBinaryString(
-                  convertNumberToString((Double) index[((Integer) object).intValue()]));
+                  convertNumberToString((Number) index[((Integer) object).intValue()]));
             default:
               throw new HopValueException(
                   toString() + MSG_UNKNOWN_STORAGE_TYPE + storageType + MSG_SPECIFIED);
@@ -5402,9 +5402,6 @@ public class ValueMetaBase implements IValueMeta {
         case Types.LONGVARBINARY:
           valtype = IValueMeta.TYPE_BINARY;
 
-          IDatabase db = databaseMeta.getIDatabase();
-          boolean isOracle = db.isOracleVariant();
-
           if (databaseMeta.isDisplaySizeTwiceThePrecision()
               && (2 * originalPrecision) == originalColumnDisplaySize) {
             // set the length for "CHAR(X) FOR BIT DATA"
@@ -5764,6 +5761,7 @@ public class ValueMetaBase implements IValueMeta {
     throw new HopValueException(getTypeDesc() + " does not implement this method");
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public void storeMetaInJson(JSONObject jValue) throws HopException {
     jValue.put("name", getName());

--- a/engine/src/main/java/org/apache/hop/pipeline/transform/BaseTransform.java
+++ b/engine/src/main/java/org/apache/hop/pipeline/transform/BaseTransform.java
@@ -1990,7 +1990,6 @@ public class BaseTransform<Meta extends ITransformMeta, Data extends ITransformD
                   pipeline.getPipelineRunConfiguration().getEngineRunConfiguration();
           waitTime = Integer.parseInt(runconfig.getWaitTime());
         }
-        if (waitTime == null) waitTime = 20;
 
         if (waitingTime == null) {
           waitingTime =

--- a/plugins/transforms/databasejoin/src/main/java/org/apache/hop/pipeline/transforms/databasejoin/DatabaseJoin.java
+++ b/plugins/transforms/databasejoin/src/main/java/org/apache/hop/pipeline/transforms/databasejoin/DatabaseJoin.java
@@ -27,6 +27,7 @@ import org.apache.hop.core.exception.HopDatabaseException;
 import org.apache.hop.core.exception.HopException;
 import org.apache.hop.core.exception.HopTransformException;
 import org.apache.hop.core.row.IRowMeta;
+import org.apache.hop.core.row.IValueMeta;
 import org.apache.hop.core.row.RowDataUtil;
 import org.apache.hop.core.row.RowMeta;
 import org.apache.hop.core.util.Utils;
@@ -116,7 +117,12 @@ public class DatabaseJoin extends BaseTransform<DatabaseJoinMeta, DatabaseJoinDa
           Object[] newRow = RowDataUtil.resizeArray(rowData, data.outputRowMeta.size());
           int newIndex = rowMeta.size();
           for (int i = 0; i < addMeta.size(); i++) {
-            newRow[newIndex++] = add[i];
+            // Convert Long to double when required. This solves the issue mentioned in the comments of #2312
+            Object value = add[i];
+            if (value instanceof Long && data.outputRowMeta.getValueMeta(newIndex).getType() == IValueMeta.TYPE_NUMBER) {
+              value = (Double) ((Long) value).doubleValue();
+            }
+            newRow[newIndex++] = value;
           }
           // we have to clone, otherwise we only get the last new value
           putRow(data.outputRowMeta, data.outputRowMeta.cloneRow(newRow));


### PR DESCRIPTION
Addresses #2312 in case of using SQLite database join. While the driver returns column type NUMERIC, when fetching data it can either return Long or Double values. This is not supported by Hop. This fix should do the required conversion. Additionally, the expected Type in convertNumberToString is changed from Double to Number.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
