### PR TITLE
Action Move Files - Support of tests against Azurite testcontainer or actual Azure on the cloud

### DIFF
--- a/plugins/actions/movefiles/pom.xml
+++ b/plugins/actions/movefiles/pom.xml
@@ -31,4 +31,28 @@
 
     <name>Hop Plugins Actions Move files</name>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>1.19.8</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-storage-blob</artifactId>
+            <version>12.26.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hop</groupId>
+            <artifactId>hop-plugins-tech-azure</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+
+
 </project>

--- a/plugins/actions/movefiles/src/main/java/org/apache/hop/workflow/actions/movefiles/ActionMoveFilesDialog.java
+++ b/plugins/actions/movefiles/src/main/java/org/apache/hop/workflow/actions/movefiles/ActionMoveFilesDialog.java
@@ -348,7 +348,7 @@ public class ActionMoveFilesDialog extends ActionDialog implements IActionDialog
           @Override
           public void widgetSelected(SelectionEvent e) {
 
-            RefreshArgFromPrevious();
+            refreshArgFromPrevious();
           }
         });
     FormData fdSettings = new FormData();
@@ -575,7 +575,7 @@ public class ActionMoveFilesDialog extends ActionDialog implements IActionDialog
     fdFields.bottom = new FormAttachment(100, -margin);
     wFields.setLayoutData(fdFields);
 
-    RefreshArgFromPrevious();
+    refreshArgFromPrevious();
 
     // Add the file to the list of files...
     SelectionAdapter selA =
@@ -1457,7 +1457,7 @@ public class ActionMoveFilesDialog extends ActionDialog implements IActionDialog
     wMovedDateTimeFormat.setEnabled(wSpecifyMoveFormat.getSelection());
   }
 
