### PR TITLE
fix #3196, fix #3200

### DIFF
--- a/core/src/main/java/org/apache/hop/core/row/value/ValueMetaBase.java
+++ b/core/src/main/java/org/apache/hop/core/row/value/ValueMetaBase.java
@@ -1046,7 +1046,8 @@ public class ValueMetaBase implements IValueMeta {
     if (date == null) {
       return null;
     }
-    return compatibleDateFormat.format(date);
+    // If a date format already exists use it otherwise use the compatible date format
+    return (getDateFormat() != null ? getDateFormat().format(date) : compatibleDateFormat.format(date));
   }
 
   public synchronized Date convertStringToDate(String string) throws HopValueException {


### PR DESCRIPTION
fix #3196 Filter Transform - Date filter forces long date format. Impossible to change on the right side after entry.
fix #3200 If you choose a date format mask when entering a value for the filter transform, your value will not be used for compare corrrectly

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
