### PR TITLE
fix #3510, fix #3512, fix #3665

### DIFF
--- a/core/src/main/java/org/apache/hop/core/database/BaseDatabaseMeta.java
+++ b/core/src/main/java/org/apache/hop/core/database/BaseDatabaseMeta.java
@@ -1618,6 +1618,11 @@ public abstract class BaseDatabaseMeta implements Cloneable, IDatabase {
     return false;
   }
 
+  /** @return true if the database is a DuckDb variant. */
+  public boolean isDuckDbVariant() {
+    return false;
+  }
+
   /**
    * @return true if the database is a Informix variant.
    */

--- a/core/src/main/java/org/apache/hop/core/database/IDatabase.java
+++ b/core/src/main/java/org/apache/hop/core/database/IDatabase.java
@@ -771,7 +771,10 @@ public interface IDatabase extends Cloneable {
   /** @return true if the database is a neoview variant. */
   boolean isNeoviewVariant();
 
-  /** @return true if the database is a Exasol variant. */
+  /** @return true if the database is a neoview variant. */
+  boolean isDuckDbVariant();
+
+  /** @return true if the database is a DuckDB variant. */
   boolean isExasolVariant();
 
   /** @return true if the database is a Informix variant. */

--- a/core/src/main/java/org/apache/hop/core/database/IDatabase.java
+++ b/core/src/main/java/org/apache/hop/core/database/IDatabase.java
@@ -727,7 +727,7 @@ public interface IDatabase extends Cloneable {
   /**
    * Generate a column alias given the column index and suggested name.
    *
-   * @param columnIndex Index of column in query
+   * @param columnIndex Index of the column in the query
    * @param suggestedName Suggested column name
    * @return Column alias that is valid for this database
    */
@@ -757,7 +757,7 @@ public interface IDatabase extends Cloneable {
   boolean isMySqlVariant();
 
   /**
-   * @return true if the database is a Postgres variant like Postgres, Greenplum, Redshift and so
+   * @return true if the database is a Postgres variant like Postgres, Greenplum, Redshift, and so
    *     on.
    */
   boolean isPostgresVariant();
@@ -771,13 +771,13 @@ public interface IDatabase extends Cloneable {
   /** @return true if the database is a neoview variant. */
   boolean isNeoviewVariant();
 
-  /** @return true if the database is a neoview variant. */
+  /** @return true if the database is a DuckDB variant. */
   boolean isDuckDbVariant();
 
   /** @return true if the database is a DuckDB variant. */
   boolean isExasolVariant();
 
-  /** @return true if the database is a Informix variant. */
+  /** @return true if the database is an Informix variant. */
   boolean isInformixVariant();
 
   /** @return true if the database is a MS SQL Server (native) variant. */
@@ -789,7 +789,7 @@ public interface IDatabase extends Cloneable {
   /** @return true if the database is an Oracle variant. */
   boolean isOracleVariant();
 
-  /** @return true if the database is an Netezza variant. */
+  /** @return true if the database is a Netezza variant. */
   boolean isNetezzaVariant();
 
   /** @return true if the database is a SQLite variant. */
@@ -799,7 +799,7 @@ public interface IDatabase extends Cloneable {
   boolean isTeradataVariant();
 
   /**
-   * Returns a true of savepoints can be release, false if not.
+   * Returns a true if savepoints can be released, false if not.
    *
    * @return
    */
@@ -819,7 +819,7 @@ public interface IDatabase extends Cloneable {
   String getDataTablespaceDDL(IVariables variables, DatabaseMeta databaseMeta);
 
   /**
-   * Returns the tablespace DDL fragment for a "Index" tablespace.
+   * Returns the tablespace DDL fragment for an "Index" tablespace.
    *
    * @param variables variables used for possible substitution
    * @param databaseMeta databaseMeta the database meta used for possible string enclosure of the

--- a/core/src/main/java/org/apache/hop/core/row/value/ValueMetaBase.java
+++ b/core/src/main/java/org/apache/hop/core/row/value/ValueMetaBase.java
@@ -235,6 +235,7 @@ public class ValueMetaBase implements IValueMeta {
     BaseMessages.getString(PKG, "ValueMeta.TrimType.Right"),
     BaseMessages.getString(PKG, "ValueMeta.TrimType.Both")
   };
+
   // endregion
 
   public ValueMetaBase() {
@@ -5619,30 +5620,53 @@ public class ValueMetaBase implements IValueMeta {
               // Convert to DATE!
               long dat = getInteger(data).longValue(); // converts using Date.getTime()
               java.sql.Date ddate = new java.sql.Date(dat);
-              if (this.getDateFormatTimeZone() == null) {
+              if (databaseMeta.getIDatabase().isDuckDbVariant()) {
+                // As of DuckDB JDBC 0.10.0
+                // setDate(int parameterIndex, Date x, Calendar cal)
+                // is not yet implemented
                 preparedStatement.setDate(index, ddate);
               } else {
-                preparedStatement.setDate(
-                    index, ddate, Calendar.getInstance(this.getDateFormatTimeZone()));
+                if (this.getDateFormatTimeZone() == null) {
+                  preparedStatement.setDate(index, ddate);
+                } else {
+                  preparedStatement.setDate(
+                      index, ddate, Calendar.getInstance(this.getDateFormatTimeZone()));
+                }
               }
             } else {
               if (data instanceof Timestamp) {
                 // Preserve ns precision!
                 //
-                if (this.getDateFormatTimeZone() == null) {
+                if (databaseMeta.getIDatabase().isDuckDbVariant()) {
+                  // As of DuckDB JDBC 0.10.0
+                  // setTimestamp(int parameterIndex, Timestamp x, Calendar cal)
+                  // is not yet implemented
                   preparedStatement.setTimestamp(index, (Timestamp) data);
                 } else {
-                  preparedStatement.setTimestamp(
-                      index, (Timestamp) data, Calendar.getInstance(this.getDateFormatTimeZone()));
+                  if (this.getDateFormatTimeZone() == null) {
+                    preparedStatement.setTimestamp(index, (Timestamp) data);
+                  } else {
+                    preparedStatement.setTimestamp(
+                        index,
+                        (Timestamp) data,
+                        Calendar.getInstance(this.getDateFormatTimeZone()));
+                  }
                 }
               } else {
                 long dat = getInteger(data).longValue(); // converts using Date.getTime()
                 Timestamp sdate = new Timestamp(dat);
-                if (this.getDateFormatTimeZone() == null) {
+                if (databaseMeta.getIDatabase().isDuckDbVariant()) {
+                  // As of DuckDB JDBC 0.10.0
+                  // setTimestamp(int parameterIndex, Timestamp x, Calendar cal)
+                  // is not yet implemented
                   preparedStatement.setTimestamp(index, sdate);
                 } else {
-                  preparedStatement.setTimestamp(
-                      index, sdate, Calendar.getInstance(this.getDateFormatTimeZone()));
+                  if (this.getDateFormatTimeZone() == null) {
+                    preparedStatement.setTimestamp(index, sdate);
+                  } else {
+                    preparedStatement.setTimestamp(
+                        index, sdate, Calendar.getInstance(this.getDateFormatTimeZone()));
+                  }
                 }
               }
             }

--- a/core/src/test/java/org/apache/hop/core/row/value/ValueMetaBaseSetPreparedStmntValueTest.java
+++ b/core/src/test/java/org/apache/hop/core/row/value/ValueMetaBaseSetPreparedStmntValueTest.java
@@ -17,7 +17,9 @@
 
 package org.apache.hop.core.row.value;
 
+import org.apache.hop.core.database.BaseDatabaseMeta;
 import org.apache.hop.core.database.DatabaseMeta;
+import org.apache.hop.core.database.IDatabase;
 import org.apache.hop.core.row.IRowMeta;
 import org.apache.hop.core.row.IValueMeta;
 import org.apache.hop.core.row.RowMeta;
@@ -52,7 +54,9 @@ public class ValueMetaBaseSetPreparedStmntValueTest {
   @Before
   public void setUp() {
     dbMeta = mock(DatabaseMeta.class);
+    IDatabase iDb = mock(BaseDatabaseMeta.class);
     when(dbMeta.supportsTimeStampToDateConversion()).thenReturn(true);
+    when(dbMeta.getIDatabase()).thenReturn(iDb);
     ps = mock(PreparedStatement.class);
     date = new Date(System.currentTimeMillis());
     ts = new Timestamp(System.currentTimeMillis());

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/duckdb.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/duckdb.adoc
@@ -24,6 +24,13 @@ DuckDB is an in-process SQL OLAP database management system.
 
 As an in-process database, DuckDB is easy to configure: specify the path to your DuckDB filename as the database name, e.g. `<PATH_TO_YOUR_DUCKDB_FILE>/duckdb`.
 
+One thing to remember is about how DuckDB manages concurrency. The things to remember are summarized below:
+
+* Only one process at a time can both read and write to the database.
+* Multiple processes can read from the database, but no processes can write. To set this behavior, remember to specify in the connection's options the property duckdb.read_only = true
+
+For details, please refer to https://duckdb.org/docs/api/java[DuckDB Java API documentation].
+
 [cols="2*",options="header"]
 |===
 | Option | Info

--- a/plugins/databases/duckdb/src/main/java/org/apache/hop/databases/duckdb/DuckDBDatabaseMeta.java
+++ b/plugins/databases/duckdb/src/main/java/org/apache/hop/databases/duckdb/DuckDBDatabaseMeta.java
@@ -136,6 +136,11 @@ public class DuckDBDatabaseMeta extends BaseDatabaseMeta implements IDatabase {
     }
 
     @Override
+    public boolean isDuckDbVariant() {
+        return true;
+    }
+
+    @Override
     public String getURL(String hostname, String port, String databaseName) throws HopDatabaseException {
         return "jdbc:duckdb:" + databaseName;
     }

--- a/plugins/transforms/tableoutput/src/main/java/org/apache/hop/pipeline/transforms/tableoutput/TableOutput.java
+++ b/plugins/transforms/tableoutput/src/main/java/org/apache/hop/pipeline/transforms/tableoutput/TableOutput.java
@@ -384,6 +384,15 @@ public class TableOutput extends BaseTransform<TableOutputMeta, TableOutputData>
               dbe);
         }
       }
+    } finally {
+      try {
+        if (insertStatement != null) {
+          insertStatement.close();
+        }
+      } catch (SQLException e) {
+        throw new HopException("unable to close statement's handle for insertStatement",
+                e);
+      }
     }
 
     // We need to add a key


### PR DESCRIPTION
fix #3510 DuckDB - if a table output fails, the destination duckdb database file remains locked and can no longer be used.
fix #3512 DuckDB- If you send it a Date some kind of setTimestamp() prepared function fails
fix #3665 DuckDB plugins documentation improvements

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