-  private void RefreshArgFromPrevious() {
+  private void refreshArgFromPrevious() {
 
     wlFields.setEnabled(!wPrevious.getSelection());
     wFields.setEnabled(!wPrevious.getSelection());

--- a/plugins/actions/movefiles/src/test/java/org/apache/hop/workflow/actions/movefiles/AzureMoveFilesIT.java
+++ b/plugins/actions/movefiles/src/test/java/org/apache/hop/workflow/actions/movefiles/AzureMoveFilesIT.java
@@ -1,0 +1,357 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.workflow.actions.movefiles;
+
+import static org.apache.hop.workflow.actions.movefiles.MoveFilesActionHelper.defaultAction;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.specialized.AppendBlobClient;
+import com.microsoft.azure.storage.StorageException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.InvalidKeyException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+import org.apache.hop.core.HopClientEnvironment;
+import org.apache.hop.core.HopEnvironment;
+import org.apache.hop.core.Result;
+import org.apache.hop.core.config.HopConfig;
+import org.apache.hop.core.exception.HopException;
+import org.apache.hop.core.logging.HopLogStore;
+import org.apache.hop.core.vfs.plugin.VfsPluginType;
+import org.apache.hop.junit.rules.RestoreHopEngineEnvironment;
+import org.apache.hop.vfs.azure.config.AzureConfig;
+import org.apache.hop.vfs.azure.config.AzureConfigSingleton;
+import org.apache.hop.workflow.WorkflowMeta;
+import org.apache.hop.workflow.engine.IWorkflowEngine;
+import org.apache.hop.workflow.engines.local.LocalWorkflowEngine;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class AzureMoveFilesIT {
+
+  private static String CONNECTION_STRING;
+  private static String account;
+  private static String key;
+  private static String emulatorUrl;
+  private static Boolean useTestContainer;
+
+  private static final String CONTAINER_NAME = "mycontainer";
+  private static final String ANOTHER_CONTAINER_NAME = "anothercontainer";
+  public static final String AZURITE_DEFAULT_ACCOUNT = "devstoreaccount1";
+  public static final String AZURITE_DEFAULT_KEY =
+      "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+
+  private static BlobServiceClient blobServiceClient;
+
+  private String basePath;
+
+  public AzureMoveFilesIT(String basePath) {
+    this.basePath = basePath;
+  }
+
+  @Parameterized.Parameters
+  public static Collection paths() {
+    return Arrays.asList(new Object[][] {{"azfs:///${currentAccount}/"}, {"azure:///"}});
+  }
+
+  @ClassRule public static RestoreHopEngineEnvironment env = new RestoreHopEngineEnvironment();
+
+  //    @ClassRule
+  //    public static GenericContainer azuriteContainer =
+  //        new GenericContainer<>("mcr.microsoft.com/azure-storage/azurite:3.30.0")
+  //            .withExposedPorts(10000)
+  //
+  //            .withCommand("azurite-blob", "--blobHost", "0.0.0.0", "--loose", "--debug",
+  // "/home/debug.log");
+
+  @BeforeClass
+  public static void init() throws HopException {
+    loadAzureProperties();
+    blobServiceClient =
+        new BlobServiceClientBuilder().connectionString(CONNECTION_STRING).buildClient();
+    blobServiceClient.createBlobContainerIfNotExists(CONTAINER_NAME);
+    blobServiceClient.createBlobContainerIfNotExists(ANOTHER_CONTAINER_NAME);
+    HopClientEnvironment.init(List.of(VfsPluginType.getInstance()));
+    HopEnvironment.init();
+    HopLogStore.init(true, true);
+  }
+
+  @Before
+  public void setup()
+      throws URISyntaxException, InvalidKeyException, StorageException, IOException, HopException {
+    // Retrieve storage account from connection-string.
+    final BlobContainerClient container = blobServiceClient.getBlobContainerClient(CONTAINER_NAME);
+    deleteFiles(CONTAINER_NAME);
+    deleteFiles(ANOTHER_CONTAINER_NAME);
+    if (basePath.contains("${currentAccount}")) {
+      basePath =
+          basePath.replace("${currentAccount}", AzureConfigSingleton.getConfig().getAccount());
+    }
+
+    uploadFileIntoContainer(
+        container.getBlobContainerName(),
+        "artists.csv",
+        "artists2.csv",
+        "alreadythere.csv",
+        "artists3.csv",
+        "artists4.csv",
+        "canbeoverwritten.csv",
+        "artists-wildcard1.csv",
+        "artists-wildcard2.csv");
+  }
+
+  @Test
+  public void whenTargetFileDoesNotExist_thenRenameFile() throws HopException {
+
+    ActionMoveFiles action = defaultAction();
+
+    String fileToRename = getFilePath("artists.csv");
+    action.sourceFileFolder[0] = fileToRename;
+    action.destinationFileFolder[0] = fileToRename + "done";
+
+    action.execute(new Result(), 1);
+
+    assertThatFileExists(CONTAINER_NAME, "artists.csvdone");
+    assertThatFileDoesNotExist(CONTAINER_NAME, "artists.csv");
+  }
+
+  @Test
+  public void whenTargetFileAlreadyExists_thenDoNotRename() throws HopException {
+    ActionMoveFiles action = defaultAction();
+    IWorkflowEngine<WorkflowMeta> parentWorkflow = new LocalWorkflowEngine();
+
+    action.sourceFileFolder[0] = getFilePath("artists2.csv");
+    action.destinationFileFolder[0] = getFilePath("alreadythere.csv");
+
+    action.execute(new Result(), 1);
+
+    assertThatFileExists(CONTAINER_NAME, "artists2.csv");
+    assertThatFileExists(CONTAINER_NAME, "alreadythere.csv");
+  }
+
+  @Test
+  public void whenTargetFileAlreadyExistsAndExplicitlySettingDoNothing_thenDoNotRename()
+      throws HopException {
+
+    ActionMoveFiles action = defaultAction();
+    IWorkflowEngine<WorkflowMeta> parentWorkflow = new LocalWorkflowEngine();
+
+    action.sourceFileFolder[0] = getFilePath("artists2.csv");
+    action.destinationFileFolder[0] = getFilePath("alreadythere.csv");
+    action.setIfFileExists("do_nothing");
+    action.execute(new Result(), 1);
+
+    assertThatFileExists(CONTAINER_NAME, "artists2.csv");
+    assertThatFileExists(CONTAINER_NAME, "alreadythere.csv");
+  }
+
+  @Test
+  public void whenTargetFileAlreadyExistsAndOverwriteIsChosen_thenDoRename() throws HopException {
+
+    ActionMoveFiles action = defaultAction();
+    action.sourceFileFolder[0] = getFilePath("artists3.csv");
+    action.destinationFileFolder[0] = getFilePath("canbeoverwritten.csv");
+    action.setIfFileExists("overwrite_file");
+
+    action.execute(new Result(), 1);
+
+    assertThatFileDoesNotExist(CONTAINER_NAME, "artists3.csv");
+    assertThatFileExists(CONTAINER_NAME, "canbeoverwritten.csv");
+  }
+
+  @Test
+  public void whenDestinationIsFileIsNotFlaggedAndFileSpecifiedAsDestination_shouldNotMove()
+      throws HopException {
+    ActionMoveFiles action = defaultAction();
+    action.sourceFileFolder[0] = getFilePath("artists3.csv");
+    action.destinationFileFolder[0] = getFolderPath();
+    action.setDestinationIsAFile(false);
+
+    action.execute(new Result(), 1);
+
+    assertThatFileExists(CONTAINER_NAME, "artists3.csv");
+    assertThatFileDoesNotExist(ANOTHER_CONTAINER_NAME, "artists3.csv");
+  }
+
+  @Test
+  public void whenCreateDestinationFolderNotFlagged_shouldNotMoveFile() throws HopException {
+    ActionMoveFiles action = defaultAction();
+    action.sourceFileFolder[0] = getFilePath("artists3.csv");
+    action.destinationFileFolder[0] = getFilePath("fakecontainer", "artists-do-not-create-folder");
+    action.setCreateDestinationFolder(false);
+
+    action.execute(new Result(), 1);
+
+    assertThatFileExists(CONTAINER_NAME, "artists3.csv");
+    assertThatFileDoesNotExist("fakecontainer", "artists3.csv");
+  }
+
+  @Test
+  public void whenUseWildCards_thenMoveFiles() throws HopException {
+    ActionMoveFiles action = defaultAction();
+    action.sourceFileFolder[0] = getFolderPath(CONTAINER_NAME);
+    action.destinationFileFolder[0] = getFolderPath(ANOTHER_CONTAINER_NAME);
+    action.wildcard[0] = ".*wildcard.*.csv";
+    action.destinationIsAFile = false;
+    action.execute(new Result(), 1);
+
+    assertThatFileExists(ANOTHER_CONTAINER_NAME, "artists-wildcard1.csv");
+    assertThatFileExists(ANOTHER_CONTAINER_NAME, "artists-wildcard2.csv");
+
+    assertThatFileDoesNotExist(CONTAINER_NAME, "artists-wildcard1.csv");
+    assertThatFileDoesNotExist(CONTAINER_NAME, "artists-wildcard2.csv");
+  }
+
+  @AfterClass
+  public static void shutDown() {
+    // azuriteContainer.stop();
+  }
+
+  private void deleteFiles(String containerName)
+      throws URISyntaxException, InvalidKeyException, StorageException {
+    final BlobContainerClient container = blobServiceClient.getBlobContainerClient(containerName);
+    container.listBlobs().forEach(blob -> container.getBlobClient(blob.getName()).deleteIfExists());
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    // Clean up the Hop environment
+    HopEnvironment.shutdown();
+  }
+
+  private void uploadFileIntoContainer(String containerName, String... fileNames)
+      throws URISyntaxException, StorageException, IOException {
+
+    for (String fileName : fileNames) {
+      BlobServiceClient blobServiceClient =
+          new BlobServiceClientBuilder().connectionString(CONNECTION_STRING).buildClient();
+
+      blobServiceClient.createBlobContainerIfNotExists(containerName);
+      final BlobContainerClient blobContainerClient =
+          blobServiceClient.getBlobContainerClient(CONTAINER_NAME);
+      BlobClient blobClient =
+          blobServiceClient.getBlobContainerClient(containerName).getBlobClient(fileName);
+      AppendBlobClient appendBlobClient = blobClient.getAppendBlobClient();
+      appendBlobClient.create();
+
+      try (OutputStream outputStream = appendBlobClient.getBlobOutputStream()) {
+
+        // Path to the file you want to upload
+        Path filePath = Paths.get("src/test/resources/" + fileName);
+
+        // Write the file to the blob
+        Files.copy(filePath, outputStream);
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+  private void assertThatFileExists(String containerName, String blobName) {
+    // Get a BlobClient object which represents a blob in the container
+    BlobClient blobClient =
+        blobServiceClient.getBlobContainerClient(containerName).getBlobClient(blobName);
+
+    // Get the properties of the blob
+    var blobProperties = blobClient.getProperties();
+
+    // Get the size of the blob
+    long blobSize = blobProperties.getBlobSize();
+
+    assertEquals(true, blobClient.exists());
+    assertTrue(blobSize >= 140);
+  }
+
+  private void assertThatFileDoesNotExist(String containerName, String blobName) {
+    // Get a BlobClient object which represents a blob in the container
+    BlobClient blobClient =
+        blobServiceClient.getBlobContainerClient(containerName).getBlobClient(blobName);
+
+    assertEquals(false, blobClient.exists());
+  }
+
+  private String getFilePath(String filename) {
+    return basePath + CONTAINER_NAME + "/" + filename;
+  }
+
+  private String getFilePath(String container, String filename) {
+    return basePath + container + "/" + filename;
+  }
+
+  private String getFolderPath() {
+    return basePath + ANOTHER_CONTAINER_NAME + "/";
+  }
+
+  private String getFolderPath(String container) {
+    return basePath + container;
+  }
+
+  private static void loadAzureProperties() {
+    Properties prop = new Properties();
+    String host = null; // azuriteContainer.getContainerIpAddress();
+    Integer port = null; // azuriteContainer.getMappedPort(10000);
+    try (InputStream input =
+        AzureMoveFilesIT.class.getClassLoader().getResourceAsStream("azure.properties")) {
+      prop.load(input);
+      useTestContainer = Boolean.parseBoolean(prop.getProperty("testcontainers.enabled", "true"));
+      account = prop.getProperty("account");
+      key = prop.getProperty("key");
+      emulatorUrl = useTestContainer ? String.format("http://%s:%d", host, port) : "";
+      CONNECTION_STRING =
+          useTestContainer
+              ? String.format(
+                  "AccountName=%s;AccountKey=%s;DefaultEndpointsProtocol=http;BlobEndpoint=http://%s:%d;",
+                  AZURITE_DEFAULT_ACCOUNT, AZURITE_DEFAULT_KEY, host, port)
+              : String.format(
+                  "DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;EndpointSuffix=core.windows.net;",
+                  account, key);
+      setAzureConfiguration(account, key, emulatorUrl);
+    } catch (IOException ex) {
+      ex.printStackTrace();
+    }
+  }
+
+  private static void setAzureConfiguration(
+      String accountName, String accountKey, String emulatorUrl) {
+    AzureConfig config = new AzureConfig();
+    config.setAccount(accountName);
+    config.setKey(accountKey);
+    config.setEmulatorUrl(emulatorUrl);
+    HopConfig.getInstance().saveOption("azure", config);
+  }
+}

--- a/plugins/actions/movefiles/src/test/java/org/apache/hop/workflow/actions/movefiles/MoveFilesActionHelper.java
+++ b/plugins/actions/movefiles/src/test/java/org/apache/hop/workflow/actions/movefiles/MoveFilesActionHelper.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.workflow.actions.movefiles;
+
+import org.apache.hop.core.logging.LogLevel;
+import org.apache.hop.workflow.WorkflowMeta;
+import org.apache.hop.workflow.engine.IWorkflowEngine;
+import org.apache.hop.workflow.engines.local.LocalWorkflowEngine;
+import org.mockito.Mockito;
+
+public class MoveFilesActionHelper {
+
+  public static ActionMoveFiles defaultAction() {
+    ActionMoveFiles action = Mockito.spy(new ActionMoveFiles());
+    IWorkflowEngine<WorkflowMeta> parentWorkflow = new LocalWorkflowEngine();
+
+    action.setLogLevel(LogLevel.BASIC);
+    action.setParentWorkflow(parentWorkflow);
+    action.setName("Test move same container");
+    action.setIncludeSubfolders(false);
+    action.setAddDate(false);
+    action.setMoveEmptyFolders(false);
+    action.setSimulate(false);
+    action.setArgFromPrevious(false);
+    action.allocate(1);
+    action.setDestinationIsAFile(true);
+    return action;
+  }
+}

--- a/plugins/actions/movefiles/src/test/resources/alreadythere.csv
+++ b/plugins/actions/movefiles/src/test/resources/alreadythere.csv
@@ -1,0 +1,9 @@
+1,ABBA,1992
+2,Roxette,1986
+3,Europe,1979
+4,The Cardigans,1992
+1,ABBA,1992
+2,Roxette,1986
+3,Europe,1979
+4,The Cardigans,1992
+5,Sergio's,1980

--- a/plugins/actions/movefiles/src/test/resources/artists-wildcard1.csv
+++ b/plugins/actions/movefiles/src/test/resources/artists-wildcard1.csv
@@ -1,0 +1,18 @@
+1,ABBA,1992
+2,Roxette,1986
+3,Europe,1979
+4,The Cardigans,1992
+1,ABBA,1992
+2,Roxette,1986
+3,Europe,1979
+4,The Cardigans,1992
+5,Sergio's,1980
+1,ABBA,1992
+2,Roxette,1986
+3,Europe,1979
+4,The Cardigans,1992
+1,ABBA,1992
+2,Roxette,1986
+3,Europe,1979
+4,The Cardigans,1992
+5,Sergio's,1980

--- a/plugins/actions/movefiles/src/test/resources/artists-wildcard2.csv
+++ b/plugins/actions/movefiles/src/test/resources/artists-wildcard2.csv
@@ -1,0 +1,18 @@
+1,ABBA,1992
+2,Roxette,1986
+3,Europe,1979
+4,The Cardigans,1992
+1,ABBA,1992
+2,Roxette,1986
+3,Europe,1979
+4,The Cardigans,1992
+5,Sergio's,1980
+1,ABBA,1992
+2,Roxette,1986
+3,Europe,1979
+4,The Cardigans,1992
+1,ABBA,1992
+2,Roxette,1986
+3,Europe,1979
+4,The Cardigans,1992
+5,Sergio's,1980

--- a/plugins/actions/movefiles/src/test/resources/artists.csv
+++ b/plugins/actions/movefiles/src/test/resources/artists.csv
@@ -1,0 +1,9 @@
+1,ABBA,1992
+2,Roxette,1986
+3,Europe,1979
+4,The Cardigans,1992
+1,ABBA,1992
+2,Roxette,1986
+3,Europe,1979
+4,The Cardigans,1992
+5,Sergio's,1980

--- a/plugins/actions/movefiles/src/test/resources/artists2.csv
+++ b/plugins/actions/movefiles/src/test/resources/artists2.csv
@@ -1,0 +1,9 @@
+1,ABBA,1992
+2,Roxette,1986
+3,Europe,1979
+4,The Cardigans,1992
+1,ABBA,1992
+2,Roxette,1986
+3,Europe,1979
+4,The Cardigans,1992
+5,Sergio's,1980

--- a/plugins/actions/movefiles/src/test/resources/artists3.csv
+++ b/plugins/actions/movefiles/src/test/resources/artists3.csv
@@ -1,0 +1,9 @@
+1,ABBA,1992
+2,Roxette,1986
+3,Europe,1979
+4,The Cardigans,1992
+1,ABBA,1992
+2,Roxette,1986
+3,Europe,1979
+4,The Cardigans,1992
+5,Sergio's,1980

--- a/plugins/actions/movefiles/src/test/resources/artists4.csv
+++ b/plugins/actions/movefiles/src/test/resources/artists4.csv
@@ -1,0 +1,18 @@
+1,ABBA,1992
+2,Roxette,1986
+3,Europe,1979
+4,The Cardigans,1992
+1,ABBA,1992
+2,Roxette,1986
+3,Europe,1979
+4,The Cardigans,1992
+5,Sergio's,1980
+1,ABBA,1992
+2,Roxette,1986
+3,Europe,1979
+4,The Cardigans,1992
+1,ABBA,1992
+2,Roxette,1986
+3,Europe,1979
+4,The Cardigans,1992
+5,Sergio's,1980

--- a/plugins/actions/movefiles/src/test/resources/azure.properties
+++ b/plugins/actions/movefiles/src/test/resources/azure.properties
@@ -1,0 +1,31 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# If you run tests against Azurite Test container, uncomment the following lines
+# Please notice that the credentials below are the default credentials for Azurite, so there's no security issue nor need to change them. Just uncomment.
+#testcontainers.enabled=true
+#account=devstoreaccount1
+#key=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBk8XYpW1qQ==
+
+
+#If you want to run these tests against a real Azure Storage account,
+# you can provide the account name and key here. Also disable testcontainers by setting testcontainers.enabled=false
+#Otherwise, use the commented settings above to run the tests against the emulator
+
+testcontainers.enabled=false
+account=your_account
+key=your_key

--- a/plugins/actions/movefiles/src/test/resources/canbeoverwritten.csv
+++ b/plugins/actions/movefiles/src/test/resources/canbeoverwritten.csv
@@ -1,0 +1,9 @@
+1,ABBA,1992
+2,Roxette,1986
+3,Europe,1979
+4,The Cardigans,1992
+1,ABBA,1992
+2,Roxette,1986
+3,Europe,1979
+4,The Cardigans,1992
+5,Sergio's,1980

--- a/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/AzureFileObject.java
+++ b/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/AzureFileObject.java
@@ -449,6 +449,11 @@ public class AzureFileObject extends AbstractFileObject<AzureFileSystem> {
   }
 
   @Override
+  public FileObject[] getChildren() throws FileSystemException {
+    return super.getChildren();
+  }
+
+  @Override
   protected long doGetContentSize() throws Exception {
     return size;
   }

--- a/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/AzureFileProvider.java
+++ b/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/AzureFileProvider.java
@@ -30,6 +30,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.vfs2.Capability;
 import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystem;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemOptions;
@@ -131,6 +132,19 @@ public class AzureFileProvider extends AbstractOriginatingFileProvider {
     }
 
     return new AzureFileSystem((AzureFileName) fileName, service, fsOptions, account);
+  }
+
+  @Override
+  public FileObject findFile(
+      FileObject baseFileObject, String uri, FileSystemOptions fileSystemOptions)
+      throws FileSystemException {
+    return super.findFile(baseFileObject, uri, fileSystemOptions);
+  }
+
+  @Override
+  protected FileObject findFile(FileName fileName, FileSystemOptions fileSystemOptions)
+      throws FileSystemException {
+    return super.findFile(fileName, fileSystemOptions);
   }
 
   @Override


### PR DESCRIPTION
Fixes #3988 

The original idea was to use Azurite Testcontainer to mimic the behaviour of Azure.
Unfortunately, the latest version of Azurite is not fully compatible with the latest versions of the Azure Blob Storage Java library (neither the other tries with older version worked, but for different exceptions).

For this reason, we assumed that, sooner or later, such incompatibilities will be fixed, so we provided the possibility to skip testcontainers and test against a real Azure account.

See the instructions in the `azure.properties` file
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
