### PR TITLE
Oracle databases do support prepared statement metadata retrieval #3515

### DIFF
--- a/plugins/databases/oracle/src/main/java/org/apache/hop/databases/oracle/OracleDatabaseMeta.java
+++ b/plugins/databases/oracle/src/main/java/org/apache/hop/databases/oracle/OracleDatabaseMeta.java
@@ -643,7 +643,7 @@ public class OracleDatabaseMeta extends BaseDatabaseMeta implements IDatabase {
    */
   @Override
   public boolean isSupportsPreparedStatementMetadataRetrieval() {
-    return false;
+    return true;
   }
 
   /** @return The maximum number of columns in a database, <=0 means: no known limit */

--- a/plugins/databases/oracle/src/test/java/org/apache/hop/databases/oracle/OracleDatabaseMetaTest.java
+++ b/plugins/databases/oracle/src/test/java/org/apache/hop/databases/oracle/OracleDatabaseMetaTest.java
@@ -222,7 +222,7 @@ public class OracleDatabaseMetaTest {
         "http://download.oracle.com/docs/cd/B19306_01/java.102/b14355/urls.htm#i1006362",
         nativeMeta.getExtraOptionsHelpText());
     assertTrue(nativeMeta.isRequiresCreateTablePrimaryKeyAppend());
-    assertFalse(nativeMeta.isSupportsPreparedStatementMetadataRetrieval());
+    assertTrue(nativeMeta.isSupportsPreparedStatementMetadataRetrieval());
     String quoteTest1 = "FOO 'BAR' \r TEST \n";
     String quoteTest2 = "FOO 'BAR' \\r TEST \\n";
     assertEquals(


### PR DESCRIPTION
Works with Oracle 12.
Low impact, used only in database explorer.