### PR TITLE
fix #4063 - StorageException while writing large parquet files to ADLSv2

### DIFF
--- a/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/BlobInputStream.java
+++ b/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/BlobInputStream.java
@@ -18,17 +18,17 @@
 
 package org.apache.hop.vfs.azure;
 
-import com.microsoft.azure.storage.blob.BlobInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-public class AppendBlobInputStream extends InputStream {
+public class BlobInputStream extends InputStream {
 
-  private BlobInputStream inputStream;
+  private com.microsoft.azure.storage.blob.BlobInputStream inputStream;
   private long fileSize;
   private long totalRead = 0;
 
-  public AppendBlobInputStream(BlobInputStream inputStream, long fileSize) {
+  public BlobInputStream(
+      com.microsoft.azure.storage.blob.BlobInputStream inputStream, long fileSize) {
     this.inputStream = inputStream;
     this.fileSize = fileSize;
   }


### PR DESCRIPTION
fix #4063 - StorageException while writing large parquet files to ADLSv2

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
