### PR TITLE
Adapt mouse cursor to context #3752

### DIFF
--- a/engine/src/main/java/org/apache/hop/core/gui/AreaOwner.java
+++ b/engine/src/main/java/org/apache/hop/core/gui/AreaOwner.java
@@ -25,53 +25,93 @@ import java.util.List;
  * that's behind it. That should make it a lot easier to track what was drawn, setting tooltips,
  * etc.
  */
-public class AreaOwner<Parent, Owner> {
+public class AreaOwner {
 
   public enum AreaType {
-    NOTE,
-    TRANSFORM_PARTITIONING,
-    TRANSFORM_ICON,
-    TRANSFORM_NAME,
-    TRANSFORM_INFO_ICON,
-    TRANSFORM_FAILURE_ICON,
-    TRANSFORM_INPUT_HOP_ICON,
-    TRANSFORM_OUTPUT_HOP_ICON,
-    TRANSFORM_INFO_HOP_ICON,
-    TRANSFORM_ERROR_HOP_ICON,
-    TRANSFORM_TARGET_HOP_ICON,
-    HOP_COPY_ICON,
-    ROW_DISTRIBUTION_ICON,
-    HOP_ERROR_ICON,
-    HOP_INFO_ICON,
-    HOP_INFO_TRANSFORM_COPIES_ERROR,
-    HOP_INFO_TRANSFORMS_PARTITIONED,
+    /** The note pad area. */
+    NOTE(true),
+    
+    /** The transformation partitioning area. */
+    TRANSFORM_PARTITIONING(false),    
+    /** The transformation icon area. */
+    TRANSFORM_ICON(true),
+    /** The transformation name area. */
+    TRANSFORM_NAME(true),
+    /** The transformation decoration information icon in the top left-hand corner indicates that it has a description. */
+    TRANSFORM_INFO_ICON(true),
+    /** The transformation decoration failure icon area in top right corner to indicate an execution error. */
+    TRANSFORM_FAILURE_ICON(false),
+    /** The transformation decoration area for the number of execution copies. */
+    TRANSFORM_COPIES_TEXT(true),    
+    /** TODO:  Not used yet */
+    TRANSFORM_DATA_SERVICE(false),
+    /** The transformation decoration data icon in the bottom right-hand corner to indicate that there are available output rows. */
+    TRANSFORM_OUTPUT_DATA(true),
+    /** The pipeline hop decoration */
+    TRANSFORM_TARGET_HOP_ICON(true),  
+    /** TODO: ? */
+    TRANSFORM_TARGET_HOP_ICON_OPTION(false),
 
-    TRANSFORM_TARGET_HOP_ICON_OPTION,
-    TRANSFORM_EDIT_ICON,
-    TRANSFORM_MENU_ICON,
-    TRANSFORM_COPIES_TEXT,
-    TRANSFORM_DATA_SERVICE,
+    @Deprecated
+    TRANSFORM_INFO_HOP_ICON(false),
+    @Deprecated
+    TRANSFORM_ERROR_HOP_ICON(false),
+    @Deprecated
+    TRANSFORM_INPUT_HOP_ICON(false),
+    @Deprecated
+    TRANSFORM_OUTPUT_HOP_ICON(false),
 
-    ACTION_ICON,
-    ACTION_NAME,
-    ACTION_INFO_ICON,
-    WORKFLOW_HOP_ICON,
-    WORKFLOW_HOP_PARALLEL_ICON,
+    /** The pipeline hop decoration copy icon that indicate that all rows. */
+    HOP_COPY_ICON(true),
+    /** The pipeline hop decoration icon for error handling. */
+    HOP_ERROR_ICON(true),
+    /** The pipeline hop decoration icon indicates that additional information is being sent to a transformation. */
+    HOP_INFO_ICON(true),
+    /** TODO: ? */
+    HOP_INFO_TRANSFORM_COPIES_ERROR(false),
+    /** TODO: ? */
+    HOP_INFO_TRANSFORMS_PARTITIONED(false),
+    
+    /** The workflow hop decoration icon indicates the condition of the following action: true/false/unconditional. */
+    WORKFLOW_HOP_ICON(true),
+    /** The workflow hop decoration icon for parallel execution. */
+    WORKFLOW_HOP_PARALLEL_ICON(true),
+    
+    /** The action icon area. */
+    ACTION_ICON(true),
+    /** The action name area. */
+    ACTION_NAME(true),
+    /** The action decoration information icon in the top left-hand corner that indicates that it has a description. */
+    ACTION_INFO_ICON(true),
+    /** The action decoration busy icon at the top right that indicates that it is currently running. */
+    ACTION_BUSY(false),
+    /** The action decoration success icon in top right corner to indicate an execution success. */
+    ACTION_RESULT_SUCCESS(true),
+    /** The action decoration failure icon in top right corner to indicate an execution error. */
+    ACTION_RESULT_FAILURE(true),
+    /** TODO:  Not used yet */
+    ACTION_RESULT_CHECKPOINT(true),
 
-    ACTION_BUSY,
-    ACTION_RESULT_SUCCESS,
-    ACTION_RESULT_FAILURE,
-    ACTION_RESULT_CHECKPOINT,
-    TRANSFORM_INJECT_ICON,
+    /** For custom row distribution plugin icon */
+    ROW_DISTRIBUTION_ICON(false),
+    
+    /** A custom area for plugins. */
+    CUSTOM(true);
+    
+    private final boolean hover;
+    
+    AreaType(boolean hover) {
+      this.hover = hover;
+    }    
 
-    TRANSFORM_OUTPUT_DATA,
-
-    CUSTOM;
+    public boolean isSupportHover() {
+      return hover;
+    }
   }
 
   private Rectangle area;
-  private Parent parent;
-  private Owner owner;
+  private Object parent;
+  private Object owner;
   private AreaType areaType;
 
   /**
@@ -88,8 +128,8 @@ public class AreaOwner<Parent, Owner> {
       int width,
       int height,
       DPoint offset,
-      Parent parent,
-      Owner owner) {
+      Object parent,
+      Object owner) {
     super();
     this.areaType = areaType;
     this.area = new Rectangle((int)(x - offset.x), (int)(y - offset.y), width, height);
@@ -97,7 +137,7 @@ public class AreaOwner<Parent, Owner> {
     this.owner = owner;
   }
 
-  public AreaOwner(AreaOwner<Parent, Owner> o) {
+  public AreaOwner(AreaOwner o) {
     this.areaType = o.areaType;
     this.area = new Rectangle(o.area);
     this.parent = o.parent;
@@ -144,11 +184,11 @@ public class AreaOwner<Parent, Owner> {
    * @param y The y coordinate
    * @return The area owner or null if nothing could be found
    */
-  public static synchronized <Owner, Parent> AreaOwner<Owner, Parent> getVisibleAreaOwner(
-      List<AreaOwner<Owner, Parent>> areaOwners, int x, int y) {
+  public static synchronized AreaOwner getVisibleAreaOwner(
+      List<AreaOwner> areaOwners, int x, int y) {
 
     for (int i = areaOwners.size() - 1; i >= 0; i--) {
-      AreaOwner<Owner, Parent> areaOwner = areaOwners.get(i);
+      AreaOwner areaOwner = areaOwners.get(i);
       if (areaOwner.contains(x, y)) {
         return areaOwner;
       }
@@ -167,22 +207,22 @@ public class AreaOwner<Parent, Owner> {
   }
 
   /** @return the owner */
-  public Owner getOwner() {
+  public Object getOwner() {
     return owner;
   }
 
   /** @param owner the owner to set */
-  public void setOwner(Owner owner) {
+  public void setOwner(Object owner) {
     this.owner = owner;
   }
 
   /** @return the parent */
-  public Parent getParent() {
+  public Object getParent() {
     return parent;
   }
 
   /** @param parent the parent to set */
-  public void setParent(Parent parent) {
+  public void setParent(Object parent) {
     this.parent = parent;
   }
 

--- a/ui/src/main/java/org/apache/hop/ui/core/dialog/ContextDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/dialog/ContextDialog.java
@@ -122,7 +122,7 @@ public class ContextDialog extends Dialog {
 
   private GuiAction selectedAction;
 
-  private List<AreaOwner<OwnerType, Object>> areaOwners = new ArrayList<>();
+  private List<AreaOwner> areaOwners = new ArrayList<>();
 
   private final Color highlightColor;
 
@@ -228,7 +228,7 @@ public class ContextDialog extends Dialog {
     private final GuiAction action;
     private final Image image;
     private boolean selected;
-    private AreaOwner<OwnerType, Object> areaOwner;
+    private AreaOwner areaOwner;
 
     public Item(GuiAction action, Image image) {
       this.action = action;
@@ -752,12 +752,14 @@ public class ContextDialog extends Dialog {
   }
 
   private void onMouseUp(Event event) {
-    AreaOwner<OwnerType, Object> areaOwner =
+    AreaOwner areaOwner =
         AreaOwner.getVisibleAreaOwner(areaOwners, event.x, event.y);
     if (areaOwner == null) {
       return;
     }
-    switch (areaOwner.getParent()) {
+    
+    OwnerType ownerType = (OwnerType) areaOwner.getParent();
+    switch (ownerType) {
       case CATEGORY:
         // Clicked on a category header: expand or unfold
         //
@@ -871,7 +873,7 @@ public class ContextDialog extends Dialog {
           org.eclipse.swt.graphics.Point categoryExtent = gc.textExtent(categoryAndOrder.category);
           gc.drawText(categoryAndOrder.category, x, y);
           areaOwners.add(
-              new AreaOwner<>(
+              new AreaOwner(
                   AreaOwner.AreaType.CUSTOM,
                   x,
                   y,
@@ -963,8 +965,8 @@ public class ContextDialog extends Dialog {
 
             // The drawn area is the complete rectangle
             //
-            AreaOwner<OwnerType, Object> areaOwner =
-                new AreaOwner<>(
+            AreaOwner areaOwner =
+                new AreaOwner(
                     AreaOwner.AreaType.CUSTOM,
                     x,
                     y,

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/execution/DragViewZoomBase.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/execution/DragViewZoomBase.java
@@ -256,7 +256,8 @@ public abstract class DragViewZoomBase extends Composite {
     if (viewPort != null && viewPort.contains(screenClick)) {
       viewPortNavigation = true;
       viewPortStart = new Point(screenClick);
-      viewDragBaseOffset = new DPoint(offset);
+      viewDragBaseOffset = new DPoint(offset);  
+      setCursor(getDisplay().getSystemCursor(SWT.CURSOR_SIZEALL));
       return true;
     }
 
@@ -267,6 +268,7 @@ public abstract class DragViewZoomBase extends Composite {
     if (viewDrag) {
       viewDragStart = screenClick;
       viewDragBaseOffset = new DPoint(offset);
+      setCursor(getDisplay().getSystemCursor(SWT.CURSOR_SIZEALL));
       return true;
     }
     return false;

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/execution/PipelineExecutionViewer.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/execution/PipelineExecutionViewer.java
@@ -855,19 +855,19 @@ public class PipelineExecutionViewer extends BaseExecutionViewer
   }
 
   @Override
-  public void mouseDown(MouseEvent e) {
+  public void mouseDown(MouseEvent event) {
     pipelineMeta.unselectAll();
 
     if (EnvironmentUtils.getInstance().isWeb()) {
       // RAP does not support certain mouse events.
-      mouseHover(e);
+      mouseHover(event);
     }
 
-    Point real = screen2real(e.x, e.y);
+    Point real = screen2real(event.x, event.y);
     lastClick = new Point(real.x, real.y);
-    boolean control = (e.stateMask & SWT.MOD1) != 0;
+    boolean control = (event.stateMask & SWT.MOD1) != 0;
 
-    if (setupDragView(e.button, control, new Point(e.x, e.y))) {
+    if (setupDragView(event.button, control, new Point(event.x, event.y))) {
       return;
     }
 
@@ -882,10 +882,17 @@ public class PipelineExecutionViewer extends BaseExecutionViewer
           // Show the data for this transform
           //
           selectedTransform = (TransformMeta) areaOwner.getOwner();
+          refreshTransformData();
+          break;
+        case TRANSFORM_NAME:
+          // Show the data for this transform
+          //
+          selectedTransform = (TransformMeta) areaOwner.getParent();
+          refreshTransformData();
           break;
       }
     }
-    refreshTransformData();
+    
     redraw();
   }
 

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/execution/WorkflowExecutionViewer.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/execution/WorkflowExecutionViewer.java
@@ -812,14 +812,14 @@ public class WorkflowExecutionViewer extends BaseExecutionViewer
   }
 
   @Override
-  public void mouseDown(MouseEvent e) {
+  public void mouseDown(MouseEvent event) {
     workflowMeta.unselectAll();
-    Point real = screen2real(e.x, e.y);
+    Point real = screen2real(event.x, event.y);
 
     lastClick = new Point(real.x, real.y);
-    boolean control = (e.stateMask & SWT.MOD1) != 0;
+    boolean control = (event.stateMask & SWT.MOD1) != 0;
 
-    if (setupDragView(e.button, control, new Point(e.x, e.y))) {
+    if (setupDragView(event.button, control, new Point(event.x, event.y))) {
       return;
     }
 
@@ -830,9 +830,15 @@ public class WorkflowExecutionViewer extends BaseExecutionViewer
 
     switch (areaOwner.getAreaType()) {
       case ACTION_ICON:
-        // Show the data for this transform
+        // Show the data for this action
         //
         selectedAction = (ActionMeta) areaOwner.getOwner();
+        refreshActionData();
+        break;
+      case ACTION_NAME:
+        // Show the data for this action
+        //
+        selectedAction = (ActionMeta) areaOwner.getParent();
         refreshActionData();
         break;
     }

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/shared/BaseExecutionViewer.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/shared/BaseExecutionViewer.java
@@ -144,35 +144,63 @@ public abstract class BaseExecutionViewer extends DragViewZoomBase
   public abstract void drillDownOnLocation(Point location);
 
   @Override
-  public void mouseDoubleClick(MouseEvent mouseEvent) {
-    drillDownOnLocation(screen2real(mouseEvent.x, mouseEvent.y));
+  public void mouseDoubleClick(MouseEvent event) {
+    drillDownOnLocation(screen2real(event.x, event.y));
   }
 
   @Override
-  public void mouseMove(MouseEvent e) {
+  public void mouseMove(MouseEvent event) {
     // Check to see if we're navigating with the view port
     //
     if (viewPortNavigation) {
-      dragViewPort(new Point(e.x, e.y));
+      dragViewPort(new Point(event.x, event.y));
     }
 
     // Drag the view around with middle button on the background?
     //
     if (viewDrag && lastClick != null) {
-      dragView(viewDragStart, new Point(e.x, e.y));
+      dragView(viewDragStart, new Point(event.x, event.y));
     }
+    
+    Point real = screen2real(event.x, event.y);
+    
+    // Moved over an area?
+    //
+    AreaOwner areaOwner = getVisibleAreaOwner(real.x, real.y);
+
+    Cursor cursor = null;
+    // Change cursor when dragging view or view port
+    if (viewDrag || viewPortNavigation) {
+      cursor = getDisplay().getSystemCursor(SWT.CURSOR_SIZEALL);
+    }
+    // Change cursor when hover an action or transform icon
+    else if (areaOwner != null && areaOwner.getAreaType() != null && areaOwner.getAreaType().isSupportHover()) {     
+      switch(areaOwner.getAreaType()) {
+        case ACTION_ICON:
+        case ACTION_NAME:
+        case TRANSFORM_ICON:
+        case TRANSFORM_NAME:
+          cursor = getDisplay().getSystemCursor(SWT.CURSOR_HAND);
+          break;  
+        default:
+      }
+    }         
+    setCursor(cursor);  
   }
 
   @Override
-  public void mouseUp(MouseEvent e) {
+  public void mouseUp(MouseEvent event) {
     if (viewPortNavigation || viewDrag) {
       viewDrag = false;
       viewPortNavigation = false;
       viewPortStart = null;
     }
+    
+    // Default cursor
+    setCursor(null);  
   }
 
-  public void mouseHover(MouseEvent e) {
+  public void mouseHover(MouseEvent event) {
     // don't do anything for now
   }
 


### PR DESCRIPTION
Adapt mouse cursor to context
- Set hand cursor when hover hop or area that support clicking
- Set move cursor when dragging the view or view port
- Set cross cursor when select a region
Edit transform description when clicking on transform info icon 
Edit transform when clicking on hop additional info icon 
Edit transform when clicking on hop stream target/true/false icon 
Cleanup generic in AreaOwner never used
Deprecate some AreaType
