### PR TITLE
Multi account Azure VFS #4062

### DIFF
--- a/core/src/main/java/org/apache/hop/core/fileinput/FileInputList.java
+++ b/core/src/main/java/org/apache/hop/core/fileinput/FileInputList.java
@@ -203,7 +203,7 @@ public class FileInputList {
       }
 
       try {
-        FileObject directoryFileObject = HopVfs.getFileObject(oneFile);
+        FileObject directoryFileObject = HopVfs.getFileObject(oneFile, variables);
         boolean processFolder = true;
         if (oneRequired) {
           if (!directoryFileObject.exists()) {
@@ -293,7 +293,7 @@ public class FileInputList {
             }
             // We don't sort here, keep the order of the files in the archive.
           } else {
-            FileObject fileObject = HopVfs.getFileObject(oneFile);
+            FileObject fileObject = HopVfs.getFileObject(oneFile, variables);
             if (fileObject.exists()) {
               if (fileObject.isReadable()) {
                 fileInputList.addFile(fileObject);
@@ -336,7 +336,7 @@ public class FileInputList {
         continue;
       }
 
-      try (FileObject directoryFileObject = HopVfs.getFileObject(oneFile)) {
+      try (FileObject directoryFileObject = HopVfs.getFileObject(oneFile, variables)) {
         // Find all folder names in this directory
         //
         if (directoryFileObject != null

--- a/core/src/main/java/org/apache/hop/core/vfs/plugin/IVfs.java
+++ b/core/src/main/java/org/apache/hop/core/vfs/plugin/IVfs.java
@@ -17,10 +17,14 @@
 
 package org.apache.hop.core.vfs.plugin;
 
+import java.util.Map;
 import org.apache.commons.vfs2.provider.FileProvider;
+import org.apache.hop.core.variables.IVariables;
 
 public interface IVfs {
   String[] getUrlSchemes();
 
   FileProvider getProvider();
+
+  Map<String, FileProvider> getProviders(IVariables variables);
 }

--- a/core/src/test/java/org/apache/hop/core/vfs/HopVfsTest.java
+++ b/core/src/test/java/org/apache/hop/core/vfs/HopVfsTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.hop.core.exception.HopFileException;
+import org.apache.hop.core.variables.Variables;
 import org.junit.Test;
 
 public class HopVfsTest {
@@ -36,11 +37,11 @@ public class HopVfsTest {
   public void testStartsWithScheme() {
     String fileName =
         "zip:file:///SavedLinkedres.zip!Calculate median and percentiles using the group by transforms.hpl";
-    assertTrue(HopVfs.startsWithScheme(fileName));
+    assertTrue(HopVfs.startsWithScheme(fileName, new Variables()));
 
     fileName =
         "SavedLinkedres.zip!Calculate median and percentiles using the group by transforms.hpl";
-    assertFalse(HopVfs.startsWithScheme(fileName));
+    assertFalse(HopVfs.startsWithScheme(fileName, new Variables()));
   }
 
   @Test

--- a/engine/src/main/java/org/apache/hop/pipeline/transforms/file/BaseFileInputTransform.java
+++ b/engine/src/main/java/org/apache/hop/pipeline/transforms/file/BaseFileInputTransform.java
@@ -290,7 +290,7 @@ public abstract class BaseFileInputTransform<
       }
       String fileValue = prevInfoFields.getString(fileRow, idx);
       try {
-        FileObject fileObject = HopVfs.getFileObject(fileValue);
+        FileObject fileObject = HopVfs.getFileObject(fileValue, variables);
         data.files.addFile(fileObject);
         if (meta.inputFiles.passingThruFields) {
           StringBuilder sb = new StringBuilder();

--- a/engine/src/test/java/org/apache/hop/utils/TestUtils.java
+++ b/engine/src/test/java/org/apache/hop/utils/TestUtils.java
@@ -73,7 +73,7 @@ public class TestUtils {
       variables.initializeFrom(null);
     }
     try {
-      FileObject file = HopVfs.getFileObject("ram://" + path);
+      FileObject file = HopVfs.getFileObject("ram://" + path, variables);
       file.createFile();
       return file.getName().getURI();
     } catch (FileSystemException | HopFileException e) {
@@ -91,7 +91,7 @@ public class TestUtils {
       variables.initializeFrom(null);
     }
     try {
-      return HopVfs.getFileObject(vfsPath);
+      return HopVfs.getFileObject(vfsPath, variables);
     } catch (HopFileException e) {
       throw new RuntimeException(e);
     }

--- a/plugins/actions/checkfilelocked/src/main/java/org/apache/hop/workflow/actions/checkfilelocked/ActionCheckFilesLocked.java
+++ b/plugins/actions/checkfilelocked/src/main/java/org/apache/hop/workflow/actions/checkfilelocked/ActionCheckFilesLocked.java
@@ -228,7 +228,7 @@ public class ActionCheckFilesLocked extends ActionBase implements Cloneable, IAc
     for (int i = 0; i < files.length && !oneFileLocked; i++) {
       FileObject file = files[i];
       String filename = HopVfs.getFilename(file);
-      LockFile locked = new LockFile(filename);
+      LockFile locked = new LockFile(filename, getVariables());
       if (locked.isLocked()) {
         oneFileLocked = true;
         logError(BaseMessages.getString(PKG, "ActionCheckFilesLocked.Log.FileLocked", filename));

--- a/plugins/actions/checkfilelocked/src/main/java/org/apache/hop/workflow/actions/checkfilelocked/ActionCheckFilesLocked.java
+++ b/plugins/actions/checkfilelocked/src/main/java/org/apache/hop/workflow/actions/checkfilelocked/ActionCheckFilesLocked.java
@@ -181,7 +181,7 @@ public class ActionCheckFilesLocked extends ActionBase implements Cloneable, IAc
     String realFileFolderName = resolve(name);
     String realWildcard = resolve(wildcard);
 
-    try (FileObject fileFolder = HopVfs.getFileObject(realFileFolderName)) {
+    try (FileObject fileFolder = HopVfs.getFileObject(realFileFolderName, getVariables())) {
       FileObject[] files = new FileObject[] {fileFolder};
       if (fileFolder.exists()) {
         // the file or folder exists

--- a/plugins/actions/checkfilelocked/src/main/java/org/apache/hop/workflow/actions/checkfilelocked/LockFile.java
+++ b/plugins/actions/checkfilelocked/src/main/java/org/apache/hop/workflow/actions/checkfilelocked/LockFile.java
@@ -19,6 +19,7 @@ package org.apache.hop.workflow.actions.checkfilelocked;
 
 import org.apache.commons.vfs2.FileObject;
 import org.apache.hop.core.exception.HopException;
+import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.core.vfs.HopVfs;
 
 public class LockFile {
@@ -36,7 +37,7 @@ public class LockFile {
    * @param filename
    * @throws HopException
    */
-  public LockFile(String filename) throws HopException {
+  public LockFile(String filename, IVariables variables) throws HopException {
     setFilename(filename);
     setLocked(false);
 
@@ -47,9 +48,9 @@ public class LockFile {
 
     try {
 
-      file = HopVfs.getFileObject(filename);
+      file = HopVfs.getFileObject(filename, variables);
       if (file.exists()) {
-        dummyfile = HopVfs.getFileObject(filename);
+        dummyfile = HopVfs.getFileObject(filename, variables);
         // move file to itself!
         file.moveTo(dummyfile);
       }

--- a/plugins/actions/copyfiles/src/main/java/org/apache/hop/workflow/actions/copyfiles/ActionCopyFiles.java
+++ b/plugins/actions/copyfiles/src/main/java/org/apache/hop/workflow/actions/copyfiles/ActionCopyFiles.java
@@ -322,8 +322,9 @@ public class ActionCopyFiles extends ActionBase implements Cloneable, IAction {
                   BaseMessages.getString(
                       PKG,
                       "ActionCopyFiles.Log.ProcessingRow",
-                      HopVfs.getFriendlyURI(resolve(vSourceFileFolderPrevious)),
-                      HopVfs.getFriendlyURI(resolve(vDestinationFileFolderPrevious)),
+                      HopVfs.getFriendlyURI(resolve(vSourceFileFolderPrevious), getVariables()),
+                      HopVfs.getFriendlyURI(
+                          resolve(vDestinationFileFolderPrevious), getVariables()),
                       resolve(vWildcardPrevious)));
             }
 
@@ -342,8 +343,9 @@ public class ActionCopyFiles extends ActionBase implements Cloneable, IAction {
                   BaseMessages.getString(
                       PKG,
                       "ActionCopyFiles.Log.IgnoringRow",
-                      HopVfs.getFriendlyURI(resolve(vSourceFileFolder[iteration])),
-                      HopVfs.getFriendlyURI(resolve(vDestinationFileFolder[iteration])),
+                      HopVfs.getFriendlyURI(resolve(vSourceFileFolder[iteration]), getVariables()),
+                      HopVfs.getFriendlyURI(
+                          resolve(vDestinationFileFolder[iteration]), getVariables()),
                       vwildcard[iteration]));
             }
           }
@@ -359,8 +361,8 @@ public class ActionCopyFiles extends ActionBase implements Cloneable, IAction {
                   BaseMessages.getString(
                       PKG,
                       "ActionCopyFiles.Log.ProcessingRow",
-                      HopVfs.getFriendlyURI(resolve(vSourceFileFolder[i])),
-                      HopVfs.getFriendlyURI(resolve(vDestinationFileFolder[i])),
+                      HopVfs.getFriendlyURI(resolve(vSourceFileFolder[i]), getVariables()),
+                      HopVfs.getFriendlyURI(resolve(vDestinationFileFolder[i]), getVariables()),
                       resolve(vwildcard[i])));
             }
 
@@ -379,8 +381,8 @@ public class ActionCopyFiles extends ActionBase implements Cloneable, IAction {
                   BaseMessages.getString(
                       PKG,
                       "ActionCopyFiles.Log.IgnoringRow",
-                      HopVfs.getFriendlyURI(resolve(vSourceFileFolder[i])),
-                      HopVfs.getFriendlyURI(resolve(vDestinationFileFolder[i])),
+                      HopVfs.getFriendlyURI(resolve(vSourceFileFolder[i]), getVariables()),
+                      HopVfs.getFriendlyURI(resolve(vDestinationFileFolder[i]), getVariables()),
                       vwildcard[i]));
             }
           }
@@ -423,8 +425,8 @@ public class ActionCopyFiles extends ActionBase implements Cloneable, IAction {
     String realWildcard = resolve(wildcard);
 
     try {
-      sourceFileFolder = HopVfs.getFileObject(realSourceFileFolderName);
-      destinationFileFolder = HopVfs.getFileObject(realDestinationFileFolderName);
+      sourceFileFolder = HopVfs.getFileObject(realSourceFileFolderName, getVariables());
+      destinationFileFolder = HopVfs.getFileObject(realDestinationFileFolderName, getVariables());
 
       if (sourceFileFolder.exists()) {
 
@@ -442,8 +444,8 @@ public class ActionCopyFiles extends ActionBase implements Cloneable, IAction {
                 BaseMessages.getString(
                     PKG,
                     "ActionCopyFiles.Log.CanNotCopyFolderToFile",
-                    HopVfs.getFriendlyURI(realSourceFileFolderName),
-                    HopVfs.getFriendlyURI(realDestinationFileFolderName)));
+                    HopVfs.getFriendlyURI(realSourceFileFolderName, getVariables()),
+                    HopVfs.getFriendlyURI(realDestinationFileFolderName, getVariables())));
 
             nbrFail++;
 
@@ -515,7 +517,7 @@ public class ActionCopyFiles extends ActionBase implements Cloneable, IAction {
                 // Unable to retrieve file through existing connection; Get the file through a new
                 // VFS connection
                 if (removeFile == null) {
-                  removeFile = HopVfs.getFileObject(fileremoventry);
+                  removeFile = HopVfs.getFileObject(fileremoventry, getVariables());
                 }
 
                 // Remove ONLY Files
@@ -528,7 +530,7 @@ public class ActionCopyFiles extends ActionBase implements Cloneable, IAction {
                             + BaseMessages.getString(
                                 PKG,
                                 "ActionCopyFiles.Error.Exception.CanRemoveFileFolder",
-                                HopVfs.getFriendlyURI(fileremoventry)));
+                                HopVfs.getFriendlyURI(fileremoventry, getVariables())));
                   } else {
                     if (isDetailed()) {
                       logDetailed(
@@ -536,7 +538,7 @@ public class ActionCopyFiles extends ActionBase implements Cloneable, IAction {
                               + BaseMessages.getString(
                                   PKG,
                                   "ActionCopyFiles.Log.FileFolderRemoved",
-                                  HopVfs.getFriendlyURI(fileremoventry)));
+                                  HopVfs.getFriendlyURI(fileremoventry, getVariables())));
                     }
                   }
                 }
@@ -564,7 +566,7 @@ public class ActionCopyFiles extends ActionBase implements Cloneable, IAction {
                 // Unable to retrieve file through existing connection; Get the file through a new
                 // VFS connection
                 if (addFile == null) {
-                  addFile = HopVfs.getFileObject(fileaddentry);
+                  addFile = HopVfs.getFileObject(fileaddentry, getVariables());
                 }
 
                 // Add ONLY Files
@@ -583,7 +585,7 @@ public class ActionCopyFiles extends ActionBase implements Cloneable, IAction {
                             + BaseMessages.getString(
                                 PKG,
                                 "ActionCopyFiles.Log.FileAddedToResultFilesName",
-                                HopVfs.getFriendlyURI(fileaddentry)));
+                                HopVfs.getFriendlyURI(fileaddentry, getVariables())));
                   }
                 }
               }
@@ -596,14 +598,14 @@ public class ActionCopyFiles extends ActionBase implements Cloneable, IAction {
               BaseMessages.getString(
                   PKG,
                   "ActionCopyFiles.Error.DestinationFolderNotFound",
-                  HopVfs.getFriendlyURI(realDestinationFileFolderName)));
+                  HopVfs.getFriendlyURI(realDestinationFileFolderName, getVariables())));
         }
       } else {
         logError(
             BaseMessages.getString(
                 PKG,
                 "ActionCopyFiles.Error.SourceFileNotExists",
-                HopVfs.getFriendlyURI(realSourceFileFolderName)));
+                HopVfs.getFriendlyURI(realSourceFileFolderName, getVariables())));
       }
     } catch (FileSystemException fse) {
       logError(
@@ -617,8 +619,8 @@ public class ActionCopyFiles extends ActionBase implements Cloneable, IAction {
           BaseMessages.getString(
               PKG,
               CONST_COPY_PROCESS,
-              HopVfs.getFriendlyURI(realSourceFileFolderName),
-              HopVfs.getFriendlyURI(realDestinationFileFolderName),
+              HopVfs.getFriendlyURI(realSourceFileFolderName, getVariables()),
+              HopVfs.getFriendlyURI(realDestinationFileFolderName, getVariables()),
               e.getMessage()),
           e);
     } finally {
@@ -825,7 +827,7 @@ public class ActionCopyFiles extends ActionBase implements Cloneable, IAction {
           // Built destination filename
           if (destinationFolderObject == null) {
             // Resolve the destination folder
-            destinationFolderObject = HopVfs.getFileObject(destinationFolder);
+            destinationFolderObject = HopVfs.getFileObject(destinationFolder, getVariables());
           }
 
           String fullName = info.getFile().toString();
@@ -963,7 +965,8 @@ public class ActionCopyFiles extends ActionBase implements Cloneable, IAction {
             } else {
               // file...Check if exists
               filename =
-                  HopVfs.getFileObject(destinationFolder + Const.FILE_SEPARATOR + shortFilename);
+                  HopVfs.getFileObject(
+                      destinationFolder + Const.FILE_SEPARATOR + shortFilename, getVariables());
 
               if (getFileWildcard(shortFilename)) {
                 if ((filename == null) || (!filename.exists())) {
@@ -1096,12 +1099,14 @@ public class ActionCopyFiles extends ActionBase implements Cloneable, IAction {
             // check if the file exists
             filename = destfolder + Const.FILE_SEPARATOR + filename;
 
-            if (HopVfs.getFileObject(filename).exists()) {
+            if (HopVfs.getFileObject(filename, getVariables()).exists()) {
               if (isDetailed()) {
                 logDetailed(
                     CONST_SPACE_SHORT
                         + BaseMessages.getString(
-                            PKG, CONST_FILE_EXISTS, HopVfs.getFriendlyURI(filename)));
+                            PKG,
+                            CONST_FILE_EXISTS,
+                            HopVfs.getFriendlyURI(filename, getVariables())));
               }
 
               if (overwriteFiles) {
@@ -1112,7 +1117,7 @@ public class ActionCopyFiles extends ActionBase implements Cloneable, IAction {
                               PKG,
                               "ActionCopyFiles.Log.FileOverwrite",
                               HopVfs.getFriendlyURI(info.getFile()),
-                              HopVfs.getFriendlyURI(filename)));
+                              HopVfs.getFriendlyURI(filename, getVariables())));
                 }
 
                 resultat = true;
@@ -1125,7 +1130,7 @@ public class ActionCopyFiles extends ActionBase implements Cloneable, IAction {
                             PKG,
                             CONST_FILE_COPIED,
                             HopVfs.getFriendlyURI(info.getFile()),
-                            HopVfs.getFriendlyURI(filename)));
+                            HopVfs.getFriendlyURI(filename, getVariables())));
               }
 
               resultat = true;
@@ -1141,7 +1146,7 @@ public class ActionCopyFiles extends ActionBase implements Cloneable, IAction {
 
           if (resultat && addResultFilenames) {
             // add this folder/file to result files name
-            listAddResult.add(HopVfs.getFileObject(filename).toString());
+            listAddResult.add(HopVfs.getFileObject(filename, getVariables()).toString());
           }
         }
       } catch (Exception e) {
@@ -1150,7 +1155,7 @@ public class ActionCopyFiles extends ActionBase implements Cloneable, IAction {
                 PKG,
                 CONST_COPY_PROCESS,
                 HopVfs.getFriendlyURI(info.getFile()),
-                HopVfs.getFriendlyURI(filename),
+                HopVfs.getFriendlyURI(filename, getVariables()),
                 e.getMessage()));
 
         resultat = false;
@@ -1221,7 +1226,7 @@ public class ActionCopyFiles extends ActionBase implements Cloneable, IAction {
     String path = null;
     try {
       String noVariablesURL = incomingURL.replaceAll("[${}]", "/");
-      FileName fileName = HopVfs.getFileSystemManager().resolveURI(noVariablesURL);
+      FileName fileName = HopVfs.getFileSystemManager(getVariables()).resolveURI(noVariablesURL);
       String root = fileName.getRootURI();
       path = incomingURL.substring(root.length() - 1);
     } catch (FileSystemException e) {

--- a/plugins/actions/copyfiles/src/main/java/org/apache/hop/workflow/actions/copyfiles/ActionCopyFiles.java
+++ b/plugins/actions/copyfiles/src/main/java/org/apache/hop/workflow/actions/copyfiles/ActionCopyFiles.java
@@ -618,7 +618,7 @@ public class ActionCopyFiles extends ActionBase implements Cloneable, IAction {
       logError(
           BaseMessages.getString(
               PKG,
-              CONST_COPY_PROCESS,
+              "ActionCopyFiles.Error.Exception.CopyProcess",
               HopVfs.getFriendlyURI(realSourceFileFolderName, getVariables()),
               HopVfs.getFriendlyURI(realDestinationFileFolderName, getVariables()),
               e.getMessage()),
@@ -1105,7 +1105,7 @@ public class ActionCopyFiles extends ActionBase implements Cloneable, IAction {
                     CONST_SPACE_SHORT
                         + BaseMessages.getString(
                             PKG,
-                            CONST_FILE_EXISTS,
+                            "ActionCopyFiles.Log.FileExists",
                             HopVfs.getFriendlyURI(filename, getVariables())));
               }
 

--- a/plugins/actions/createfile/src/main/java/org/apache/hop/workflow/actions/createfile/ActionCreateFile.java
+++ b/plugins/actions/createfile/src/main/java/org/apache/hop/workflow/actions/createfile/ActionCreateFile.java
@@ -132,7 +132,7 @@ public class ActionCreateFile extends ActionBase implements Cloneable, IAction {
       String realFilename = getRealFilename();
       FileObject fileObject = null;
       try {
-        fileObject = HopVfs.getFileObject(realFilename);
+        fileObject = HopVfs.getFileObject(realFilename, getVariables());
 
         if (fileObject.exists()) {
           if (isFailIfFileExists()) {
@@ -184,7 +184,7 @@ public class ActionCreateFile extends ActionBase implements Cloneable, IAction {
       throws HopException {
     FileObject targetFile = null;
     try {
-      targetFile = HopVfs.getFileObject(targetFilename);
+      targetFile = HopVfs.getFileObject(targetFilename, getVariables());
 
       // Add to the result files...
       ResultFile resultFile =

--- a/plugins/actions/createfolder/src/main/java/org/apache/hop/workflow/actions/createfolder/ActionCreateFolder.java
+++ b/plugins/actions/createfolder/src/main/java/org/apache/hop/workflow/actions/createfolder/ActionCreateFolder.java
@@ -89,7 +89,7 @@ public class ActionCreateFolder extends ActionBase implements Cloneable, IAction
     }
 
     String realFolderName = getRealFolderName();
-    try (FileObject folderObject = HopVfs.getFileObject(realFolderName)) {
+    try (FileObject folderObject = HopVfs.getFileObject(realFolderName, getVariables())) {
 
       if (folderObject.exists()) {
         boolean isFolder = folderObject.getType() == FileType.FOLDER;

--- a/plugins/actions/deletefile/src/main/java/org/apache/hop/workflow/actions/deletefile/ActionDeleteFile.java
+++ b/plugins/actions/deletefile/src/main/java/org/apache/hop/workflow/actions/deletefile/ActionDeleteFile.java
@@ -107,7 +107,7 @@ public class ActionDeleteFile extends ActionBase implements Cloneable, IAction {
 
       FileObject fileObject = null;
       try {
-        fileObject = HopVfs.getFileObject(realFilename);
+        fileObject = HopVfs.getFileObject(realFilename, getVariables());
 
         if (!fileObject.exists()) {
           if (isFailIfFileNotExists()) {

--- a/plugins/actions/deletefiles/src/main/java/org/apache/hop/workflow/actions/deletefiles/ActionDeleteFiles.java
+++ b/plugins/actions/deletefiles/src/main/java/org/apache/hop/workflow/actions/deletefiles/ActionDeleteFiles.java
@@ -259,7 +259,7 @@ public class ActionDeleteFiles extends ActionBase implements Cloneable, IAction 
     FileObject fileFolder = null;
 
     try {
-      fileFolder = HopVfs.getFileObject(path);
+      fileFolder = HopVfs.getFileObject(path, getVariables());
 
       if (fileFolder.exists()) {
         if (fileFolder.getType() == FileType.FOLDER) {

--- a/plugins/actions/evalfilesmetrics/src/main/java/org/apache/hop/workflow/actions/evalfilesmetrics/ActionEvalFilesMetrics.java
+++ b/plugins/actions/evalfilesmetrics/src/main/java/org/apache/hop/workflow/actions/evalfilesmetrics/ActionEvalFilesMetrics.java
@@ -793,7 +793,7 @@ public class ActionEvalFilesMetrics extends ActionBase implements Cloneable, IAc
     final boolean includeSubFolders = YES.equalsIgnoreCase(includeSubfolders);
 
     try {
-      sourcefilefolder = HopVfs.getFileObject(realSourceFilefoldername);
+      sourcefilefolder = HopVfs.getFileObject(realSourceFilefoldername, getVariables());
 
       if (sourcefilefolder.exists()) {
         // File exists

--- a/plugins/actions/filecompare/src/main/java/org/apache/hop/workflow/actions/filecompare/ActionFileCompare.java
+++ b/plugins/actions/filecompare/src/main/java/org/apache/hop/workflow/actions/filecompare/ActionFileCompare.java
@@ -115,10 +115,12 @@ public class ActionFileCompare extends ActionBase implements Cloneable, IAction 
     try {
       in1 =
           new DataInputStream(
-              new BufferedInputStream(HopVfs.getInputStream(HopVfs.getFilename(file1))));
+              new BufferedInputStream(
+                  HopVfs.getInputStream(HopVfs.getFilename(file1), getVariables())));
       in2 =
           new DataInputStream(
-              new BufferedInputStream(HopVfs.getInputStream(HopVfs.getFilename(file2))));
+              new BufferedInputStream(
+                  HopVfs.getInputStream(HopVfs.getFilename(file2), getVariables())));
 
       char ch1;
       char ch2;
@@ -167,8 +169,8 @@ public class ActionFileCompare extends ActionBase implements Cloneable, IAction 
     try {
       if (filename1 != null && filename2 != null) {
 
-        file1 = HopVfs.getFileObject(realFilename1);
-        file2 = HopVfs.getFileObject(realFilename2);
+        file1 = HopVfs.getFileObject(realFilename1, getVariables());
+        file2 = HopVfs.getFileObject(realFilename2, getVariables());
 
         if (file1.exists() && file2.exists()) {
           if (equalFileContents(file1, file2)) {

--- a/plugins/actions/fileexists/src/main/java/org/apache/hop/workflow/actions/fileexists/ActionFileExists.java
+++ b/plugins/actions/fileexists/src/main/java/org/apache/hop/workflow/actions/fileexists/ActionFileExists.java
@@ -102,7 +102,7 @@ public class ActionFileExists extends ActionBase implements Cloneable, IAction {
 
       String realFilename = getRealFilename();
       try {
-        FileObject file = HopVfs.getFileObject(realFilename);
+        FileObject file = HopVfs.getFileObject(realFilename, getVariables());
         if (file.exists() && file.isReadable()) {
           logDetailed(BaseMessages.getString(PKG, "ActionFileExists.File_Exists", realFilename));
           result.setResult(true);
@@ -185,7 +185,7 @@ public class ActionFileExists extends ActionBase implements Cloneable, IAction {
         // From : ${FOLDER}/../foo/bar.csv
         // To : /home/matt/test/files/foo/bar.csv
         //
-        FileObject fileObject = HopVfs.getFileObject(variables.resolve(filename));
+        FileObject fileObject = HopVfs.getFileObject(variables.resolve(filename), getVariables());
 
         // If the file doesn't exist, forget about this effort too!
         //

--- a/plugins/actions/filesexist/src/main/java/org/apache/hop/workflow/actions/filesexist/ActionFilesExist.java
+++ b/plugins/actions/filesexist/src/main/java/org/apache/hop/workflow/actions/filesexist/ActionFilesExist.java
@@ -155,7 +155,7 @@ public class ActionFilesExist extends ActionBase implements Cloneable, IAction {
 
         try {
           String realFilefoldername = resolve(arguments[i]);
-          file = HopVfs.getFileObject(realFilefoldername);
+          file = HopVfs.getFileObject(realFilefoldername, getVariables());
 
           if (file.exists()
               && file.isReadable()) { // TODO: is it needed to check file for readability?

--- a/plugins/actions/folderisempty/src/main/java/org/apache/hop/workflow/actions/folderisempty/ActionFolderIsEmpty.java
+++ b/plugins/actions/folderisempty/src/main/java/org/apache/hop/workflow/actions/folderisempty/ActionFolderIsEmpty.java
@@ -154,7 +154,7 @@ public class ActionFolderIsEmpty extends ActionBase implements Cloneable, IActio
       String realFoldername = getRealFolderName();
       FileObject folderObject = null;
       try {
-        folderObject = HopVfs.getFileObject(realFoldername);
+        folderObject = HopVfs.getFileObject(realFoldername, getVariables());
         if (folderObject.exists()) {
           // Check if it's a folder
           if (folderObject.getType() == FileType.FOLDER) {

--- a/plugins/actions/folderscompare/src/main/java/org/apache/hop/workflow/actions/folderscompare/ActionFoldersCompare.java
+++ b/plugins/actions/folderscompare/src/main/java/org/apache/hop/workflow/actions/folderscompare/ActionFoldersCompare.java
@@ -208,10 +208,12 @@ public class ActionFoldersCompare extends ActionBase implements Cloneable, IActi
 
       in1 =
           new DataInputStream(
-              new BufferedInputStream(HopVfs.getInputStream(HopVfs.getFilename(file1))));
+              new BufferedInputStream(
+                  HopVfs.getInputStream(HopVfs.getFilename(file1), getVariables())));
       in2 =
           new DataInputStream(
-              new BufferedInputStream(HopVfs.getInputStream(HopVfs.getFilename(file2))));
+              new BufferedInputStream(
+                  HopVfs.getInputStream(HopVfs.getFilename(file2), getVariables())));
 
       char ch1;
       char ch2;
@@ -264,8 +266,8 @@ public class ActionFoldersCompare extends ActionBase implements Cloneable, IActi
     try {
       if (filename1 != null && filename2 != null) {
         // Get Folders/Files to compare
-        folder1 = HopVfs.getFileObject(realFilename1);
-        folder2 = HopVfs.getFileObject(realFilename2);
+        folder1 = HopVfs.getFileObject(realFilename1, getVariables());
+        folder2 = HopVfs.getFileObject(realFilename2, getVariables());
 
         if (folder1.exists() && folder2.exists()) {
           if (!folder1.getType().equals(folder2.getType())) {
@@ -364,8 +366,9 @@ public class ActionFoldersCompare extends ActionBase implements Cloneable, IActi
                               realFilename2));
                     }
 
-                    filefolder1 = HopVfs.getFileObject(entree.getValue());
-                    filefolder2 = HopVfs.getFileObject(collection2.get(entree.getKey()));
+                    filefolder1 = HopVfs.getFileObject(entree.getValue(), getVariables());
+                    filefolder2 =
+                        HopVfs.getFileObject(collection2.get(entree.getKey()), getVariables());
 
                     if (!filefolder2.getType().equals(filefolder1.getType())) {
                       // The file1 exist in the folder2..but they don't have the same type

--- a/plugins/actions/movefiles/src/main/java/org/apache/hop/workflow/actions/movefiles/ActionMoveFiles.java
+++ b/plugins/actions/movefiles/src/main/java/org/apache/hop/workflow/actions/movefiles/ActionMoveFiles.java
@@ -319,7 +319,7 @@ public class ActionMoveFiles extends ActionBase implements Cloneable, IAction {
       }
       FileObject folder = null;
       try {
-        folder = HopVfs.getFileObject(moveToFolder);
+        folder = HopVfs.getFileObject(moveToFolder, getVariables());
         if (!folder.exists()) {
           if (log.isDetailed()) {
             logDetailed(
@@ -531,10 +531,10 @@ public class ActionMoveFiles extends ActionBase implements Cloneable, IAction {
     String realWildcard = resolve(wildcard);
 
     try {
-      sourcefilefolder = HopVfs.getFileObject(realSourceFilefoldername);
-      destinationfilefolder = HopVfs.getFileObject(realDestinationFilefoldername);
+      sourcefilefolder = HopVfs.getFileObject(realSourceFilefoldername, getVariables());
+      destinationfilefolder = HopVfs.getFileObject(realDestinationFilefoldername, getVariables());
       if (!Utils.isEmpty(moveToFolder)) {
-        movetofolderfolder = HopVfs.getFileObject(moveToFolder);
+        movetofolderfolder = HopVfs.getFileObject(moveToFolder, getVariables());
       }
 
       if (sourcefilefolder.exists()) {
@@ -583,7 +583,8 @@ public class ActionMoveFiles extends ActionBase implements Cloneable, IAction {
 
               String destinationfilenamefull =
                   HopVfs.getFilename(destinationfilefolder) + Const.FILE_SEPARATOR + shortfilename;
-              FileObject destinationfile = HopVfs.getFileObject(destinationfilenamefull);
+              FileObject destinationfile =
+                  HopVfs.getFileObject(destinationfilenamefull, getVariables());
 
               destinationfile.createFolder();
 
@@ -599,7 +600,8 @@ public class ActionMoveFiles extends ActionBase implements Cloneable, IAction {
             } else if (sourcefilefolder.getType().equals(FileType.FILE) && destinationIsAFile) {
               // Source is a file, destination is a file
 
-              FileObject destinationfile = HopVfs.getFileObject(realDestinationFilefoldername);
+              FileObject destinationfile =
+                  HopVfs.getFileObject(realDestinationFilefoldername, getVariables());
 
               // return destination short filename
               String shortfilename = destinationfile.getName().getBaseName();
@@ -618,13 +620,13 @@ public class ActionMoveFiles extends ActionBase implements Cloneable, IAction {
               }
 
               if (destinationfile.getName().getURI().startsWith("azfs")) {
-                destinationfile = HopVfs.getFileObject(destinationfilefoldername);
+                destinationfile = HopVfs.getFileObject(destinationfilefoldername, getVariables());
               } else if (destinationfile.getName().getURI().startsWith("azure")) {
                 String destinationfilenamefull =
                     HopVfs.getFilename(destinationfile.getParent())
                         + Const.FILE_SEPARATOR
                         + shortfilename;
-                destinationfile = HopVfs.getFileObject(destinationfilenamefull);
+                destinationfile = HopVfs.getFileObject(destinationfilenamefull, getVariables());
               } else {
                 throw new HopException(
                     "Could not extract the file name from the URI: "
@@ -781,7 +783,8 @@ public class ActionMoveFiles extends ActionBase implements Cloneable, IAction {
         if (includeSubfolders) {
           // Check if
           FileObject destinationFilePath =
-              HopVfs.getFileObject(destinationfilename.getName().getParent().toString());
+              HopVfs.getFileObject(
+                  destinationfilename.getName().getParent().toString(), getVariables());
           if (!destinationFilePath.exists()) destinationFilePath.createFolder();
         }
 
@@ -855,7 +858,7 @@ public class ActionMoveFiles extends ActionBase implements Cloneable, IAction {
 
           String movetofilenamefull =
               destinationfilename.getParent().toString() + Const.FILE_SEPARATOR + shortFilename;
-          destinationfile = HopVfs.getFileObject(movetofilenamefull);
+          destinationfile = HopVfs.getFileObject(movetofilenamefull, getVariables());
 
           if (!simulate) {
             sourcefilename.moveTo(destinationfile);
@@ -908,7 +911,7 @@ public class ActionMoveFiles extends ActionBase implements Cloneable, IAction {
 
           String movetofilenamefull =
               movetofolderfolder.toString() + Const.FILE_SEPARATOR + shortFilename;
-          destinationfile = HopVfs.getFileObject(movetofilenamefull);
+          destinationfile = HopVfs.getFileObject(movetofilenamefull, getVariables());
           if (!destinationfile.exists()) {
             if (!simulate) {
               sourcefilename.moveTo(destinationfile);
@@ -960,7 +963,7 @@ public class ActionMoveFiles extends ActionBase implements Cloneable, IAction {
 
               String destinationfilenamefull =
                   movetofolderfolder.toString() + Const.FILE_SEPARATOR + shortFilename;
-              destinationfile = HopVfs.getFileObject(destinationfilenamefull);
+              destinationfile = HopVfs.getFileObject(destinationfilenamefull, getVariables());
 
               if (!simulate) {
                 sourcefilename.moveTo(destinationfile);
@@ -1062,7 +1065,8 @@ public class ActionMoveFiles extends ActionBase implements Cloneable, IAction {
         // Built destination filename
         filename =
             HopVfs.getFileObject(
-                realDestinationFilefoldername + Const.FILE_SEPARATOR + shortFilenameFromBaseFolder);
+                realDestinationFilefoldername + Const.FILE_SEPARATOR + shortFilenameFromBaseFolder,
+                getVariables());
 
         if (!currentfile.getParent().toString().equals(sourcefilefolder.toString())) {
 
@@ -1168,7 +1172,7 @@ public class ActionMoveFiles extends ActionBase implements Cloneable, IAction {
       ResultFile resultFile =
           new ResultFile(
               ResultFile.FILE_TYPE_GENERAL,
-              HopVfs.getFileObject(fileaddentry),
+              HopVfs.getFileObject(fileaddentry, getVariables()),
               parentWorkflow.getWorkflowName(),
               toString());
       result.getResultFiles().put(resultFile.getFile().toString(), resultFile);

--- a/plugins/actions/pgpfiles/src/main/java/org/apache/hop/workflow/actions/pgpdecryptfiles/ActionPGPDecryptFiles.java
+++ b/plugins/actions/pgpfiles/src/main/java/org/apache/hop/workflow/actions/pgpdecryptfiles/ActionPGPDecryptFiles.java
@@ -330,7 +330,7 @@ public class ActionPGPDecryptFiles extends ActionBase implements Cloneable, IAct
         }
         FileObject folder = null;
         try {
-          folder = HopVfs.getFileObject(moveToFolder);
+          folder = HopVfs.getFileObject(moveToFolder, getVariables());
           if (!folder.exists()) {
             if (isDetailed()) {
               logDetailed(
@@ -371,7 +371,7 @@ public class ActionPGPDecryptFiles extends ActionBase implements Cloneable, IAct
         }
       }
 
-      gpg = new GPG(resolve(gpgLocation), log);
+      gpg = new GPG(resolve(gpgLocation), log, getVariables());
 
       if (argFromPrevious) {
         if (isDetailed()) {
@@ -561,10 +561,10 @@ public class ActionPGPDecryptFiles extends ActionBase implements Cloneable, IAct
 
     try {
 
-      sourcefilefolder = HopVfs.getFileObject(realSourceFilefoldername);
-      destinationfilefolder = HopVfs.getFileObject(realDestinationFilefoldername);
+      sourcefilefolder = HopVfs.getFileObject(realSourceFilefoldername, getVariables());
+      destinationfilefolder = HopVfs.getFileObject(realDestinationFilefoldername, getVariables());
       if (!Utils.isEmpty(moveToFolder)) {
-        movetofolderfolder = HopVfs.getFileObject(moveToFolder);
+        movetofolderfolder = HopVfs.getFileObject(moveToFolder, getVariables());
       }
 
       if (sourcefilefolder.exists()) {
@@ -611,7 +611,8 @@ public class ActionPGPDecryptFiles extends ActionBase implements Cloneable, IAct
 
               String destinationfilenamefull =
                   destinationfilefolder.toString() + Const.FILE_SEPARATOR + shortfilename;
-              FileObject destinationfile = HopVfs.getFileObject(destinationfilenamefull);
+              FileObject destinationfile =
+                  HopVfs.getFileObject(destinationfilenamefull, getVariables());
 
               entrystatus =
                   DecryptFile(
@@ -626,7 +627,8 @@ public class ActionPGPDecryptFiles extends ActionBase implements Cloneable, IAct
             } else if (sourcefilefolder.getType().equals(FileType.FILE) && destinationIsAFile) {
               // Source is a file, destination is a file
 
-              FileObject destinationfile = HopVfs.getFileObject(realDestinationFilefoldername);
+              FileObject destinationfile =
+                  HopVfs.getFileObject(realDestinationFilefoldername, getVariables());
 
               // return destination short filename
               String shortfilename = destinationfile.getName().getBaseName();
@@ -646,7 +648,7 @@ public class ActionPGPDecryptFiles extends ActionBase implements Cloneable, IAct
                   destinationfilefolder.getParent().toString()
                       + Const.FILE_SEPARATOR
                       + shortfilename;
-              destinationfile = HopVfs.getFileObject(destinationfilenamefull);
+              destinationfile = HopVfs.getFileObject(destinationfilenamefull, getVariables());
 
               entrystatus =
                   DecryptFile(
@@ -864,7 +866,7 @@ public class ActionPGPDecryptFiles extends ActionBase implements Cloneable, IAct
 
           String movetofilenamefull =
               destinationfilename.getParent().toString() + Const.FILE_SEPARATOR + shortFilename;
-          destinationfile = HopVfs.getFileObject(movetofilenamefull);
+          destinationfile = HopVfs.getFileObject(movetofilenamefull, getVariables());
 
           gpg.decryptFile(sourcefilename, passPharse, destinationfile);
 
@@ -909,7 +911,7 @@ public class ActionPGPDecryptFiles extends ActionBase implements Cloneable, IAct
 
           String movetofilenamefull =
               movetofolderfolder.toString() + Const.FILE_SEPARATOR + shortFilename;
-          destinationfile = HopVfs.getFileObject(movetofilenamefull);
+          destinationfile = HopVfs.getFileObject(movetofilenamefull, getVariables());
           if (!destinationfile.exists()) {
             sourcefilename.moveTo(destinationfile);
             if (isDetailed()) {
@@ -956,7 +958,7 @@ public class ActionPGPDecryptFiles extends ActionBase implements Cloneable, IAct
 
               String destinationfilenamefull =
                   movetofolderfolder.toString() + Const.FILE_SEPARATOR + shortFilename;
-              destinationfile = HopVfs.getFileObject(destinationfilenamefull);
+              destinationfile = HopVfs.getFileObject(destinationfilenamefull, getVariables());
 
               sourcefilename.moveTo(destinationfile);
               if (isDetailed()) {
@@ -1054,7 +1056,8 @@ public class ActionPGPDecryptFiles extends ActionBase implements Cloneable, IAct
         // Built destination filename
         filename =
             HopVfs.getFileObject(
-                realDestinationFilefoldername + Const.FILE_SEPARATOR + shortFilenameFromBaseFolder);
+                realDestinationFilefoldername + Const.FILE_SEPARATOR + shortFilenameFromBaseFolder,
+                getVariables());
 
         if (!currentfile.getParent().toString().equals(sourcefilefolder.toString())) {
 
@@ -1138,7 +1141,7 @@ public class ActionPGPDecryptFiles extends ActionBase implements Cloneable, IAct
       ResultFile resultFile =
           new ResultFile(
               ResultFile.FILE_TYPE_GENERAL,
-              HopVfs.getFileObject(fileaddentry),
+              HopVfs.getFileObject(fileaddentry, getVariables()),
               parentWorkflow.getWorkflowName(),
               toString());
       result.getResultFiles().put(resultFile.getFile().toString(), resultFile);

--- a/plugins/actions/pgpfiles/src/main/java/org/apache/hop/workflow/actions/pgpencryptfiles/ActionPGPEncryptFiles.java
+++ b/plugins/actions/pgpfiles/src/main/java/org/apache/hop/workflow/actions/pgpencryptfiles/ActionPGPEncryptFiles.java
@@ -369,7 +369,7 @@ public class ActionPGPEncryptFiles extends ActionBase implements Cloneable, IAct
         }
         FileObject folder = null;
         try {
-          folder = HopVfs.getFileObject(moveToFolder);
+          folder = HopVfs.getFileObject(moveToFolder, getVariables());
           if (!folder.exists()) {
             if (isDetailed()) {
               logDetailed(
@@ -410,7 +410,7 @@ public class ActionPGPEncryptFiles extends ActionBase implements Cloneable, IAct
         }
       }
 
-      gpg = new GPG(resolve(gpgLocation), log);
+      gpg = new GPG(resolve(gpgLocation), log, getVariables());
 
       if (argFromPrevious) {
         if (isDetailed()) {
@@ -629,10 +629,10 @@ public class ActionPGPEncryptFiles extends ActionBase implements Cloneable, IAct
 
     try {
 
-      sourcefilefolder = HopVfs.getFileObject(realSourceFilefoldername);
-      destinationfilefolder = HopVfs.getFileObject(realDestinationFilefoldername);
+      sourcefilefolder = HopVfs.getFileObject(realSourceFilefoldername, getVariables());
+      destinationfilefolder = HopVfs.getFileObject(realDestinationFilefoldername, getVariables());
       if (!Utils.isEmpty(moveToFolder)) {
-        movetofolderfolder = HopVfs.getFileObject(moveToFolder);
+        movetofolderfolder = HopVfs.getFileObject(moveToFolder, getVariables());
       }
 
       if (sourcefilefolder.exists()) {
@@ -679,7 +679,8 @@ public class ActionPGPEncryptFiles extends ActionBase implements Cloneable, IAct
 
               String destinationfilenamefull =
                   destinationfilefolder.toString() + Const.FILE_SEPARATOR + shortfilename;
-              FileObject destinationfile = HopVfs.getFileObject(destinationfilenamefull);
+              FileObject destinationfile =
+                  HopVfs.getFileObject(destinationfilenamefull, getVariables());
 
               entrystatus =
                   EncryptFile(
@@ -696,7 +697,8 @@ public class ActionPGPEncryptFiles extends ActionBase implements Cloneable, IAct
 
               // Source is a file, destination is a file
 
-              FileObject destinationfile = HopVfs.getFileObject(realDestinationFilefoldername);
+              FileObject destinationfile =
+                  HopVfs.getFileObject(realDestinationFilefoldername, getVariables());
 
               // return destination short filename
               String shortfilename = destinationfile.getName().getBaseName();
@@ -716,7 +718,7 @@ public class ActionPGPEncryptFiles extends ActionBase implements Cloneable, IAct
                   destinationfilefolder.getParent().toString()
                       + Const.FILE_SEPARATOR
                       + shortfilename;
-              destinationfile = HopVfs.getFileObject(destinationfilenamefull);
+              destinationfile = HopVfs.getFileObject(destinationfilenamefull, getVariables());
 
               entrystatus =
                   EncryptFile(
@@ -936,7 +938,7 @@ public class ActionPGPEncryptFiles extends ActionBase implements Cloneable, IAct
 
           String movetofilenamefull =
               destinationfilename.getParent().toString() + Const.FILE_SEPARATOR + shortFilename;
-          destinationfile = HopVfs.getFileObject(movetofilenamefull);
+          destinationfile = HopVfs.getFileObject(movetofilenamefull, getVariables());
 
           doJob(actionType, sourcefilename, userID, destinationfilename);
           if (isDetailed()) {
@@ -981,7 +983,7 @@ public class ActionPGPEncryptFiles extends ActionBase implements Cloneable, IAct
 
           String movetofilenamefull =
               movetofolderfolder.toString() + Const.FILE_SEPARATOR + shortFilename;
-          destinationfile = HopVfs.getFileObject(movetofilenamefull);
+          destinationfile = HopVfs.getFileObject(movetofilenamefull, getVariables());
           if (!destinationfile.exists()) {
             sourcefilename.moveTo(destinationfile);
             if (isDetailed()) {
@@ -1028,7 +1030,7 @@ public class ActionPGPEncryptFiles extends ActionBase implements Cloneable, IAct
 
               String destinationfilenamefull =
                   movetofolderfolder.toString() + Const.FILE_SEPARATOR + shortFilename;
-              destinationfile = HopVfs.getFileObject(destinationfilenamefull);
+              destinationfile = HopVfs.getFileObject(destinationfilenamefull, getVariables());
 
               sourcefilename.moveTo(destinationfile);
               if (isDetailed()) {
@@ -1127,7 +1129,8 @@ public class ActionPGPEncryptFiles extends ActionBase implements Cloneable, IAct
         // Built destination filename
         filename =
             HopVfs.getFileObject(
-                realDestinationFilefoldername + Const.FILE_SEPARATOR + shortFilenameFromBaseFolder);
+                realDestinationFilefoldername + Const.FILE_SEPARATOR + shortFilenameFromBaseFolder,
+                getVariables());
 
         if (!currentfile.getParent().toString().equals(sourcefilefolder.toString())) {
 
@@ -1214,7 +1217,7 @@ public class ActionPGPEncryptFiles extends ActionBase implements Cloneable, IAct
       ResultFile resultFile =
           new ResultFile(
               ResultFile.FILE_TYPE_GENERAL,
-              HopVfs.getFileObject(fileaddentry),
+              HopVfs.getFileObject(fileaddentry, getVariables()),
               parentWorkflow.getWorkflowName(),
               toString());
       result.getResultFiles().put(resultFile.getFile().toString(), resultFile);

--- a/plugins/actions/pgpfiles/src/main/java/org/apache/hop/workflow/actions/pgpencryptfiles/GPG.java
+++ b/plugins/actions/pgpfiles/src/main/java/org/apache/hop/workflow/actions/pgpencryptfiles/GPG.java
@@ -30,6 +30,7 @@ import org.apache.hop.core.Const;
 import org.apache.hop.core.exception.HopException;
 import org.apache.hop.core.logging.ILogChannel;
 import org.apache.hop.core.util.Utils;
+import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.core.vfs.HopVfs;
 import org.apache.hop.i18n.BaseMessages;
 
@@ -97,7 +98,8 @@ public class GPG {
    * @param logInterface ILogChannel
    * @throws HopException
    */
-  public GPG(String gpgFilename, ILogChannel logInterface) throws HopException {
+  public GPG(String gpgFilename, ILogChannel logInterface, IVariables variables)
+      throws HopException {
     this.log = logInterface;
     this.gpgexe = gpgFilename;
     // Let's check GPG filename
@@ -108,7 +110,7 @@ public class GPG {
     // We have a filename, we need to check
     FileObject file = null;
     try {
-      file = HopVfs.getFileObject(getGpgExeFile());
+      file = HopVfs.getFileObject(getGpgExeFile(), variables);
 
       if (!file.exists()) {
         throw new HopException(BaseMessages.getString(PKG, "GPG.GPGFilenameNotFound"));

--- a/plugins/actions/pgpfiles/src/main/java/org/apache/hop/workflow/actions/pgpverify/ActionPGPVerify.java
+++ b/plugins/actions/pgpfiles/src/main/java/org/apache/hop/workflow/actions/pgpverify/ActionPGPVerify.java
@@ -160,9 +160,9 @@ public class ActionPGPVerify extends ActionBase implements Cloneable, IAction {
         logError(BaseMessages.getString(PKG, "ActionPGPVerify.FilenameMissing"));
         return result;
       }
-      file = HopVfs.getFileObject(realFilename);
+      file = HopVfs.getFileObject(realFilename, getVariables());
 
-      GPG gpg = new GPG(resolve(getGPGLocation()), log);
+      GPG gpg = new GPG(resolve(getGPGLocation()), log, getVariables());
 
       if (useDetachedfilename()) {
         String signature = resolve(getDetachedfilename());
@@ -171,7 +171,7 @@ public class ActionPGPVerify extends ActionBase implements Cloneable, IAction {
           logError(BaseMessages.getString(PKG, "ActionPGPVerify.DetachedSignatureMissing"));
           return result;
         }
-        detachedSignature = HopVfs.getFileObject(signature);
+        detachedSignature = HopVfs.getFileObject(signature, getVariables());
 
         gpg.verifyDetachedSignature(detachedSignature, file);
       } else {
@@ -260,7 +260,8 @@ public class ActionPGPVerify extends ActionBase implements Cloneable, IAction {
         // From : ${FOLDER}/../foo/bar.csv
         // To : /home/matt/test/files/foo/bar.csv
         //
-        FileObject fileObject = HopVfs.getFileObject(variables.resolve(gpgLocation));
+        FileObject fileObject =
+            HopVfs.getFileObject(variables.resolve(gpgLocation), getVariables());
 
         // If the file doesn't exist, forget about this effort too!
         //

--- a/plugins/actions/unzip/src/main/java/org/apache/hop/workflow/actions/unzip/ActionUnZip.java
+++ b/plugins/actions/unzip/src/main/java/org/apache/hop/workflow/actions/unzip/ActionUnZip.java
@@ -309,7 +309,7 @@ public class ActionUnZip extends ActionBase implements Cloneable, IAction {
       boolean exitaction = false;
 
       // Target folder
-      targetdir = HopVfs.getFileObject(realTargetdirectory);
+      targetdir = HopVfs.getFileObject(realTargetdirectory, getVariables());
 
       if (!targetdir.exists()) {
         if (createfolder) {
@@ -346,7 +346,7 @@ public class ActionUnZip extends ActionBase implements Cloneable, IAction {
           log.logError(BaseMessages.getString(PKG, "ActionUnZip.MoveToDirectoryEmpty.Label"));
           exitaction = true;
         } else {
-          movetodir = HopVfs.getFileObject(realMovetodirectory);
+          movetodir = HopVfs.getFileObject(realMovetodirectory, getVariables());
           if (!(movetodir.exists()) || !(movetodir.getType() == FileType.FOLDER)) {
             if (createMoveToDirectory) {
               movetodir.createFolder();
@@ -391,7 +391,7 @@ public class ActionUnZip extends ActionBase implements Cloneable, IAction {
             realFilenameSource = resultRow.getString(0, null);
             realWildcardSource = resultRow.getString(1, null);
 
-            fileObject = HopVfs.getFileObject(realFilenameSource);
+            fileObject = HopVfs.getFileObject(realFilenameSource, getVariables());
             if (fileObject.exists()) {
               processOneFile(
                   result,
@@ -412,7 +412,7 @@ public class ActionUnZip extends ActionBase implements Cloneable, IAction {
           }
         }
       } else {
-        fileObject = HopVfs.getFileObject(realFilenameSource);
+        fileObject = HopVfs.getFileObject(realFilenameSource, getVariables());
         if (!fileObject.exists()) {
           log.logError(
               BaseMessages.getString(
@@ -612,7 +612,7 @@ public class ActionUnZip extends ActionBase implements Cloneable, IAction {
 
         String folderName =
             realTargetdirectory + "/" + shortSourceFilename.substring(0, lastindexOfDot);
-        FileObject rootfolder = HopVfs.getFileObject(folderName);
+        FileObject rootfolder = HopVfs.getFileObject(folderName, getVariables());
         if (!rootfolder.exists()) {
           try {
             rootfolder.createFolder();
@@ -632,7 +632,7 @@ public class ActionUnZip extends ActionBase implements Cloneable, IAction {
       // Try to read the entries from the VFS object...
       //
       String zipFilename = "zip:" + sourceFileObject.getName().getFriendlyURI();
-      FileObject zipFile = HopVfs.getFileObject(zipFilename);
+      FileObject zipFile = HopVfs.getFileObject(zipFilename, getVariables());
       FileObject[] items =
           zipFile.findFiles(
               new AllFileSelector() {
@@ -674,7 +674,7 @@ public class ActionUnZip extends ActionBase implements Cloneable, IAction {
           return false;
         }
 
-        synchronized (HopVfs.getFileSystemManager()) {
+        synchronized (HopVfs.getFileSystemManager(getVariables())) {
           FileObject newFileObject = null;
           try {
             if (log.isDetailed()) {
@@ -689,7 +689,7 @@ public class ActionUnZip extends ActionBase implements Cloneable, IAction {
             // get real destination filename
             //
             String newFileName = unzipToFolder + Const.FILE_SEPARATOR + getTargetFilename(item);
-            newFileObject = HopVfs.getFileObject(newFileName);
+            newFileObject = HopVfs.getFileObject(newFileName, getVariables());
 
             if (item.getType().equals(FileType.FOLDER)) {
               // Directory
@@ -814,7 +814,7 @@ public class ActionUnZip extends ActionBase implements Cloneable, IAction {
             }
             // Close file object
             // close() does not release resources!
-            HopVfs.getFileSystemManager().closeFileSystem(item.getFileSystem());
+            HopVfs.getFileSystemManager(getVariables()).closeFileSystem(item.getFileSystem());
             if (items != null) {
               items = null;
             }
@@ -868,7 +868,7 @@ public class ActionUnZip extends ActionBase implements Cloneable, IAction {
       try {
         String destinationFilename =
             movetodir + Const.FILE_SEPARATOR + sourceFileObject.getName().getBaseName();
-        destFile = HopVfs.getFileObject(destinationFilename);
+        destFile = HopVfs.getFileObject(destinationFilename, getVariables());
 
         sourceFileObject.moveTo(destFile);
 
@@ -910,7 +910,7 @@ public class ActionUnZip extends ActionBase implements Cloneable, IAction {
       ResultFile resultFile =
           new ResultFile(
               ResultFile.FILE_TYPE_GENERAL,
-              HopVfs.getFileObject(newfile),
+              HopVfs.getFileObject(newfile, getVariables()),
               parentWorkflow.getWorkflowName(),
               toString());
       result.getResultFiles().put(resultFile.getFile().toString(), resultFile);

--- a/plugins/actions/writetofile/src/main/java/org/apache/hop/workflow/actions/writetofile/ActionWriteToFile.java
+++ b/plugins/actions/writetofile/src/main/java/org/apache/hop/workflow/actions/writetofile/ActionWriteToFile.java
@@ -139,7 +139,7 @@ public class ActionWriteToFile extends ActionBase implements Cloneable, IAction 
         createParentFolder(realFilename);
 
         // Create / open file for writing
-        os = HopVfs.getOutputStream(realFilename, isAppendFile());
+        os = HopVfs.getOutputStream(realFilename, isAppendFile(), getVariables());
 
         if (Utils.isEmpty(encoding)) {
           if (isDebug()) {
@@ -195,7 +195,7 @@ public class ActionWriteToFile extends ActionBase implements Cloneable, IAction 
   private void createParentFolder(String realFilename) throws HopException {
     FileObject parent = null;
     try {
-      parent = HopVfs.getFileObject(realFilename).getParent();
+      parent = HopVfs.getFileObject(realFilename, getVariables()).getParent();
       if (!parent.exists()) {
         if (isCreateParentFolder()) {
           if (isDetailed()) {

--- a/plugins/actions/zipfile/src/main/java/org/apache/hop/workflow/actions/zipfile/ActionZipFile.java
+++ b/plugins/actions/zipfile/src/main/java/org/apache/hop/workflow/actions/zipfile/ActionZipFile.java
@@ -180,7 +180,7 @@ public class ActionZipFile extends ActionBase implements Cloneable, IAction {
     boolean result = false;
     try {
       // Get parent folder
-      parentfolder = HopVfs.getFileObject(filename).getParent();
+      parentfolder = HopVfs.getFileObject(filename, getVariables()).getParent();
 
       if (!parentfolder.exists()) {
         if (log.isDetailed()) {
@@ -239,7 +239,7 @@ public class ActionZipFile extends ActionBase implements Cloneable, IAction {
     // Check if target file/folder exists!
     String localSourceFilename;
 
-    try (FileObject originFile = HopVfs.getFileObject(realSourceDirectoryOrFile)) {
+    try (FileObject originFile = HopVfs.getFileObject(realSourceDirectoryOrFile, getVariables())) {
       localSourceFilename = HopVfs.getFilename(originFile);
       orginExist = originFile.exists();
     } catch (Exception e) {
@@ -250,7 +250,7 @@ public class ActionZipFile extends ActionBase implements Cloneable, IAction {
     String localrealZipfilename = realZipFilename;
     if (realZipFilename != null && orginExist) {
 
-      try (FileObject fileObject = HopVfs.getFileObject(localrealZipfilename)) {
+      try (FileObject fileObject = HopVfs.getFileObject(localrealZipfilename, getVariables())) {
         localrealZipfilename = HopVfs.getFilename(fileObject);
         // Check if Zip File exists
         if (fileObject.exists()) {
@@ -295,7 +295,7 @@ public class ActionZipFile extends ActionBase implements Cloneable, IAction {
           // Let's see if we deal with file or folder
           FileObject[] fileList;
 
-          FileObject sourceFileOrFolder = HopVfs.getFileObject(localSourceFilename);
+          FileObject sourceFileOrFolder = HopVfs.getFileObject(localSourceFilename, getVariables());
           boolean isSourceDirectory = sourceFileOrFolder.getType().equals(FileType.FOLDER);
           final Pattern pattern;
           final Pattern excludePattern;
@@ -405,7 +405,8 @@ public class ActionZipFile extends ActionBase implements Cloneable, IAction {
             List<FileObject> zippedFiles = new ArrayList<>();
 
             // Prepare Zip File
-            try (OutputStream dest = HopVfs.getOutputStream(localrealZipfilename, false)) {
+            try (OutputStream dest =
+                HopVfs.getOutputStream(localrealZipfilename, false, getVariables())) {
               try (BufferedOutputStream buff = new BufferedOutputStream(dest)) {
                 try (ZipOutputStream out = new ZipOutputStream(buff)) {
 
@@ -475,7 +476,7 @@ public class ActionZipFile extends ActionBase implements Cloneable, IAction {
                       targetFilename = localSourceFilename;
                     }
 
-                    try (FileObject file = HopVfs.getFileObject(targetFilename)) {
+                    try (FileObject file = HopVfs.getFileObject(targetFilename, getVariables())) {
                       boolean isTargetDirectory =
                           file.exists() && file.getType().equals(FileType.FOLDER);
 
@@ -527,7 +528,7 @@ public class ActionZipFile extends ActionBase implements Cloneable, IAction {
               for (FileObject fileObjectd : zippedFiles) {
                 // Delete, Move File
                 if (!isSourceDirectory) {
-                  fileObjectd = HopVfs.getFileObject(localSourceFilename);
+                  fileObjectd = HopVfs.getFileObject(localSourceFilename, getVariables());
                 }
 
                 // Here we can move, delete files
@@ -654,7 +655,8 @@ public class ActionZipFile extends ActionBase implements Cloneable, IAction {
     boolean success = successResult;
     try (FileObject fileObjectm =
         HopVfs.getFileObject(
-            realMoveToDirectory + Const.FILE_SEPARATOR + fileObjectd.getName().getBaseName())) {
+            realMoveToDirectory + Const.FILE_SEPARATOR + fileObjectd.getName().getBaseName(),
+            getVariables())) {
 
       fileObjectd.moveTo(fileObjectm);
     } catch (Exception e) {
@@ -741,7 +743,7 @@ public class ActionZipFile extends ActionBase implements Cloneable, IAction {
       if (depth == 0) {
         return filename;
       }
-      FileObject fileObject = HopVfs.getFileObject(filename);
+      FileObject fileObject = HopVfs.getFileObject(filename, getVariables());
       FileObject folder = fileObject.getParent();
       String baseName = fileObject.getName().getBaseName();
       if (depth == 1) {
@@ -763,7 +765,7 @@ public class ActionZipFile extends ActionBase implements Cloneable, IAction {
 
   private File getFile(final String filename) {
     try {
-      String uri = HopVfs.getFileObject(resolve(filename)).getName().getPath();
+      String uri = HopVfs.getFileObject(resolve(filename), getVariables()).getName().getPath();
       return new File(uri);
     } catch (HopFileException ex) {
       logError("Error in Fetching URI for File: " + filename, ex);
@@ -808,7 +810,7 @@ public class ActionZipFile extends ActionBase implements Cloneable, IAction {
       } else {
         FileObject moveToDirectory = null;
         try {
-          moveToDirectory = HopVfs.getFileObject(realMovetodirectory);
+          moveToDirectory = HopVfs.getFileObject(realMovetodirectory, getVariables());
           if (moveToDirectory.exists()) {
             if (moveToDirectory.getType() == FileType.FOLDER) {
               if (log.isDetailed()) {

--- a/plugins/misc/projects/src/main/java/org/apache/hop/projects/gui/ProjectsGuiPlugin.java
+++ b/plugins/misc/projects/src/main/java/org/apache/hop/projects/gui/ProjectsGuiPlugin.java
@@ -240,6 +240,9 @@ public class ProjectsGuiPlugin {
           HopExtensionPoint.HopGuiProjectAfterEnabled.name(),
           project);
 
+      // Reset VFS filesystem to load additional configurations
+      HopVfs.reset();
+
     } catch (Exception e) {
       throw new HopException("Error enabling project '" + projectName + "' in HopGui", e);
     }

--- a/plugins/tech/avro/src/main/java/org/apache/hop/avro/transforms/avroinput/AvroFileInput.java
+++ b/plugins/tech/avro/src/main/java/org/apache/hop/avro/transforms/avroinput/AvroFileInput.java
@@ -92,7 +92,7 @@ public class AvroFileInput extends BaseTransform<AvroFileInputMeta, AvroFileInpu
     // Read Avro rows of data from the file...
     //
     try {
-      try (InputStream inputStream = HopVfs.getInputStream(filename)) {
+      try (InputStream inputStream = HopVfs.getInputStream(filename, variables)) {
         GenericDatumReader<GenericRecord> datumReader = new GenericDatumReader<>();
         DataFileStream<GenericRecord> fileStream = new DataFileStream<>(inputStream, datumReader);
         while (fileStream.hasNext()) {

--- a/plugins/tech/avro/src/main/java/org/apache/hop/avro/transforms/avrooutput/AvroOutput.java
+++ b/plugins/tech/avro/src/main/java/org/apache/hop/avro/transforms/avrooutput/AvroOutput.java
@@ -678,11 +678,11 @@ public class AvroOutput extends BaseTransform<AvroOutputMeta, AvroOutputData> {
   }
 
   protected FileObject getFileObject(String vfsFilename) throws HopFileException {
-    return HopVfs.getFileObject(vfsFilename);
+    return HopVfs.getFileObject(vfsFilename, variables);
   }
 
   protected OutputStream getOutputStream(String vfsFilename, boolean append)
       throws HopFileException {
-    return HopVfs.getOutputStream(vfsFilename, append);
+    return HopVfs.getOutputStream(vfsFilename, append, variables);
   }
 }

--- a/plugins/tech/aws/src/main/java/org/apache/hop/pipeline/transforms/redshift/bulkloader/RedshiftBulkLoader.java
+++ b/plugins/tech/aws/src/main/java/org/apache/hop/pipeline/transforms/redshift/bulkloader/RedshiftBulkLoader.java
@@ -71,7 +71,8 @@ public class RedshiftBulkLoader
 
         if (meta.isStreamToS3Csv()) {
           // get the file output stream to write to S3
-          data.writer = HopVfs.getOutputStream(resolve(meta.getCopyFromFilename()), false);
+          data.writer =
+              HopVfs.getOutputStream(resolve(meta.getCopyFromFilename()), false, variables);
         }
 
         data.db = new Database(this, this, data.databaseMeta);

--- a/plugins/tech/aws/src/main/java/org/apache/hop/vfs/s3/S3VfsPlugin.java
+++ b/plugins/tech/aws/src/main/java/org/apache/hop/vfs/s3/S3VfsPlugin.java
@@ -17,7 +17,9 @@
 
 package org.apache.hop.vfs.s3;
 
+import java.util.Map;
 import org.apache.commons.vfs2.provider.FileProvider;
+import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.core.vfs.plugin.IVfs;
 import org.apache.hop.core.vfs.plugin.VfsPlugin;
 import org.apache.hop.vfs.s3.s3.vfs.S3FileProvider;
@@ -32,5 +34,10 @@ public class S3VfsPlugin implements IVfs {
   @Override
   public FileProvider getProvider() {
     return new S3FileProvider();
+  }
+
+  @Override
+  public Map<String, FileProvider> getProviders(IVariables variables) {
+    return null;
   }
 }

--- a/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/AzureCustomFileNameParser.java
+++ b/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/AzureCustomFileNameParser.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.hop.vfs.azure;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileType;
+import org.apache.commons.vfs2.provider.HostFileNameParser;
+import org.apache.commons.vfs2.provider.UriParser;
+import org.apache.commons.vfs2.provider.VfsComponentContext;
+import org.apache.hop.vfs.azure.config.AzureConfig;
+import org.apache.hop.vfs.azure.config.AzureConfigSingleton;
+
+public class AzureCustomFileNameParser extends HostFileNameParser {
+  private String prefix;
+
+  public AzureCustomFileNameParser(String prefix) {
+    super(443);
+    this.prefix = prefix;
+  }
+
+  @Override
+  public FileName parseUri(final VfsComponentContext context, FileName base, String uri)
+      throws FileSystemException {
+    StringBuilder sb = new StringBuilder(uri);
+
+    UriParser.normalisePath(sb);
+    String normalizedUri = sb.toString();
+    String scheme = normalizedUri.substring(0, normalizedUri.indexOf(':'));
+
+    UriParser.normalisePath(sb);
+
+    String absPath = "/";
+    FileType fileType = FileType.IMAGINARY;
+    String[] s = normalizedUri.split("/");
+
+    if (s.length > 1) {
+      if (scheme.equals("azure")) {
+
+        String container = s[1];
+        for (int i = 1; i < s.length; i++) {
+          absPath += s[i];
+
+          if (s.length > 1 && i != s.length - 1) {
+            absPath += "/";
+          }
+        }
+        fileType = getFileType(uri);
+
+      } else if (scheme.equals(prefix)) {
+        fileType = getFileType(uri);
+        String path =
+            normalizedUri.substring(normalizedUri.indexOf('/', 1), normalizedUri.length());
+        AzureConfig azureConfig = AzureConfigSingleton.getConfig();
+        absPath =
+            StringUtils.isNotBlank(azureConfig.getAccount())
+                ? path.replace("/" + azureConfig.getAccount(), "")
+                : path;
+      }
+    }
+    return new AzureFileName(scheme, absPath, fileType);
+  }
+
+  private FileType getFileType(String uri) {
+    if (uri.endsWith("/")) {
+      return FileType.FOLDER;
+    } else {
+      return FileType.FILE;
+    }
+  }
+}

--- a/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/AzureFileProvider.java
+++ b/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/AzureFileProvider.java
@@ -51,7 +51,7 @@ public class AzureFileProvider extends AbstractOriginatingFileProvider {
           Arrays.asList(
               Capability.CREATE,
               Capability.DELETE,
-              // Capability.RENAME,
+              Capability.RENAME,
               Capability.ATTRIBUTES,
               Capability.GET_TYPE,
               Capability.GET_LAST_MODIFIED,

--- a/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/AzureVfsPlugin.java
+++ b/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/AzureVfsPlugin.java
@@ -18,9 +18,16 @@
 
 package org.apache.hop.vfs.azure;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.apache.commons.vfs2.provider.FileProvider;
+import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.core.vfs.plugin.IVfs;
 import org.apache.hop.core.vfs.plugin.VfsPlugin;
+import org.apache.hop.metadata.api.IHopMetadataProvider;
+import org.apache.hop.metadata.util.HopMetadataUtil;
+import org.apache.hop.vfs.azure.metadatatype.AzureMetadataType;
 
 @VfsPlugin(type = "azure", typeDescription = "Azure VFS plugin")
 public class AzureVfsPlugin implements IVfs {
@@ -31,7 +38,24 @@ public class AzureVfsPlugin implements IVfs {
 
   @Override
   public FileProvider getProvider() {
-    AzureFileProvider fileProvider = new AzureFileProvider();
-    return fileProvider;
+    return new AzureFileProvider();
+  }
+
+  @Override
+  public Map<String, FileProvider> getProviders(IVariables variables) {
+    Map<String, FileProvider> providers = new HashMap<>();
+    try {
+      IHopMetadataProvider metadataProvider =
+          HopMetadataUtil.getStandardHopMetadataProvider(variables);
+      List<AzureMetadataType> azureMetadataTypes =
+          metadataProvider.getSerializer(AzureMetadataType.class).loadAll();
+      for (AzureMetadataType azureMetadataType : azureMetadataTypes) {
+        providers.put(
+            azureMetadataType.getName(), new AzureFileProvider(variables, azureMetadataType));
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    return providers;
   }
 }

--- a/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/metadatatype/AzureMetadataType.java
+++ b/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/metadatatype/AzureMetadataType.java
@@ -33,7 +33,10 @@ public class AzureMetadataType extends HopMetadataBase implements Serializable, 
   private static final Class<?> PKG = AzureMetadataType.class; // For Translator
   @HopMetadataProperty private String description;
   @HopMetadataProperty private String storageAccountName;
-  @HopMetadataProperty private String storageAccountKey;
+
+  @HopMetadataProperty(password = true)
+  private String storageAccountKey;
+
   @HopMetadataProperty private String storageAccountEndpoint;
 
   public AzureMetadataType() {}

--- a/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/metadatatype/AzureMetadataType.java
+++ b/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/metadatatype/AzureMetadataType.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hop.vfs.azure.metadatatype;
+
+import java.io.Serializable;
+import org.apache.hop.metadata.api.HopMetadata;
+import org.apache.hop.metadata.api.HopMetadataBase;
+import org.apache.hop.metadata.api.HopMetadataProperty;
+import org.apache.hop.metadata.api.IHopMetadata;
+
+@HopMetadata(
+    key = "AzureConnectionDefinition",
+    name = "i18n::AzureMetadataType.Name",
+    description = "i18n::AzureMetadataType.Description",
+    image = "ui/images/folder.svg",
+    documentationUrl = "/metadata-types/staticschema.html")
+public class AzureMetadataType extends HopMetadataBase implements Serializable, IHopMetadata {
+
+  private static final Class<?> PKG = AzureMetadataType.class; // For Translator
+  @HopMetadataProperty private String description;
+  @HopMetadataProperty private String storageAccountName;
+  @HopMetadataProperty private String storageAccountKey;
+  @HopMetadataProperty private String storageAccountEndpoint;
+
+  public AzureMetadataType() {}
+
+  /**
+   * Gets description
+   *
+   * @return value of description
+   */
+  public String getDescription() {
+    return description;
+  }
+
+  /**
+   * @param description The description to set
+   */
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  /**
+   * Get Azure storage account name
+   *
+   * @return storageAccountName
+   */
+  public String getStorageAccountName() {
+    return storageAccountName;
+  }
+
+  /**
+   * Set Azure storage account name
+   *
+   * @param storageAccountName
+   */
+  public void setStorageAccountName(String storageAccountName) {
+    this.storageAccountName = storageAccountName;
+  }
+
+  /**
+   * Get storage account key
+   *
+   * @return storageAccountKey
+   */
+  public String getStorageAccountKey() {
+    return storageAccountKey;
+  }
+
+  /**
+   * Set storage account key
+   *
+   * @param storageAccountKey
+   */
+  public void setStorageAccountKey(String storageAccountKey) {
+    this.storageAccountKey = storageAccountKey;
+  }
+
+  /**
+   * Get storage account endpoint
+   *
+   * @return storageAccountEndpoint
+   */
+  public String getStorageAccountEndpoint() {
+    return storageAccountEndpoint;
+  }
+
+  /**
+   * Set storage account endpoint
+   *
+   * @param storageAccountEndpoint
+   */
+  public void setStorageAccountEndpoint(String storageAccountEndpoint) {
+    this.storageAccountEndpoint = storageAccountEndpoint;
+  }
+}

--- a/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/metadatatype/AzureMetadataTypeEditor.java
+++ b/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/metadatatype/AzureMetadataTypeEditor.java
@@ -17,6 +17,8 @@
 package org.apache.hop.vfs.azure.metadatatype;
 
 import org.apache.hop.core.Const;
+import org.apache.hop.core.exception.HopException;
+import org.apache.hop.core.vfs.HopVfs;
 import org.apache.hop.i18n.BaseMessages;
 import org.apache.hop.ui.core.PropsUi;
 import org.apache.hop.ui.core.metadata.MetadataEditor;
@@ -192,5 +194,11 @@ public class AzureMetadataTypeEditor extends MetadataEditor<AzureMetadataType> {
       return false;
     }
     return wName.setFocus();
+  }
+
+  @Override
+  public void save() throws HopException {
+    super.save();
+    HopVfs.reset();
   }
 }

--- a/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/metadatatype/AzureMetadataTypeEditor.java
+++ b/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/metadatatype/AzureMetadataTypeEditor.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hop.vfs.azure.metadatatype;
+
+import org.apache.hop.core.Const;
+import org.apache.hop.i18n.BaseMessages;
+import org.apache.hop.ui.core.PropsUi;
+import org.apache.hop.ui.core.metadata.MetadataEditor;
+import org.apache.hop.ui.core.metadata.MetadataManager;
+import org.apache.hop.ui.core.widget.PasswordTextVar;
+import org.apache.hop.ui.core.widget.TextVar;
+import org.apache.hop.ui.hopgui.HopGui;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.FormAttachment;
+import org.eclipse.swt.layout.FormData;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Text;
+
+public class AzureMetadataTypeEditor extends MetadataEditor<AzureMetadataType> {
+
+  private static final Class<?> PKG = AzureMetadataTypeEditor.class; // For Translator
+
+  // Connection properties
+  //
+  private Text wName;
+  private Text wDescription;
+  private TextVar wStorageAccountName;
+  private PasswordTextVar wStorageAccountKey;
+  private TextVar wStorageAccountEndpoint;
+
+  public AzureMetadataTypeEditor(
+      HopGui hopGui, MetadataManager<AzureMetadataType> manager, AzureMetadataType metadata) {
+    super(hopGui, manager, metadata);
+  }
+
+  @Override
+  public void createControl(Composite parent) {
+
+    PropsUi props = PropsUi.getInstance();
+    int middle = props.getMiddlePct();
+    int margin = PropsUi.getMargin() + 2;
+
+    Control lastControl;
+
+    // The name
+    //
+    Label wlName = new Label(parent, SWT.RIGHT);
+    PropsUi.setLook(wlName);
+    wlName.setText(BaseMessages.getString(PKG, "AzureMetadataTypeEditor.Name.Label"));
+    FormData fdlName = new FormData();
+    fdlName.top = new FormAttachment(0, margin);
+    fdlName.left = new FormAttachment(0, 0);
+    fdlName.right = new FormAttachment(middle, -margin);
+    wlName.setLayoutData(fdlName);
+    wName = new Text(parent, SWT.SINGLE | SWT.LEFT | SWT.BORDER);
+    PropsUi.setLook(wName);
+    FormData fdName = new FormData();
+    fdName.top = new FormAttachment(wlName, 0, SWT.CENTER);
+    fdName.left = new FormAttachment(middle, 0);
+    fdName.right = new FormAttachment(95, 0);
+    wName.setLayoutData(fdName);
+    lastControl = wName;
+
+    // The Description
+    //
+    Label wlDescription = new Label(parent, SWT.RIGHT);
+    PropsUi.setLook(wlDescription);
+    wlDescription.setText(BaseMessages.getString(PKG, "AzureMetadataTypeEditor.Description.Label"));
+    FormData fdlDescription = new FormData();
+    fdlDescription.top = new FormAttachment(lastControl, margin);
+    fdlDescription.left = new FormAttachment(0, 0);
+    fdlDescription.right = new FormAttachment(middle, -margin);
+    wlDescription.setLayoutData(fdlDescription);
+    wDescription = new Text(parent, SWT.SINGLE | SWT.LEFT | SWT.BORDER);
+    PropsUi.setLook(wDescription);
+    FormData fdDescription = new FormData();
+    fdDescription.top = new FormAttachment(wlDescription, 0, SWT.CENTER);
+    fdDescription.left = new FormAttachment(middle, 0); // To the right of the label
+    fdDescription.right = new FormAttachment(95, 0);
+    wDescription.setLayoutData(fdDescription);
+    lastControl = wDescription;
+
+    // The Storage account name
+    //
+    Label wlStorageAccountName = new Label(parent, SWT.RIGHT);
+    PropsUi.setLook(wlStorageAccountName);
+    wlStorageAccountName.setText(
+        BaseMessages.getString(PKG, "AzureMetadataTypeEditor.StorageAccountName.Label"));
+    FormData fdlStorageAccountName = new FormData();
+    fdlStorageAccountName.top = new FormAttachment(lastControl, margin);
+    fdlStorageAccountName.left = new FormAttachment(0, 0);
+    fdlStorageAccountName.right = new FormAttachment(middle, -margin);
+    wlStorageAccountName.setLayoutData(fdlStorageAccountName);
+    wStorageAccountName = new TextVar(getVariables(), parent, SWT.SINGLE | SWT.LEFT | SWT.BORDER);
+    PropsUi.setLook(wStorageAccountName);
+    FormData fdStorageAccountName = new FormData();
+    fdStorageAccountName.top = new FormAttachment(wlStorageAccountName, 0, SWT.CENTER);
+    fdStorageAccountName.left = new FormAttachment(middle, 0);
+    fdStorageAccountName.right = new FormAttachment(95, 0);
+    wStorageAccountName.setLayoutData(fdStorageAccountName);
+    lastControl = wStorageAccountName;
+
+    // The Storage account key
+    //
+    Label wlStorageAccountKey = new Label(parent, SWT.RIGHT);
+    PropsUi.setLook(wlStorageAccountKey);
+    wlStorageAccountKey.setText(
+        BaseMessages.getString(PKG, "AzureMetadataTypeEditor.StorageAccountKey.Label"));
+    FormData fdlStorageAccountKey = new FormData();
+    fdlStorageAccountKey.top = new FormAttachment(lastControl, margin);
+    fdlStorageAccountKey.left = new FormAttachment(0, 0);
+    fdlStorageAccountKey.right = new FormAttachment(middle, -margin);
+    wlStorageAccountKey.setLayoutData(fdlStorageAccountKey);
+    wStorageAccountKey =
+        new PasswordTextVar(getVariables(), parent, SWT.SINGLE | SWT.LEFT | SWT.BORDER);
+    PropsUi.setLook(wStorageAccountKey);
+    FormData fdStorageAccountKey = new FormData();
+    fdStorageAccountKey.top = new FormAttachment(wlStorageAccountKey, 0, SWT.CENTER);
+    fdStorageAccountKey.left = new FormAttachment(middle, 0);
+    fdStorageAccountKey.right = new FormAttachment(95, 0);
+    wStorageAccountKey.setLayoutData(fdStorageAccountKey);
+    lastControl = wStorageAccountKey;
+
+    // The storage account endpoint
+    //
+    Label wlStorageAccountEndpoint = new Label(parent, SWT.RIGHT);
+    PropsUi.setLook(wlStorageAccountEndpoint);
+    wlStorageAccountEndpoint.setText(
+        BaseMessages.getString(PKG, "AzureMetadataTypeEditor.StorageAccountEndpoint.Label"));
+    FormData fdlStorageAccountEndpoint = new FormData();
+    fdlStorageAccountEndpoint.top = new FormAttachment(lastControl, margin);
+    fdlStorageAccountEndpoint.left = new FormAttachment(0, 0);
+    fdlStorageAccountEndpoint.right = new FormAttachment(middle, -margin);
+    wlStorageAccountEndpoint.setLayoutData(fdlStorageAccountEndpoint);
+    wStorageAccountEndpoint =
+        new TextVar(getVariables(), parent, SWT.SINGLE | SWT.LEFT | SWT.BORDER);
+    PropsUi.setLook(wStorageAccountEndpoint);
+    FormData fdStorageAccountEndpoint = new FormData();
+    fdStorageAccountEndpoint.top = new FormAttachment(wlStorageAccountEndpoint, 0, SWT.CENTER);
+    fdStorageAccountEndpoint.left = new FormAttachment(middle, 0);
+    fdStorageAccountEndpoint.right = new FormAttachment(95, 0);
+    wStorageAccountEndpoint.setLayoutData(fdStorageAccountEndpoint);
+
+    setWidgetsContent();
+
+    // Add listener to detect change after loading data
+    wName.addModifyListener(e -> setChanged());
+    wDescription.addModifyListener(e -> setChanged());
+    wStorageAccountName.addModifyListener(e -> setChanged());
+    wStorageAccountKey.addModifyListener(e -> setChanged());
+    wStorageAccountEndpoint.addModifyListener(e -> setChanged());
+  }
+
+  @Override
+  public void setWidgetsContent() {
+    AzureMetadataType azureMetadataType = this.getMetadata();
+    wName.setText(Const.NVL(azureMetadataType.getName(), ""));
+    wDescription.setText(Const.NVL(azureMetadataType.getDescription(), ""));
+    wStorageAccountName.setText(Const.NVL(azureMetadataType.getStorageAccountName(), ""));
+    wStorageAccountKey.setText(Const.NVL(azureMetadataType.getStorageAccountKey(), ""));
+    wStorageAccountEndpoint.setText(Const.NVL(azureMetadataType.getStorageAccountEndpoint(), ""));
+  }
+
+  @Override
+  public void getWidgetsContent(AzureMetadataType azureMetadataType) {
+    azureMetadataType.setName(wName.getText());
+    azureMetadataType.setDescription(wDescription.getText());
+    azureMetadataType.setStorageAccountName(wStorageAccountName.getText());
+    azureMetadataType.setStorageAccountKey(wStorageAccountKey.getText());
+    azureMetadataType.setStorageAccountEndpoint(wStorageAccountEndpoint.getText());
+  }
+
+  @Override
+  public boolean setFocus() {
+    if (wName == null || wName.isDisposed()) {
+      return false;
+    }
+    return wName.setFocus();
+  }
+}

--- a/plugins/tech/azure/src/main/resources/org/apache/hop/vfs/azure/metadatatype/messages/messages_en_US.properties
+++ b/plugins/tech/azure/src/main/resources/org/apache/hop/vfs/azure/metadatatype/messages/messages_en_US.properties
@@ -1,0 +1,26 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+AzureMetadataType.Name=Azure Authentication
+AzureMetadataType.Description=
+AzureMetadataTypeEditor.Name.Label=Name
+AzureMetadataTypeEditor.Description.Label=Description
+AzureMetadataTypeEditor.StorageAccountName.Label=Storage Account Name
+AzureMetadataTypeEditor.StorageAccountKey.Label=Storage Account Key
+AzureMetadataTypeEditor.StorageAccountEndpoint.Label=Storage Endpoint

--- a/plugins/tech/dropbox/src/main/java/org/apache/hop/vfs/dropbox/DropboxVfsPlugin.java
+++ b/plugins/tech/dropbox/src/main/java/org/apache/hop/vfs/dropbox/DropboxVfsPlugin.java
@@ -18,7 +18,9 @@
 
 package org.apache.hop.vfs.dropbox;
 
+import java.util.Map;
 import org.apache.commons.vfs2.provider.FileProvider;
+import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.core.vfs.plugin.IVfs;
 import org.apache.hop.core.vfs.plugin.VfsPlugin;
 
@@ -32,5 +34,10 @@ public class DropboxVfsPlugin implements IVfs {
   @Override
   public FileProvider getProvider() {
     return new DropboxFileProvider();
+  }
+
+  @Override
+  public Map<String, FileProvider> getProviders(IVariables variables) {
+    return null;
   }
 }

--- a/plugins/tech/google/src/main/java/org/apache/hop/pipeline/transforms/googlesheets/GoogleSheetsCredentials.java
+++ b/plugins/tech/google/src/main/java/org/apache/hop/pipeline/transforms/googlesheets/GoogleSheetsCredentials.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.util.Collections;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hop.core.exception.HopFileException;
+import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.core.vfs.HopVfs;
 
 /** Describe your transform plugin. */
@@ -36,13 +37,14 @@ public class GoogleSheetsCredentials {
   public static final String APPLICATION_NAME = "Apache-Hop-Google-Sheets";
 
   public static HttpCredentialsAdapter getCredentialsJson(
-      String scope, String jsonCredentialPath, String impersonation) throws IOException {
+      String scope, String jsonCredentialPath, String impersonation, IVariables variables)
+      throws IOException {
 
     GoogleCredentials credential;
 
     InputStream in;
     try {
-      in = HopVfs.getInputStream(jsonCredentialPath);
+      in = HopVfs.getInputStream(jsonCredentialPath, variables);
     } catch (HopFileException ex) {
       throw new IOException("Error opening JSON Credentials file " + jsonCredentialPath, ex);
     }

--- a/plugins/tech/google/src/main/java/org/apache/hop/pipeline/transforms/googlesheets/GoogleSheetsInput.java
+++ b/plugins/tech/google/src/main/java/org/apache/hop/pipeline/transforms/googlesheets/GoogleSheetsInput.java
@@ -77,7 +77,10 @@ public class GoogleSheetsInput extends BaseTransform<GoogleSheetsInputMeta, Goog
       try {
         HttpRequestInitializer credential =
             GoogleSheetsCredentials.getCredentialsJson(
-                scope, resolve(meta.getJsonCredentialPath()), resolve(meta.getImpersonation()));
+                scope,
+                resolve(meta.getJsonCredentialPath()),
+                resolve(meta.getImpersonation()),
+                variables);
         Sheets service =
             new Sheets.Builder(
                     HTTP_TRANSPORT,

--- a/plugins/tech/google/src/main/java/org/apache/hop/pipeline/transforms/googlesheets/GoogleSheetsInputDialog.java
+++ b/plugins/tech/google/src/main/java/org/apache/hop/pipeline/transforms/googlesheets/GoogleSheetsInputDialog.java
@@ -483,7 +483,8 @@ public class GoogleSheetsInputDialog extends BaseTransformDialog {
           GoogleSheetsCredentials.getCredentialsJson(
               scope,
               variables.resolve(meta.getJsonCredentialPath()),
-              variables.resolve(meta.getImpersonation()));
+              variables.resolve(meta.getImpersonation()),
+              variables);
       //
       new Drive.Builder(
               HTTP_TRANSPORT,
@@ -507,7 +508,8 @@ public class GoogleSheetsInputDialog extends BaseTransformDialog {
           GoogleSheetsCredentials.getCredentialsJson(
               scope,
               variables.resolve(meta.getJsonCredentialPath()),
-              variables.resolve(meta.getImpersonation()));
+              variables.resolve(meta.getImpersonation()),
+              variables);
       //
       Drive service =
           new Drive.Builder(
@@ -573,7 +575,8 @@ public class GoogleSheetsInputDialog extends BaseTransformDialog {
           GoogleSheetsCredentials.getCredentialsJson(
               scope,
               variables.resolve(meta.getJsonCredentialPath()),
-              variables.resolve(meta.getImpersonation()));
+              variables.resolve(meta.getImpersonation()),
+              variables);
       //
       Sheets service =
           new Sheets.Builder(
@@ -779,7 +782,8 @@ public class GoogleSheetsInputDialog extends BaseTransformDialog {
           GoogleSheetsCredentials.getCredentialsJson(
               scope,
               variables.resolve(meta.getJsonCredentialPath()),
-              variables.resolve(meta.getImpersonation()));
+              variables.resolve(meta.getImpersonation()),
+              variables);
       Sheets service =
           new Sheets.Builder(
                   HTTP_TRANSPORT,

--- a/plugins/tech/google/src/main/java/org/apache/hop/pipeline/transforms/googlesheets/GoogleSheetsOutput.java
+++ b/plugins/tech/google/src/main/java/org/apache/hop/pipeline/transforms/googlesheets/GoogleSheetsOutput.java
@@ -88,7 +88,10 @@ public class GoogleSheetsOutput
 
         HttpRequestInitializer credential =
             GoogleSheetsCredentials.getCredentialsJson(
-                scope, resolve(meta.getJsonCredentialPath()), resolve(meta.getImpersonation()));
+                scope,
+                resolve(meta.getJsonCredentialPath()),
+                resolve(meta.getImpersonation()),
+                variables);
         Drive service =
             new Drive.Builder(
                     HTTP_TRANSPORT,
@@ -321,7 +324,10 @@ public class GoogleSheetsOutput
           String scope = SheetsScopes.SPREADSHEETS;
           HttpRequestInitializer credential =
               GoogleSheetsCredentials.getCredentialsJson(
-                  scope, resolve(meta.getJsonCredentialPath()), resolve(meta.getImpersonation()));
+                  scope,
+                  resolve(meta.getJsonCredentialPath()),
+                  resolve(meta.getImpersonation()),
+                  variables);
           data.service =
               new Sheets.Builder(
                       HTTP_TRANSPORT,

--- a/plugins/tech/google/src/main/java/org/apache/hop/pipeline/transforms/googlesheets/GoogleSheetsOutputDialog.java
+++ b/plugins/tech/google/src/main/java/org/apache/hop/pipeline/transforms/googlesheets/GoogleSheetsOutputDialog.java
@@ -476,7 +476,8 @@ public class GoogleSheetsOutputDialog extends BaseTransformDialog {
           GoogleSheetsCredentials.getCredentialsJson(
               scope,
               variables.resolve(meta.getJsonCredentialPath()),
-              variables.resolve(meta.getImpersonation()));
+              variables.resolve(meta.getImpersonation()),
+              variables);
       Sheets service =
           new Sheets.Builder(
                   HTTP_TRANSPORT,
@@ -531,7 +532,8 @@ public class GoogleSheetsOutputDialog extends BaseTransformDialog {
           GoogleSheetsCredentials.getCredentialsJson(
               scope,
               variables.resolve(meta.getJsonCredentialPath()),
-              variables.resolve(meta.getImpersonation()));
+              variables.resolve(meta.getImpersonation()),
+              variables);
       Drive service =
           new Drive.Builder(
                   HTTP_TRANSPORT,
@@ -594,7 +596,8 @@ public class GoogleSheetsOutputDialog extends BaseTransformDialog {
           GoogleSheetsCredentials.getCredentialsJson(
               scope,
               variables.resolve(meta.getJsonCredentialPath()),
-              variables.resolve(meta.getImpersonation()));
+              variables.resolve(meta.getImpersonation()),
+              variables);
       // Build a Drive connection to test it
       //
       new Drive.Builder(

--- a/plugins/tech/google/src/main/java/org/apache/hop/vfs/googledrive/GoogleDriveVfsPlugin.java
+++ b/plugins/tech/google/src/main/java/org/apache/hop/vfs/googledrive/GoogleDriveVfsPlugin.java
@@ -17,7 +17,9 @@
 
 package org.apache.hop.vfs.googledrive;
 
+import java.util.Map;
 import org.apache.commons.vfs2.provider.FileProvider;
+import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.core.vfs.plugin.IVfs;
 import org.apache.hop.core.vfs.plugin.VfsPlugin;
 
@@ -31,5 +33,10 @@ public class GoogleDriveVfsPlugin implements IVfs {
   @Override
   public FileProvider getProvider() {
     return new GoogleDriveFileProvider();
+  }
+
+  @Override
+  public Map<String, FileProvider> getProviders(IVariables variables) {
+    return null;
   }
 }

--- a/plugins/tech/google/src/main/java/org/apache/hop/vfs/gs/GoogleStorageVfsPlugin.java
+++ b/plugins/tech/google/src/main/java/org/apache/hop/vfs/gs/GoogleStorageVfsPlugin.java
@@ -17,7 +17,9 @@
 
 package org.apache.hop.vfs.gs;
 
+import java.util.Map;
 import org.apache.commons.vfs2.provider.FileProvider;
+import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.core.vfs.plugin.IVfs;
 import org.apache.hop.core.vfs.plugin.VfsPlugin;
 
@@ -31,5 +33,10 @@ public class GoogleStorageVfsPlugin implements IVfs {
   @Override
   public FileProvider getProvider() {
     return new GoogleStorageFileProvider();
+  }
+
+  @Override
+  public Map<String, FileProvider> getProviders(IVariables variables) {
+    return null;
   }
 }

--- a/plugins/tech/parquet/src/main/java/org/apache/hop/parquet/transforms/input/ParquetInput.java
+++ b/plugins/tech/parquet/src/main/java/org/apache/hop/parquet/transforms/input/ParquetInput.java
@@ -71,7 +71,7 @@ public class ParquetInput extends BaseTransform<ParquetInputMeta, ParquetInputDa
     }
 
     String filename = getInputRowMeta().getString(row, data.filenameFieldIndex);
-    FileObject fileObject = HopVfs.getFileObject(filename);
+    FileObject fileObject = HopVfs.getFileObject(filename, variables);
 
     try {
       long size = fileObject.getContent().getSize();

--- a/plugins/tech/parquet/src/main/java/org/apache/hop/parquet/transforms/input/ParquetInputDialog.java
+++ b/plugins/tech/parquet/src/main/java/org/apache/hop/parquet/transforms/input/ParquetInputDialog.java
@@ -211,7 +211,7 @@ public class ParquetInputDialog extends BaseTransformDialog {
               new String[] {"Parquet files", "All files"},
               true);
       if (filename != null) {
-        FileObject fileObject = HopVfs.getFileObject(variables.resolve(filename));
+        FileObject fileObject = HopVfs.getFileObject(variables.resolve(filename), variables);
 
         long size = fileObject.getContent().getSize();
         InputStream inputStream = HopVfs.getInputStream(fileObject);

--- a/plugins/tech/parquet/src/main/java/org/apache/hop/parquet/transforms/output/ParquetOutput.java
+++ b/plugins/tech/parquet/src/main/java/org/apache/hop/parquet/transforms/output/ParquetOutput.java
@@ -213,7 +213,7 @@ public class ParquetOutput extends BaseTransform<ParquetOutputMeta, ParquetOutpu
     data.filename = buildFilename(getPipeline().getExecutionStartDate());
 
     try {
-      FileObject fileObject = HopVfs.getFileObject(data.filename);
+      FileObject fileObject = HopVfs.getFileObject(data.filename, variables);
 
       // See if we need to create the parent folder(s)...
       //
@@ -226,7 +226,7 @@ public class ParquetOutput extends BaseTransform<ParquetOutputMeta, ParquetOutpu
         }
       }
 
-      data.outputStream = HopVfs.getOutputStream(data.filename, false);
+      data.outputStream = HopVfs.getOutputStream(data.filename, false, variables);
       data.outputFile = new ParquetOutputFile(data.outputStream);
 
       data.writer =

--- a/plugins/transforms/changefileencoding/src/main/java/org/apache/hop/pipeline/transforms/changefileencoding/ChangeFileEncoding.java
+++ b/plugins/transforms/changefileencoding/src/main/java/org/apache/hop/pipeline/transforms/changefileencoding/ChangeFileEncoding.java
@@ -137,7 +137,7 @@ public class ChangeFileEncoding
                 PKG, "ChangeFileEncoding.Error.TargetFileIsEmpty", meta.getTargetFilenameField()));
       }
 
-      data.sourceFile = HopVfs.getFileObject(sourceFilename);
+      data.sourceFile = HopVfs.getFileObject(sourceFilename, variables);
 
       // Check if source file exists
       if (!data.sourceFile.exists()) {
@@ -258,7 +258,7 @@ public class ChangeFileEncoding
         ResultFile resultFile =
             new ResultFile(
                 ResultFile.FILE_TYPE_GENERAL,
-                HopVfs.getFileObject(targetFilename),
+                HopVfs.getFileObject(targetFilename, variables),
                 getPipelineMeta().getName(),
                 getTransformName());
         resultFile.setComment(

--- a/plugins/transforms/changefileencoding/src/main/java/org/apache/hop/pipeline/transforms/changefileencoding/ChangeFileEncodingDialog.java
+++ b/plugins/transforms/changefileencoding/src/main/java/org/apache/hop/pipeline/transforms/changefileencoding/ChangeFileEncodingDialog.java
@@ -96,7 +96,7 @@ public class ChangeFileEncodingDialog extends BaseTransformDialog {
     shell.setText(BaseMessages.getString(PKG, "ChangeFileEncodingDialog.Shell.Title"));
 
     int middle = props.getMiddlePct();
-    int margin = props.getMargin();
+    int margin = PropsUi.getMargin();
 
     // Buttons at the very bottom
     wOk = new Button(shell, SWT.PUSH);

--- a/plugins/transforms/cubeinput/src/main/java/org/apache/hop/pipeline/transforms/cubeinput/CubeInput.java
+++ b/plugins/transforms/cubeinput/src/main/java/org/apache/hop/pipeline/transforms/cubeinput/CubeInput.java
@@ -74,10 +74,8 @@ public class CubeInput extends BaseTransform<CubeInputMeta, CubeInputData> {
       throw new HopException(e); // shouldn't happen on files
     }
 
-    if (checkFeedback(getLinesInput())) {
-      if (log.isBasic()) {
-        logBasic(BaseMessages.getString(PKG, "CubeInput.Log.LineNumber") + getLinesInput());
-      }
+    if (checkFeedback(getLinesInput()) && log.isBasic()) {
+      logBasic(BaseMessages.getString(PKG, "CubeInput.Log.LineNumber") + getLinesInput());
     }
 
     return true;
@@ -95,14 +93,14 @@ public class CubeInput extends BaseTransform<CubeInputMeta, CubeInputData> {
           ResultFile resultFile =
               new ResultFile(
                   ResultFile.FILE_TYPE_GENERAL,
-                  HopVfs.getFileObject(filename),
+                  HopVfs.getFileObject(filename, variables),
                   getPipelineMeta().getName(),
                   toString());
           resultFile.setComment("File was read by a Cube Input transform");
           addResultFile(resultFile);
         }
 
-        data.fis = HopVfs.getInputStream(filename);
+        data.fis = HopVfs.getInputStream(filename, variables);
         data.zip = new GZIPInputStream(data.fis);
         data.dis = new DataInputStream(data.zip);
 

--- a/plugins/transforms/cubeinput/src/main/java/org/apache/hop/pipeline/transforms/cubeinput/CubeInputDialog.java
+++ b/plugins/transforms/cubeinput/src/main/java/org/apache/hop/pipeline/transforms/cubeinput/CubeInputDialog.java
@@ -71,7 +71,7 @@ public class CubeInputDialog extends BaseTransformDialog {
     shell.setText(BaseMessages.getString(PKG, "CubeInputDialog.Shell.Title"));
 
     int middle = props.getMiddlePct();
-    int margin = props.getMargin();
+    int margin = PropsUi.getMargin();
 
     // TransformName line
     wlTransformName = new Label(shell, SWT.RIGHT);

--- a/plugins/transforms/cubeoutput/src/main/java/org/apache/hop/pipeline/transforms/cubeoutput/CubeOutput.java
+++ b/plugins/transforms/cubeoutput/src/main/java/org/apache/hop/pipeline/transforms/cubeoutput/CubeOutput.java
@@ -114,10 +114,8 @@ public class CubeOutput extends BaseTransform<CubeOutputMeta, CubeOutputData> {
 
     putRow(data.outputMeta, r); // in case we want it to go further...
 
-    if (checkFeedback(getLinesOutput())) {
-      if (log.isBasic()) {
-        logBasic(BaseMessages.getString(PKG, "CubeOutput.Log.LineNumber") + getLinesOutput());
-      }
+    if (checkFeedback(getLinesOutput()) && log.isBasic()) {
+      logBasic(BaseMessages.getString(PKG, "CubeOutput.Log.LineNumber") + getLinesOutput());
     }
 
     return result;
@@ -172,7 +170,7 @@ public class CubeOutput extends BaseTransform<CubeOutputMeta, CubeOutputData> {
     try {
       String filename = resolve(meta.getFilename());
 
-      FileObject fileObject = HopVfs.getFileObject(filename);
+      FileObject fileObject = HopVfs.getFileObject(filename, variables);
 
       // See if we need to create the parent folder(s)...
       //
@@ -192,7 +190,7 @@ public class CubeOutput extends BaseTransform<CubeOutputMeta, CubeOutputData> {
         addResultFile(resultFile);
       }
 
-      data.fos = HopVfs.getOutputStream(filename, false);
+      data.fos = HopVfs.getOutputStream(filename, false, variables);
       data.zip = new GZIPOutputStream(data.fos);
       data.dos = new DataOutputStream(data.zip);
     } catch (Exception e) {

--- a/plugins/transforms/edi2xml/src/main/java/org/apache/hop/pipeline/transforms/edi2xml/Edi2Xml.java
+++ b/plugins/transforms/edi2xml/src/main/java/org/apache/hop/pipeline/transforms/edi2xml/Edi2Xml.java
@@ -37,6 +37,8 @@ import org.apache.hop.pipeline.transforms.edi2xml.grammar.FastSimpleGenericEdifa
 public class Edi2Xml extends BaseTransform<Edi2XmlMeta, Edi2XmlData> {
 
   private static final Class<?> PKG = Edi2XmlMeta.class; // For Translator
+  private static final String CONST_UNKNOWN = "<UNKNOWN>";
+  private static final String CONST_PROBLEM_LINE = "Problem line: ";
 
   private FastSimpleGenericEdifactDirectXMLLexer lexer;
   private CommonTokenStream tokens;
@@ -128,7 +130,7 @@ public class Edi2Xml extends BaseTransform<Edi2XmlMeta, Edi2XmlData> {
           "error parsing edi on line " + e.line + " position " + e.charPositionInLine);
       errorMessage.append(
           ": expecting "
-              + ((e.expecting > -1) ? parser.getTokenNames()[e.expecting] : "<UNKNOWN>")
+              + ((e.expecting > -1) ? parser.getTokenNames()[e.expecting] : CONST_UNKNOWN)
               + " but found ");
       errorMessage.append(
           (e.token.getType() >= 0) ? parser.getTokenNames()[e.token.getType()] : "<EOF>");
@@ -145,15 +147,15 @@ public class Edi2Xml extends BaseTransform<Edi2XmlMeta, Edi2XmlData> {
         logError(errorMessage.toString());
 
         // try to determine the error line
-        String errorline = "<UNKNOWN>";
+        String errorline = CONST_UNKNOWN;
         try {
           errorline = inputValue.split("\\r?\\n")[e.line - 1];
         } catch (Exception ee) {
           // Ignore pattern syntax errors
         }
 
-        logError("Problem line: " + errorline);
-        logError(StringUtils.leftPad("^", e.charPositionInLine + "Problem line: ".length() + 1));
+        logError(CONST_PROBLEM_LINE + errorline);
+        logError(StringUtils.leftPad("^", e.charPositionInLine + CONST_PROBLEM_LINE.length() + 1));
         throw new HopException(e);
       }
     } catch (RecognitionException e) {
@@ -178,15 +180,15 @@ public class Edi2Xml extends BaseTransform<Edi2XmlMeta, Edi2XmlData> {
         logError(errorMessage.toString());
 
         // try to determine the error line
-        String errorline = "<UNKNOWN>";
+        String errorline = CONST_UNKNOWN;
         try {
           errorline = inputValue.split("\\r?\\n")[e.line - 1];
         } catch (Exception ee) {
           // Ignore pattern syntax errors
         }
 
-        logError("Problem line: " + errorline);
-        logError(StringUtils.leftPad("^", e.charPositionInLine + "Problem line: ".length() + 1));
+        logError(CONST_PROBLEM_LINE + errorline);
+        logError(StringUtils.leftPad("^", e.charPositionInLine + CONST_PROBLEM_LINE.length() + 1));
 
         throw new HopException(e);
       }

--- a/plugins/transforms/edi2xml/src/main/java/org/apache/hop/pipeline/transforms/edi2xml/Edi2XmlDialog.java
+++ b/plugins/transforms/edi2xml/src/main/java/org/apache/hop/pipeline/transforms/edi2xml/Edi2XmlDialog.java
@@ -74,7 +74,7 @@ public class Edi2XmlDialog extends BaseTransformDialog {
     shell.setText(BaseMessages.getString(PKG, "Edi2Xml.Shell.Title"));
 
     int middle = props.getMiddlePct();
-    int margin = props.getMargin();
+    int margin = PropsUi.getMargin();
 
     // TransformName line
     wlTransformName = new Label(shell, SWT.RIGHT);

--- a/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelinput/ExcelInput.java
+++ b/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelinput/ExcelInput.java
@@ -417,7 +417,7 @@ public class ExcelInput extends BaseTransform<ExcelInputMeta, ExcelInputData> {
           }
           String fileValue = rowSet.getRowMeta().getString(fileRow, idx);
           try {
-            data.files.addFile(HopVfs.getFileObject(fileValue));
+            data.files.addFile(HopVfs.getFileObject(fileValue, variables));
           } catch (HopFileException e) {
             throw new HopException(
                 BaseMessages.getString(
@@ -582,7 +582,7 @@ public class ExcelInput extends BaseTransform<ExcelInputMeta, ExcelInputData> {
 
         data.workbook =
             WorkbookFactory.getWorkbook(
-                meta.getSpreadSheetType(), data.filename, meta.getEncoding());
+                meta.getSpreadSheetType(), data.filename, meta.getEncoding(), variables);
 
         data.errorHandler.handleFile(data.file);
         // Start at the first sheet again...

--- a/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelinput/ExcelInputDialog.java
+++ b/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelinput/ExcelInputDialog.java
@@ -33,8 +33,8 @@ import org.apache.hop.core.fileinput.FileInputList;
 import org.apache.hop.core.row.IRowMeta;
 import org.apache.hop.core.row.IValueMeta;
 import org.apache.hop.core.row.RowMeta;
+import org.apache.hop.core.row.value.ValueMetaBase;
 import org.apache.hop.core.row.value.ValueMetaFactory;
-import org.apache.hop.core.row.value.ValueMetaString;
 import org.apache.hop.core.spreadsheet.IKCell;
 import org.apache.hop.core.spreadsheet.IKSheet;
 import org.apache.hop.core.spreadsheet.IKWorkbook;
@@ -94,10 +94,18 @@ public class ExcelInputDialog extends BaseTransformDialog {
   /** Marker put on tab to indicate attention required */
   private static final String TAB_FLAG = "!";
 
+  private static final String CONST_COMBO_NO = "System.Combo.No";
+  private static final String CONST_COMBO_YES = "System.Combo.Yes";
+  private static final String CONST_ERROR_TITLE = "System.Dialog.Error.Title";
+  private static final String CONST_BUTTON_BROWSE = "System.Button.Browse";
+  private static final String CONST_BUTTON_VARIABLE = "System.Button.Variable";
+  private static final String CONST_LABEL_EXTENSION = "System.Label.Extension";
+  private static final String CONST_BROWSE_FOR_DIR = "System.Tooltip.BrowseForDir";
+  private static final String CONST_BROWSE_TO_DIR = "System.Tooltip.VariableToDir";
+
   private static final String[] YES_NO_COMBO =
       new String[] {
-        BaseMessages.getString(PKG, "System.Combo.No"),
-        BaseMessages.getString(PKG, "System.Combo.Yes")
+        BaseMessages.getString(PKG, CONST_COMBO_NO), BaseMessages.getString(PKG, CONST_COMBO_YES)
       };
 
   private CTabFolder wTabFolder;
@@ -331,7 +339,7 @@ public class ExcelInputDialog extends BaseTransformDialog {
 
     wbbFilename = new Button(wFileComp, SWT.PUSH | SWT.CENTER);
     PropsUi.setLook(wbbFilename);
-    wbbFilename.setText(BaseMessages.getString(PKG, "System.Button.Browse"));
+    wbbFilename.setText(BaseMessages.getString(PKG, CONST_BUTTON_BROWSE));
     wbbFilename.setToolTipText(
         BaseMessages.getString(PKG, "System.Tooltip.BrowseForFileOrDirAndAdd"));
     FormData fdbFilename = new FormData();
@@ -930,8 +938,8 @@ public class ExcelInputDialog extends BaseTransformDialog {
           new ColumnInfo(
               BaseMessages.getString(PKG, "ExcelInputDialog.Repeat.Column"),
               ColumnInfo.COLUMN_TYPE_CCOMBO,
-              BaseMessages.getString(PKG, "System.Combo.Yes"),
-              BaseMessages.getString(PKG, "System.Combo.No")),
+              BaseMessages.getString(PKG, CONST_COMBO_YES),
+              BaseMessages.getString(PKG, CONST_COMBO_NO)),
           new ColumnInfo(
               BaseMessages.getString(PKG, "ExcelInputDialog.Format.Column"),
               ColumnInfo.COLUMN_TYPE_FORMAT,
@@ -1120,50 +1128,47 @@ public class ExcelInputDialog extends BaseTransformDialog {
       mb.setText(BaseMessages.getString(PKG, "ExcelInputDialog.Load.SchemaDefinition.Title"));
       int answer = mb.open();
 
-      if (answer == SWT.YES) {
-        if (!Utils.isEmpty(schemaName)) {
-          try {
-            SchemaDefinition schemaDefinition =
-                (new SchemaDefinitionUtil()).loadSchemaDefinition(metadataProvider, schemaName);
-            if (schemaDefinition != null) {
-              IRowMeta r = schemaDefinition.getRowMeta();
-              if (r != null) {
-                String[] fieldNames = r.getFieldNames();
-                if (fieldNames != null) {
-                  wFields.clearAll();
-                  for (int i = 0; i < fieldNames.length; i++) {
-                    IValueMeta valueMeta = r.getValueMeta(i);
-                    TableItem item = new TableItem(wFields.table, SWT.NONE);
+      if (answer == SWT.YES && !Utils.isEmpty(schemaName)) {
+        try {
+          SchemaDefinition schemaDefinition =
+              (new SchemaDefinitionUtil()).loadSchemaDefinition(metadataProvider, schemaName);
+          if (schemaDefinition != null) {
+            IRowMeta r = schemaDefinition.getRowMeta();
+            if (r != null) {
+              String[] fieldNames = r.getFieldNames();
+              if (fieldNames != null) {
+                wFields.clearAll();
+                for (int i = 0; i < fieldNames.length; i++) {
+                  IValueMeta valueMeta = r.getValueMeta(i);
+                  TableItem item = new TableItem(wFields.table, SWT.NONE);
 
-                    item.setText(1, valueMeta.getName());
-                    item.setText(2, ValueMetaFactory.getValueMetaName(valueMeta.getType()));
-                    item.setText(
-                        3,
-                        valueMeta.getLength() >= 0 ? Integer.toString(valueMeta.getLength()) : "");
-                    item.setText(
-                        4,
-                        valueMeta.getPrecision() >= 0
-                            ? Integer.toString(valueMeta.getPrecision())
-                            : "");
-                    item.setText(
-                        5, Const.NVL(ValueMetaString.getTrimTypeDesc(valueMeta.getTrimType()), ""));
-                    item.setText(7, Const.NVL(valueMeta.getConversionMask(), ""));
-                    item.setText(8, Const.NVL(valueMeta.getCurrencySymbol(), ""));
-                    item.setText(9, Const.NVL(valueMeta.getDecimalSymbol(), ""));
-                    item.setText(10, Const.NVL(valueMeta.getGroupingSymbol(), ""));
-                  }
+                  item.setText(1, valueMeta.getName());
+                  item.setText(2, ValueMetaFactory.getValueMetaName(valueMeta.getType()));
+                  item.setText(
+                      3, valueMeta.getLength() >= 0 ? Integer.toString(valueMeta.getLength()) : "");
+                  item.setText(
+                      4,
+                      valueMeta.getPrecision() >= 0
+                          ? Integer.toString(valueMeta.getPrecision())
+                          : "");
+                  item.setText(
+                      5, Const.NVL(ValueMetaBase.getTrimTypeDesc(valueMeta.getTrimType()), ""));
+                  item.setText(7, Const.NVL(valueMeta.getConversionMask(), ""));
+                  item.setText(8, Const.NVL(valueMeta.getCurrencySymbol(), ""));
+                  item.setText(9, Const.NVL(valueMeta.getDecimalSymbol(), ""));
+                  item.setText(10, Const.NVL(valueMeta.getGroupingSymbol(), ""));
                 }
               }
             }
-          } catch (HopTransformException | HopPluginException e) {
-
-            // ignore any errors here.
           }
+        } catch (HopTransformException | HopPluginException e) {
 
-          wFields.removeEmptyRows();
-          wFields.setRowNums();
-          wFields.optWidth(true);
+          // ignore any errors here.
         }
+
+        wFields.removeEmptyRows();
+        wFields.setRowNums();
+        wFields.optWidth(true);
       }
     }
   }
@@ -1272,8 +1277,8 @@ public class ExcelInputDialog extends BaseTransformDialog {
       String trim = f.getTrimType().getDescription();
       String rep =
           f.isRepeat()
-              ? BaseMessages.getString(PKG, "System.Combo.Yes")
-              : BaseMessages.getString(PKG, "System.Combo.No");
+              ? BaseMessages.getString(PKG, CONST_COMBO_YES)
+              : BaseMessages.getString(PKG, CONST_COMBO_NO);
       String format = f.getFormat();
       String currency = f.getCurrencySymbol();
       String decimal = f.getDecimalSymbol();
@@ -1394,7 +1399,7 @@ public class ExcelInputDialog extends BaseTransformDialog {
       String sprec = item.getText(4);
       field.setTrimType(IValueMeta.TrimType.lookupDescription(item.getText(5)));
       field.setRepeat(
-          BaseMessages.getString(PKG, "System.Combo.Yes").equalsIgnoreCase(item.getText(6)));
+          BaseMessages.getString(PKG, CONST_COMBO_YES).equalsIgnoreCase(item.getText(6)));
       field.setLength(Const.toInt(slength, -1));
       field.setPrecision(Const.toInt(sprec, -1));
       field.setFormat(item.getText(7));
@@ -1529,8 +1534,8 @@ public class ExcelInputDialog extends BaseTransformDialog {
 
     wbbWarningDestDir = new Button(wErrorComp, SWT.PUSH | SWT.CENTER);
     PropsUi.setLook(wbbWarningDestDir);
-    wbbWarningDestDir.setText(BaseMessages.getString(PKG, "System.Button.Browse"));
-    wbbWarningDestDir.setToolTipText(BaseMessages.getString(PKG, "System.Tooltip.BrowseForDir"));
+    wbbWarningDestDir.setText(BaseMessages.getString(PKG, CONST_BUTTON_BROWSE));
+    wbbWarningDestDir.setToolTipText(BaseMessages.getString(PKG, CONST_BROWSE_FOR_DIR));
     FormData fdbWarningDestDir = new FormData();
     fdbWarningDestDir.right = new FormAttachment(100, 0);
     fdbWarningDestDir.top = new FormAttachment(previous, margin * 4);
@@ -1538,8 +1543,8 @@ public class ExcelInputDialog extends BaseTransformDialog {
 
     wbvWarningDestDir = new Button(wErrorComp, SWT.PUSH | SWT.CENTER);
     PropsUi.setLook(wbvWarningDestDir);
-    wbvWarningDestDir.setText(BaseMessages.getString(PKG, "System.Button.Variable"));
-    wbvWarningDestDir.setToolTipText(BaseMessages.getString(PKG, "System.Tooltip.VariableToDir"));
+    wbvWarningDestDir.setText(BaseMessages.getString(PKG, CONST_BUTTON_VARIABLE));
+    wbvWarningDestDir.setToolTipText(BaseMessages.getString(PKG, CONST_BROWSE_TO_DIR));
     FormData fdbvWarningDestDir = new FormData();
     fdbvWarningDestDir.right = new FormAttachment(wbbWarningDestDir, -margin);
     fdbvWarningDestDir.top = new FormAttachment(previous, margin * 4);
@@ -1554,7 +1559,7 @@ public class ExcelInputDialog extends BaseTransformDialog {
     wWarningExt.setLayoutData(fdWarningDestExt);
 
     wlWarningExt = new Label(wErrorComp, SWT.RIGHT);
-    wlWarningExt.setText(BaseMessages.getString(PKG, "System.Label.Extension"));
+    wlWarningExt.setText(BaseMessages.getString(PKG, CONST_LABEL_EXTENSION));
     PropsUi.setLook(wlWarningExt);
     FormData fdlWarningDestExt = new FormData();
     fdlWarningDestExt.top = new FormAttachment(previous, margin * 4);
@@ -1595,8 +1600,8 @@ public class ExcelInputDialog extends BaseTransformDialog {
 
     wbbErrorDestDir = new Button(wErrorComp, SWT.PUSH | SWT.CENTER);
     PropsUi.setLook(wbbErrorDestDir);
-    wbbErrorDestDir.setText(BaseMessages.getString(PKG, "System.Button.Browse"));
-    wbbErrorDestDir.setToolTipText(BaseMessages.getString(PKG, "System.Tooltip.BrowseForDir"));
+    wbbErrorDestDir.setText(BaseMessages.getString(PKG, CONST_BUTTON_BROWSE));
+    wbbErrorDestDir.setToolTipText(BaseMessages.getString(PKG, CONST_BROWSE_FOR_DIR));
     FormData fdbErrorDestDir = new FormData();
     fdbErrorDestDir.right = new FormAttachment(100, 0);
     fdbErrorDestDir.top = new FormAttachment(previous, margin);
@@ -1604,8 +1609,8 @@ public class ExcelInputDialog extends BaseTransformDialog {
 
     wbvErrorDestDir = new Button(wErrorComp, SWT.PUSH | SWT.CENTER);
     PropsUi.setLook(wbvErrorDestDir);
-    wbvErrorDestDir.setText(BaseMessages.getString(PKG, "System.Button.Variable"));
-    wbvErrorDestDir.setToolTipText(BaseMessages.getString(PKG, "System.Tooltip.VariableToDir"));
+    wbvErrorDestDir.setText(BaseMessages.getString(PKG, CONST_BUTTON_VARIABLE));
+    wbvErrorDestDir.setToolTipText(BaseMessages.getString(PKG, CONST_BROWSE_TO_DIR));
     FormData fdbvErrorDestDir = new FormData();
     fdbvErrorDestDir.right = new FormAttachment(wbbErrorDestDir, -margin);
     fdbvErrorDestDir.top = new FormAttachment(previous, margin);
@@ -1620,7 +1625,7 @@ public class ExcelInputDialog extends BaseTransformDialog {
     wErrorExt.setLayoutData(fdErrorDestExt);
 
     wlErrorExt = new Label(wErrorComp, SWT.RIGHT);
-    wlErrorExt.setText(BaseMessages.getString(PKG, "System.Label.Extension"));
+    wlErrorExt.setText(BaseMessages.getString(PKG, CONST_LABEL_EXTENSION));
     PropsUi.setLook(wlErrorExt);
     FormData fdlErrorDestExt = new FormData();
     fdlErrorDestExt.top = new FormAttachment(previous, margin);
@@ -1661,8 +1666,8 @@ public class ExcelInputDialog extends BaseTransformDialog {
 
     wbbLineNrDestDir = new Button(wErrorComp, SWT.PUSH | SWT.CENTER);
     PropsUi.setLook(wbbLineNrDestDir);
-    wbbLineNrDestDir.setText(BaseMessages.getString(PKG, "System.Button.Browse"));
-    wbbLineNrDestDir.setToolTipText(BaseMessages.getString(PKG, "System.Tooltip.BrowseForDir"));
+    wbbLineNrDestDir.setText(BaseMessages.getString(PKG, CONST_BUTTON_BROWSE));
+    wbbLineNrDestDir.setToolTipText(BaseMessages.getString(PKG, CONST_BROWSE_FOR_DIR));
     FormData fdbLineNrDestDir = new FormData();
     fdbLineNrDestDir.right = new FormAttachment(100, 0);
     fdbLineNrDestDir.top = new FormAttachment(previous, margin);
@@ -1670,8 +1675,8 @@ public class ExcelInputDialog extends BaseTransformDialog {
 
     wbvLineNrDestDir = new Button(wErrorComp, SWT.PUSH | SWT.CENTER);
     PropsUi.setLook(wbvLineNrDestDir);
-    wbvLineNrDestDir.setText(BaseMessages.getString(PKG, "System.Button.Variable"));
-    wbvLineNrDestDir.setToolTipText(BaseMessages.getString(PKG, "System.Tooltip.VariableToDir"));
+    wbvLineNrDestDir.setText(BaseMessages.getString(PKG, CONST_BUTTON_VARIABLE));
+    wbvLineNrDestDir.setToolTipText(BaseMessages.getString(PKG, CONST_BROWSE_TO_DIR));
     FormData fdbvLineNrDestDir = new FormData();
     fdbvLineNrDestDir.right = new FormAttachment(wbbLineNrDestDir, -margin);
     fdbvLineNrDestDir.top = new FormAttachment(previous, margin);
@@ -1686,7 +1691,7 @@ public class ExcelInputDialog extends BaseTransformDialog {
     wLineNrExt.setLayoutData(fdLineNrDestExt);
 
     wlLineNrExt = new Label(wErrorComp, SWT.RIGHT);
-    wlLineNrExt.setText(BaseMessages.getString(PKG, "System.Label.Extension"));
+    wlLineNrExt.setText(BaseMessages.getString(PKG, CONST_LABEL_EXTENSION));
     PropsUi.setLook(wlLineNrExt);
     FormData fdlLineNrDestExt = new FormData();
     fdlLineNrDestExt.top = new FormAttachment(previous, margin);
@@ -1812,7 +1817,10 @@ public class ExcelInputDialog extends BaseTransformDialog {
       try {
         IKWorkbook workbook =
             WorkbookFactory.getWorkbook(
-                info.getSpreadSheetType(), HopVfs.getFilename(fileObject), info.getEncoding());
+                info.getSpreadSheetType(),
+                HopVfs.getFilename(fileObject),
+                info.getEncoding(),
+                variables);
 
         int nrSheets = workbook.getNumberOfSheets();
         for (int j = 0; j < nrSheets; j++) {
@@ -1828,7 +1836,7 @@ public class ExcelInputDialog extends BaseTransformDialog {
       } catch (Exception e) {
         new ErrorDialog(
             shell,
-            BaseMessages.getString(PKG, "System.Dialog.Error.Title"),
+            BaseMessages.getString(PKG, CONST_ERROR_TITLE),
             BaseMessages.getString(
                 PKG,
                 "ExcelInputDialog.ErrorReadingFile.DialogMessage",
@@ -1880,13 +1888,13 @@ public class ExcelInputDialog extends BaseTransformDialog {
       try {
         IKWorkbook workbook =
             WorkbookFactory.getWorkbook(
-                info.getSpreadSheetType(), HopVfs.getFilename(file), info.getEncoding());
+                info.getSpreadSheetType(), HopVfs.getFilename(file), info.getEncoding(), variables);
         processingWorkbook(fields, info, workbook);
         workbook.close();
       } catch (Exception e) {
         new ErrorDialog(
             shell,
-            BaseMessages.getString(PKG, "System.Dialog.Error.Title"),
+            BaseMessages.getString(PKG, CONST_ERROR_TITLE),
             BaseMessages.getString(
                 PKG,
                 "ExcelInputDialog.ErrorReadingFile2.DialogMessage",
@@ -2010,7 +2018,7 @@ public class ExcelInputDialog extends BaseTransformDialog {
     } else {
       MessageBox mb = new MessageBox(shell, SWT.OK | SWT.ICON_ERROR);
       mb.setMessage(BaseMessages.getString(PKG, "ExcelInputDialog.NoFilesFound.DialogMessage"));
-      mb.setText(BaseMessages.getString(PKG, "System.Dialog.Error.Title"));
+      mb.setText(BaseMessages.getString(PKG, CONST_ERROR_TITLE));
       mb.open();
     }
   }

--- a/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelinput/ExcelInputMeta.java
+++ b/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelinput/ExcelInputMeta.java
@@ -796,7 +796,8 @@ public class ExcelInputMeta extends BaseTransformMeta<ExcelInput, ExcelInputData
         // Replace the filename ONLY (folder or filename)
         //
         for (EIFile file : files) {
-          FileObject fileObject = HopVfs.getFileObject(variables.resolve(file.getName()));
+          FileObject fileObject =
+              HopVfs.getFileObject(variables.resolve(file.getName()), variables);
           file.setName(
               iResourceNaming.nameResource(fileObject, variables, Utils.isEmpty(file.getMask())));
         }

--- a/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelinput/WorkbookFactory.java
+++ b/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelinput/WorkbookFactory.java
@@ -20,6 +20,7 @@ package org.apache.hop.pipeline.transforms.excelinput;
 import java.io.InputStream;
 import org.apache.hop.core.exception.HopException;
 import org.apache.hop.core.spreadsheet.IKWorkbook;
+import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.pipeline.transforms.excelinput.ods.OdfWorkbook;
 import org.apache.hop.pipeline.transforms.excelinput.poi.PoiWorkbook;
 import org.apache.hop.pipeline.transforms.excelinput.staxpoi.StaxPoiWorkbook;
@@ -30,17 +31,18 @@ public class WorkbookFactory {
     throw new IllegalStateException("Utility class");
   }
 
-  public static IKWorkbook getWorkbook(SpreadSheetType type, String filename, String encoding)
+  public static IKWorkbook getWorkbook(
+      SpreadSheetType type, String filename, String encoding, IVariables variables)
       throws HopException {
     switch (type) {
       case POI:
         return new PoiWorkbook(
-            filename, encoding); // encoding is not used, perhaps detected automatically?
+            filename, encoding, variables); // encoding is not used, perhaps detected automatically?
       case SAX_POI:
-        return new StaxPoiWorkbook(filename, encoding);
+        return new StaxPoiWorkbook(filename, encoding, variables);
       case ODS:
         return new OdfWorkbook(
-            filename, encoding); // encoding is not used, perhaps detected automatically?
+            filename, encoding, variables); // encoding is not used, perhaps detected automatically?
       default:
         throw new HopException(
             "Sorry, spreadsheet type " + type.getDescription() + " is not yet supported");

--- a/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelinput/ods/OdfWorkbook.java
+++ b/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelinput/ods/OdfWorkbook.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.apache.hop.core.exception.HopException;
 import org.apache.hop.core.spreadsheet.IKSheet;
 import org.apache.hop.core.spreadsheet.IKWorkbook;
+import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.core.vfs.HopVfs;
 import org.odftoolkit.odfdom.doc.OdfDocument;
 import org.odftoolkit.odfdom.doc.OdfSpreadsheetDocument;
@@ -35,13 +36,15 @@ public class OdfWorkbook implements IKWorkbook {
   private String encoding;
   private OdfDocument document;
   private Map<String, OdfSheet> openSheetsMap = new HashMap<>();
+  private IVariables variables;
 
-  public OdfWorkbook(String filename, String encoding) throws HopException {
+  public OdfWorkbook(String filename, String encoding, IVariables variables) throws HopException {
     this.filename = filename;
     this.encoding = encoding;
+    this.variables = variables;
 
     try {
-      document = OdfSpreadsheetDocument.loadDocument(HopVfs.getInputStream(filename));
+      document = OdfSpreadsheetDocument.loadDocument(HopVfs.getInputStream(filename, variables));
     } catch (Exception e) {
       throw new HopException(e);
     }

--- a/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelinput/poi/PoiWorkbook.java
+++ b/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelinput/poi/PoiWorkbook.java
@@ -27,6 +27,7 @@ import org.apache.hop.core.logging.HopLogStore;
 import org.apache.hop.core.logging.ILogChannel;
 import org.apache.hop.core.spreadsheet.IKSheet;
 import org.apache.hop.core.spreadsheet.IKWorkbook;
+import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.core.vfs.HopVfs;
 import org.apache.poi.poifs.filesystem.POIFSFileSystem;
 import org.apache.poi.ss.usermodel.Sheet;
@@ -39,15 +40,17 @@ public class PoiWorkbook implements IKWorkbook {
   private Workbook workbook;
   private String filename;
   private String encoding;
+  private IVariables variables;
 
   private POIFSFileSystem poifs;
 
-  public PoiWorkbook(String filename, String encoding) throws HopException {
+  public PoiWorkbook(String filename, String encoding, IVariables variables) throws HopException {
     this.filename = filename;
     this.encoding = encoding;
     this.log = HopLogStore.getLogChannelFactory().create(this);
+    this.variables = variables;
     try {
-      FileObject fileObject = HopVfs.getFileObject(filename);
+      FileObject fileObject = HopVfs.getFileObject(filename, variables);
       if (fileObject instanceof LocalFile) {
         // This supposedly shaves off a little bit of memory usage by allowing POI to randomly
         // access data in the file
@@ -61,7 +64,7 @@ public class PoiWorkbook implements IKWorkbook {
           workbook = org.apache.poi.ss.usermodel.WorkbookFactory.create(excelFile, null, true);
         }
       } else {
-        try (InputStream internalIS = HopVfs.getInputStream(filename)) {
+        try (InputStream internalIS = HopVfs.getInputStream(filename, variables)) {
           workbook = org.apache.poi.ss.usermodel.WorkbookFactory.create(internalIS);
         }
       }

--- a/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelinput/staxpoi/StaxPoiWorkbook.java
+++ b/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelinput/staxpoi/StaxPoiWorkbook.java
@@ -31,6 +31,7 @@ import org.apache.hop.core.logging.HopLogStore;
 import org.apache.hop.core.logging.ILogChannel;
 import org.apache.hop.core.spreadsheet.IKSheet;
 import org.apache.hop.core.spreadsheet.IKWorkbook;
+import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.core.vfs.HopVfs;
 import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.util.IOUtils;
@@ -58,6 +59,7 @@ public class StaxPoiWorkbook implements IKWorkbook {
   private Map<String, StaxPoiSheet> openSheetsMap;
 
   private OPCPackage opcpkg;
+  private IVariables variables;
 
   protected StaxPoiWorkbook() {
     openSheetsMap = new HashMap<>();
@@ -65,10 +67,11 @@ public class StaxPoiWorkbook implements IKWorkbook {
     this.log = HopLogStore.getLogChannelFactory().create(this);
   }
 
-  public StaxPoiWorkbook(String filename, String encoding) throws HopException {
+  public StaxPoiWorkbook(String filename, String encoding, IVariables variables)
+      throws HopException {
     this();
     try {
-      try (InputStream inputStream = HopVfs.getInputStream(filename)) {
+      try (InputStream inputStream = HopVfs.getInputStream(filename, variables)) {
         opcpkg = OPCPackage.open(inputStream);
         openFile(opcpkg, encoding);
       }

--- a/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelwriter/ExcelWriterTransform.java
+++ b/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelwriter/ExcelWriterTransform.java
@@ -72,7 +72,7 @@ public class ExcelWriterTransform
   public static final String STREAMER_FORCE_RECALC_PROP_NAME =
       "HOP_EXCEL_WRITER_STREAMER_FORCE_RECALCULATE";
 
-  public static int BYTE_ARRAY_MAX_OVERRIDE = 250000000;
+  public static final int BYTE_ARRAY_MAX_OVERRIDE = 250000000;
 
   public ExcelWriterTransform(
       TransformMeta transformMeta,
@@ -838,7 +838,7 @@ public class ExcelWriterTransform
           // handle template case (must have same format)
           // ensure extensions match
           String templateExt =
-              HopVfs.getFileObject(data.realTemplateFileName).getName().getExtension();
+              HopVfs.getFileObject(data.realTemplateFileName, variables).getName().getExtension();
           if (!meta.getFile().getExtension().equalsIgnoreCase(templateExt)) {
             throw new HopException(
                 "Template Format Mismatch: Template has extension: "
@@ -848,9 +848,9 @@ public class ExcelWriterTransform
                     + ". Template and output file must share the same format!");
           }
 
-          if (HopVfs.getFileObject(data.realTemplateFileName).exists()) {
+          if (HopVfs.getFileObject(data.realTemplateFileName, variables).exists()) {
             // if the template exists just copy the template in place
-            copyFile(HopVfs.getFileObject(data.realTemplateFileName), file);
+            copyFile(HopVfs.getFileObject(data.realTemplateFileName, variables), file);
           } else {
             // template is missing, log it and get out
             if (log.isBasic()) {
@@ -881,7 +881,7 @@ public class ExcelWriterTransform
       Sheet sheet;
       // file is guaranteed to be in place now
       if (meta.getFile().getExtension().equalsIgnoreCase("xlsx")) {
-        try (InputStream inputStream = HopVfs.getInputStream(HopVfs.getFilename(file))) {
+        try (InputStream inputStream = HopVfs.getInputStream(HopVfs.getFilename(file), variables)) {
           XSSFWorkbook xssfWorkbook = new XSSFWorkbook(inputStream);
           if (meta.getFile().isStreamingData() && !meta.getTemplate().isTemplateEnabled()) {
             wb = new SXSSFWorkbook(xssfWorkbook, 100);
@@ -1020,7 +1020,7 @@ public class ExcelWriterTransform
       if (meta.getFile().getExtension().equalsIgnoreCase("xlsx")
           && meta.getFile().isStreamingData()
           && meta.getTemplate().isTemplateEnabled()) {
-        try (InputStream inputStream = HopVfs.getInputStream(HopVfs.getFilename(file))) {
+        try (InputStream inputStream = HopVfs.getInputStream(HopVfs.getFilename(file), variables)) {
           XSSFWorkbook xssfWorkbook = new XSSFWorkbook(inputStream);
           wb = new SXSSFWorkbook(xssfWorkbook, 100);
           sheet = wb.getSheet(data.realSheetname);
@@ -1170,7 +1170,7 @@ public class ExcelWriterTransform
         (!meta.getFile().isFileNameInField())
             ? buildFilename(getNextSplitNr(meta.getFile().getFileName()))
             : buildFilename(data.inputRowMeta, row);
-    return HopVfs.getFileObject(buildFilename);
+    return HopVfs.getFileObject(buildFilename, variables);
   }
 
   /**

--- a/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelwriter/ExcelWriterTransformDialog.java
+++ b/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelwriter/ExcelWriterTransformDialog.java
@@ -1647,37 +1647,35 @@ public class ExcelWriterTransformDialog extends BaseTransformDialog {
       mb.setText(BaseMessages.getString(PKG, "ExcelWriterDialog.Load.SchemaDefinition.Title"));
       int answer = mb.open();
 
-      if (answer == SWT.YES) {
-        if (!Utils.isEmpty(schemaName)) {
-          try {
-            SchemaDefinition schemaDefinition =
-                (new SchemaDefinitionUtil()).loadSchemaDefinition(metadataProvider, schemaName);
-            if (schemaDefinition != null) {
-              IRowMeta r = schemaDefinition.getRowMeta();
-              if (r != null) {
-                String[] fieldNames = r.getFieldNames();
-                if (fieldNames != null) {
-                  wFields.clearAll();
-                  for (int i = 0; i < fieldNames.length; i++) {
-                    IValueMeta valueMeta = r.getValueMeta(i);
-                    TableItem item = new TableItem(wFields.table, SWT.NONE);
+      if (answer == SWT.YES && !Utils.isEmpty(schemaName)) {
+        try {
+          SchemaDefinition schemaDefinition =
+              (new SchemaDefinitionUtil()).loadSchemaDefinition(metadataProvider, schemaName);
+          if (schemaDefinition != null) {
+            IRowMeta r = schemaDefinition.getRowMeta();
+            if (r != null) {
+              String[] fieldNames = r.getFieldNames();
+              if (fieldNames != null) {
+                wFields.clearAll();
+                for (int i = 0; i < fieldNames.length; i++) {
+                  IValueMeta valueMeta = r.getValueMeta(i);
+                  TableItem item = new TableItem(wFields.table, SWT.NONE);
 
-                    item.setText(1, valueMeta.getName());
-                    item.setText(2, ValueMetaFactory.getValueMetaName(valueMeta.getType()));
-                    item.setText(3, Const.NVL(valueMeta.getConversionMask(), ""));
-                  }
+                  item.setText(1, valueMeta.getName());
+                  item.setText(2, ValueMetaFactory.getValueMetaName(valueMeta.getType()));
+                  item.setText(3, Const.NVL(valueMeta.getConversionMask(), ""));
                 }
               }
             }
-          } catch (HopTransformException | HopPluginException e) {
-
-            // ignore any errors here.
           }
+        } catch (HopTransformException | HopPluginException e) {
 
-          wFields.removeEmptyRows();
-          wFields.setRowNums();
-          wFields.optWidth(true);
+          // ignore any errors here.
         }
+
+        wFields.removeEmptyRows();
+        wFields.setRowNums();
+        wFields.optWidth(true);
       }
     }
   }

--- a/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelwriter/ExcelWriterTransformMeta.java
+++ b/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelwriter/ExcelWriterTransformMeta.java
@@ -534,12 +534,13 @@ public class ExcelWriterTransformMeta
       // So let's change the filename from relative to absolute by grabbing the file object...
       //
       if (!Utils.isEmpty(file.getFileName())) {
-        FileObject fileObject = HopVfs.getFileObject(variables.resolve(file.getFileName()));
+        FileObject fileObject =
+            HopVfs.getFileObject(variables.resolve(file.getFileName()), variables);
         file.setFileName(iResourceNaming.nameResource(fileObject, variables, true));
       }
       if (!Utils.isEmpty(template.getTemplateFileName())) {
         FileObject fileObject =
-            HopVfs.getFileObject(variables.resolve(template.getTemplateFileName()));
+            HopVfs.getFileObject(variables.resolve(template.getTemplateFileName()), variables);
         template.setTemplateFileName(iResourceNaming.nameResource(fileObject, variables, true));
       }
 

--- a/plugins/transforms/excel/src/test/java/org/apache/hop/pipeline/transforms/excelinput/OdfSheetTest.java
+++ b/plugins/transforms/excel/src/test/java/org/apache/hop/pipeline/transforms/excelinput/OdfSheetTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import org.apache.hop.core.exception.HopException;
 import org.apache.hop.core.spreadsheet.IKCell;
 import org.apache.hop.core.spreadsheet.IKWorkbook;
+import org.apache.hop.core.variables.Variables;
 import org.apache.hop.pipeline.transforms.excelinput.ods.OdfSheet;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,12 +38,14 @@ public class OdfSheetTest {
         WorkbookFactory.getWorkbook(
             SpreadSheetType.ODS,
             this.getClass().getResource("files/sample-3.4.1.ods").getPath(),
-            null);
+            null,
+            new Variables());
     ods24 =
         WorkbookFactory.getWorkbook(
             SpreadSheetType.ODS,
             this.getClass().getResource("files/sample-2.4.ods").getPath(),
-            null);
+            null,
+            new Variables());
   }
 
   @Test

--- a/plugins/transforms/filelocked/src/main/java/org/apache/hop/pipeline/transforms/filelocked/FileLocked.java
+++ b/plugins/transforms/filelocked/src/main/java/org/apache/hop/pipeline/transforms/filelocked/FileLocked.java
@@ -93,7 +93,7 @@ public class FileLocked extends BaseTransform<FileLockedMeta, FileLockedData> {
       String filename = data.previousRowMeta.getString(r, data.indexOfFileename);
       if (!Utils.isEmpty(filename)) {
         // Check if file
-        LockFile locked = new LockFile(filename);
+        LockFile locked = new LockFile(filename, variables);
         fileLocked = locked.isLocked();
 
         // add filename to result filenames?
@@ -102,7 +102,7 @@ public class FileLocked extends BaseTransform<FileLockedMeta, FileLockedData> {
           ResultFile resultFile =
               new ResultFile(
                   ResultFile.FILE_TYPE_GENERAL,
-                  HopVfs.getFileObject(filename),
+                  HopVfs.getFileObject(filename, variables),
                   getPipelineMeta().getName(),
                   getTransformName());
           resultFile.setComment(BaseMessages.getString(PKG, "FileLocked.Log.FileAddedResult"));

--- a/plugins/transforms/filelocked/src/main/java/org/apache/hop/pipeline/transforms/filelocked/FileLockedDialog.java
+++ b/plugins/transforms/filelocked/src/main/java/org/apache/hop/pipeline/transforms/filelocked/FileLockedDialog.java
@@ -80,7 +80,7 @@ public class FileLockedDialog extends BaseTransformDialog {
     shell.setText(BaseMessages.getString(PKG, "FileLockedDialog.Shell.Title"));
 
     int middle = props.getMiddlePct();
-    int margin = props.getMargin();
+    int margin = PropsUi.getMargin();
 
     // TransformName line
     wlTransformName = new Label(shell, SWT.RIGHT);

--- a/plugins/transforms/filemetadata/src/main/java/org/apache/hop/pipeline/transforms/filemetadata/FileMetadata.java
+++ b/plugins/transforms/filemetadata/src/main/java/org/apache/hop/pipeline/transforms/filemetadata/FileMetadata.java
@@ -180,7 +180,7 @@ public class FileMetadata extends BaseTransform<FileMetadataMeta, FileMetadataDa
 
     // if the file does not exist, just send an empty row
     try {
-      if (!HopVfs.fileExists(fileName)) {
+      if (!HopVfs.fileExists(fileName, variables)) {
         putRow(data.outputRowMeta, outputRow);
         return;
       }
@@ -257,7 +257,7 @@ public class FileMetadata extends BaseTransform<FileMetadataMeta, FileMetadataDa
 
     try (BufferedReader inputReader =
         new BufferedReader(
-            new InputStreamReader(HopVfs.getInputStream(fileName), detectedCharset))) {
+            new InputStreamReader(HopVfs.getInputStream(fileName, variables), detectedCharset))) {
       while (skipLines > 0) {
         skipLines--;
         // Skip the line. There is no need to use a variable here.
@@ -363,7 +363,7 @@ public class FileMetadata extends BaseTransform<FileMetadataMeta, FileMetadataDa
   }
 
   private Charset detectCharset(String fileName) {
-    try (InputStream stream = HopVfs.getInputStream(fileName)) {
+    try (InputStream stream = HopVfs.getInputStream(fileName, variables)) {
       return EncodingDetector.detectEncoding(
           stream, defaultCharset, limitRows * 500); // estimate a row is ~500 chars
     } catch (FileNotFoundException e) {
@@ -382,7 +382,8 @@ public class FileMetadata extends BaseTransform<FileMetadataMeta, FileMetadataDa
     // guess the delimiters
 
     try (BufferedReader f =
-        new BufferedReader(new InputStreamReader(HopVfs.getInputStream(fileName), charset))) {
+        new BufferedReader(
+            new InputStreamReader(HopVfs.getInputStream(fileName, variables), charset))) {
 
       DelimiterDetector detector =
           new DelimiterDetectorBuilder()

--- a/plugins/transforms/filemetadata/src/main/java/org/apache/hop/pipeline/transforms/filemetadata/FileMetadataDialog.java
+++ b/plugins/transforms/filemetadata/src/main/java/org/apache/hop/pipeline/transforms/filemetadata/FileMetadataDialog.java
@@ -260,7 +260,9 @@ public class FileMetadataDialog extends BaseTransformDialog {
     wFilenameField.addFocusListener(
         new FocusListener() {
           @Override
-          public void focusLost(FocusEvent e) {}
+          public void focusLost(FocusEvent e) {
+            // Do Nothing
+          }
 
           @Override
           public void focusGained(FocusEvent e) {

--- a/plugins/transforms/filestoresult/src/main/java/org/apache/hop/pipeline/transforms/filestoresult/FilesToResult.java
+++ b/plugins/transforms/filestoresult/src/main/java/org/apache/hop/pipeline/transforms/filestoresult/FilesToResult.java
@@ -81,7 +81,7 @@ public class FilesToResult extends BaseTransform<FilesToResultMeta, FilesToResul
               meta.getFileType() == null
                   ? ResultFile.FileType.GENERAL.getType()
                   : meta.getFileType().getType(),
-              HopVfs.getFileObject(filename),
+              HopVfs.getFileObject(filename, variables),
               getPipeline().getPipelineMeta().getName(),
               getTransformName());
 

--- a/plugins/transforms/getfilenames/src/main/java/org/apache/hop/pipeline/transforms/getfilenames/GetFileNames.java
+++ b/plugins/transforms/getfilenames/src/main/java/org/apache/hop/pipeline/transforms/getfilenames/GetFileNames.java
@@ -44,6 +44,10 @@ import org.apache.hop.pipeline.transform.TransformMeta;
 public class GetFileNames extends BaseTransform<GetFileNamesMeta, GetFileNamesData> {
 
   private static final Class<?> PKG = GetFileNamesMeta.class; // For Translator
+  private static final String CONST_LOG_NO_FILE = "GetFileNames.Log.NoFile";
+  private static final String CONST_ERROR_FINDING_FIELD = "GetFileNames.Log.ErrorFindingField";
+  private static final String CONST_COULD_NOT_FIND_FIELD =
+      "GetFileNames.Exception.CouldnotFindField";
 
   public GetFileNames(
       TransformMeta transformMeta,
@@ -106,12 +110,10 @@ public class GetFileNames extends BaseTransform<GetFileNamesMeta, GetFileNamesDa
             // The field is unreachable !
             logError(
                 BaseMessages.getString(
-                    PKG, "GetFileNames.Log.ErrorFindingField", meta.getDynamicFilenameField()));
+                    PKG, CONST_ERROR_FINDING_FIELD, meta.getDynamicFilenameField()));
             throw new HopException(
                 BaseMessages.getString(
-                    PKG,
-                    "GetFileNames.Exception.CouldnotFindField",
-                    meta.getDynamicFilenameField()));
+                    PKG, CONST_COULD_NOT_FIND_FIELD, meta.getDynamicFilenameField()));
           }
         }
 
@@ -122,15 +124,13 @@ public class GetFileNames extends BaseTransform<GetFileNamesMeta, GetFileNamesDa
           if (data.indexOfWildcardField < 0) {
             // The field is unreachable !
             logError(
-                BaseMessages.getString(PKG, "GetFileNames.Log.ErrorFindingField")
+                BaseMessages.getString(PKG, CONST_ERROR_FINDING_FIELD)
                     + "["
                     + meta.getDynamicWildcardField()
                     + "]");
             throw new HopException(
                 BaseMessages.getString(
-                    PKG,
-                    "GetFileNames.Exception.CouldnotFindField",
-                    meta.getDynamicWildcardField()));
+                    PKG, CONST_COULD_NOT_FIND_FIELD, meta.getDynamicWildcardField()));
           }
         }
         // If ExcludeWildcard field is specified, Check if field exists
@@ -141,15 +141,13 @@ public class GetFileNames extends BaseTransform<GetFileNamesMeta, GetFileNamesDa
           if (data.indexOfExcludeWildcardField < 0) {
             // The field is unreachable !
             logError(
-                BaseMessages.getString(PKG, "GetFileNames.Log.ErrorFindingField")
+                BaseMessages.getString(PKG, CONST_ERROR_FINDING_FIELD)
                     + "["
                     + meta.getDynamicExcludeWildcardField()
                     + "]");
             throw new HopException(
                 BaseMessages.getString(
-                    PKG,
-                    "GetFileNames.Exception.CouldnotFindField",
-                    meta.getDynamicExcludeWildcardField()));
+                    PKG, CONST_COULD_NOT_FIND_FIELD, meta.getDynamicExcludeWildcardField()));
           }
         }
       }
@@ -189,11 +187,11 @@ public class GetFileNames extends BaseTransform<GetFileNamesMeta, GetFileNamesDa
         if (!meta.isDoNotFailIfNoFile() && data.filessize == 0) {
           if (meta.isRaiseAnExceptionIfNoFile()) {
             if (getTransformMeta().isDoingErrorHandling()) {
-              sendErrorRow(BaseMessages.getString(PKG, "GetFileNames.Log.NoFile"));
+              sendErrorRow(BaseMessages.getString(PKG, CONST_LOG_NO_FILE));
             } else
               throw new HopException(BaseMessages.getString(PKG, "GetFileNames.Log.NoFileStop"));
           }
-          logError(BaseMessages.getString(PKG, "GetFileNames.Log.NoFile"));
+          logError(BaseMessages.getString(PKG, CONST_LOG_NO_FILE));
         } else {
           // Clone current input row
           outputRow = data.readrow.clone();
@@ -312,23 +310,23 @@ public class GetFileNames extends BaseTransform<GetFileNamesMeta, GetFileNamesDa
     if (!meta.isDoNotFailIfNoFile() && data.files.nrOfFiles() == 0) {
       if (meta.isRaiseAnExceptionIfNoFile()) {
         if (getTransformMeta().isDoingErrorHandling()) {
-          sendErrorRow(BaseMessages.getString(PKG, "GetFileNames.Log.NoFile"));
+          sendErrorRow(BaseMessages.getString(PKG, CONST_LOG_NO_FILE));
         } else throw new HopException(BaseMessages.getString(PKG, "GetFileNames.Log.NoFileStop"));
       }
-      logError(BaseMessages.getString(PKG, "GetFileNames.Log.NoFile"));
+      logError(BaseMessages.getString(PKG, CONST_LOG_NO_FILE));
       return;
     }
 
     List<FileObject> nonExistantFiles = data.files.getNonExistentFiles();
 
-    if (nonExistantFiles.size() != 0) {
+    if (!nonExistantFiles.isEmpty()) {
       String message = FileInputList.getRequiredFilesDescription(nonExistantFiles);
       logBasic("ERROR: Missing " + message);
       throw new HopException("Following required files are missing: " + message);
     }
 
     List<FileObject> nonAccessibleFiles = data.files.getNonAccessibleFiles();
-    if (nonAccessibleFiles.size() != 0) {
+    if (!nonAccessibleFiles.isEmpty()) {
       String message = FileInputList.getRequiredFilesDescription(nonAccessibleFiles);
       logBasic("WARNING: Not accessible " + message);
       throw new HopException("Following required files are not accessible: " + message);

--- a/plugins/transforms/getfilenames/src/main/java/org/apache/hop/pipeline/transforms/getfilenames/GetFileNamesDialog.java
+++ b/plugins/transforms/getfilenames/src/main/java/org/apache/hop/pipeline/transforms/getfilenames/GetFileNamesDialog.java
@@ -156,7 +156,7 @@ public class GetFileNamesDialog extends BaseTransformDialog {
     shell.setText(BaseMessages.getString(PKG, "GetFileNamesDialog.DialogTitle"));
 
     int middle = props.getMiddlePct();
-    int margin = props.getMargin();
+    int margin = PropsUi.getMargin();
 
     // Buttons at the bottom
     wOk = new Button(shell, SWT.PUSH);
@@ -981,7 +981,7 @@ public class GetFileNamesDialog extends BaseTransformDialog {
   public void getData(GetFileNamesMeta meta) {
     final GetFileNamesMeta in = meta;
 
-    if (in.getFilesList().size() > 0) {
+    if (!in.getFilesList().isEmpty()) {
       wFilenameList.removeAll();
 
       for (int i = 0; i < meta.getFilesList().size(); i++) {

--- a/plugins/transforms/getfilesrowcount/src/main/java/org/apache/hop/pipeline/transforms/getfilesrowcount/GetFilesRowsCount.java
+++ b/plugins/transforms/getfilesrowcount/src/main/java/org/apache/hop/pipeline/transforms/getfilesrowcount/GetFilesRowsCount.java
@@ -235,7 +235,7 @@ public class GetFilesRowsCount extends BaseTransform<GetFilesRowsCountMeta, GetF
                   filename));
         }
 
-        data.file = HopVfs.getFileObject(filename);
+        data.file = HopVfs.getFileObject(filename, variables);
 
         // Init Row number
         if (meta.isFileFromField()) {

--- a/plugins/transforms/javascript/src/main/java/org/apache/hop/pipeline/transforms/javascript/ScriptValuesAddedFunctions.java
+++ b/plugins/transforms/javascript/src/main/java/org/apache/hop/pipeline/transforms/javascript/ScriptValuesAddedFunctions.java
@@ -2882,7 +2882,10 @@ public class ScriptValuesAddedFunctions extends ScriptableObject {
               return Context.getUndefinedValue();
             }
             // Returns file content
-            oRC = new String(LoadFileInput.getFileBinaryContent(Context.toString(argList[0])));
+            oRC =
+                new String(
+                    LoadFileInput.getFileBinaryContent(
+                        Context.toString(argList[0]), new Variables()));
           } catch (Exception e) {
             throw Context.reportRuntimeError(
                 "The function call loadFileContent throw an error : " + e.toString());
@@ -2902,7 +2905,9 @@ public class ScriptValuesAddedFunctions extends ScriptableObject {
             // Returns file content
             oRC =
                 new String(
-                    LoadFileInput.getFileBinaryContent(Context.toString(argList[0])), encoding);
+                    LoadFileInput.getFileBinaryContent(
+                        Context.toString(argList[0]), new Variables()),
+                    encoding);
           } catch (Exception e) {
             throw Context.reportRuntimeError(
                 "The function call loadFileContent throw an error : " + e.toString());

--- a/plugins/transforms/loadfileinput/src/main/java/org/apache/hop/pipeline/transforms/loadfileinput/LoadFileInput.java
+++ b/plugins/transforms/loadfileinput/src/main/java/org/apache/hop/pipeline/transforms/loadfileinput/LoadFileInput.java
@@ -32,6 +32,7 @@ import org.apache.hop.core.row.IValueMeta;
 import org.apache.hop.core.row.RowDataUtil;
 import org.apache.hop.core.row.RowMeta;
 import org.apache.hop.core.util.Utils;
+import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.core.vfs.HopVfs;
 import org.apache.hop.i18n.BaseMessages;
 import org.apache.hop.pipeline.Pipeline;
@@ -134,7 +135,7 @@ public class LoadFileInput extends BaseTransform<LoadFileInputMeta, LoadFileInpu
 
         try {
           // Source is a file.
-          data.file = HopVfs.getFileObject(fieldvalue);
+          data.file = HopVfs.getFileObject(fieldvalue, variables);
         } catch (Exception e) {
           throw new HopException(e);
         }
@@ -264,7 +265,7 @@ public class LoadFileInput extends BaseTransform<LoadFileInputMeta, LoadFileInpu
 
   void getFileContent() throws HopException {
     try {
-      data.filecontent = getFileBinaryContent(data.file.toString());
+      data.filecontent = getFileBinaryContent(data.file.toString(), variables);
     } catch (OutOfMemoryError o) {
       logError(
           "There is no enaugh memory to load the content of the file ["
@@ -283,12 +284,13 @@ public class LoadFileInput extends BaseTransform<LoadFileInputMeta, LoadFileInpu
    * @return The content of the file as a byte[]
    * @throws HopException
    */
-  public static byte[] getFileBinaryContent(String vfsFilename) throws HopException {
+  public static byte[] getFileBinaryContent(String vfsFilename, IVariables variables)
+      throws HopException {
     InputStream inputStream = null;
 
     byte[] retval = null;
     try {
-      inputStream = HopVfs.getInputStream(vfsFilename);
+      inputStream = HopVfs.getInputStream(vfsFilename, variables);
       retval = IOUtils.toByteArray(new BufferedInputStream(inputStream));
     } catch (Exception e) {
       throw new HopException(
@@ -310,7 +312,7 @@ public class LoadFileInput extends BaseTransform<LoadFileInputMeta, LoadFileInpu
   private void handleMissingFiles() throws HopException {
     List<FileObject> nonExistantFiles = data.files.getNonExistentFiles();
 
-    if (nonExistantFiles.size() != 0) {
+    if (!nonExistantFiles.isEmpty()) {
       String message = FileInputList.getRequiredFilesDescription(nonExistantFiles);
       logError(
           BaseMessages.getString(PKG, "LoadFileInput.Log.RequiredFilesTitle"),
@@ -321,7 +323,7 @@ public class LoadFileInput extends BaseTransform<LoadFileInputMeta, LoadFileInpu
     }
 
     List<FileObject> nonAccessibleFiles = data.files.getNonAccessibleFiles();
-    if (nonAccessibleFiles.size() != 0) {
+    if (!nonAccessibleFiles.isEmpty()) {
       String message = FileInputList.getRequiredFilesDescription(nonAccessibleFiles);
       logError(
           BaseMessages.getString(PKG, "LoadFileInput.Log.RequiredFilesTitle"),

--- a/plugins/transforms/loadfileinput/src/main/java/org/apache/hop/pipeline/transforms/loadfileinput/LoadFileInputDialog.java
+++ b/plugins/transforms/loadfileinput/src/main/java/org/apache/hop/pipeline/transforms/loadfileinput/LoadFileInputDialog.java
@@ -66,11 +66,12 @@ import org.eclipse.swt.widgets.Text;
 
 public class LoadFileInputDialog extends BaseTransformDialog {
   private static final Class<?> PKG = LoadFileInputMeta.class; // For Translator
+  private static final String CONST_COMBO_NO = "System.Combo.No";
+  private static final String CONST_COMBO_YES = "System.Combo.Yes";
 
   private static final String[] YES_NO_COMBO =
       new String[] {
-        BaseMessages.getString(PKG, "System.Combo.No"),
-        BaseMessages.getString(PKG, "System.Combo.Yes")
+        BaseMessages.getString(PKG, CONST_COMBO_NO), BaseMessages.getString(PKG, CONST_COMBO_YES)
       };
 
   private CTabFolder wTabFolder;
@@ -171,7 +172,7 @@ public class LoadFileInputDialog extends BaseTransformDialog {
     shell.setText(BaseMessages.getString(PKG, "LoadFileInputDialog.DialogTitle"));
 
     middle = props.getMiddlePct();
-    margin = props.getMargin();
+    margin = PropsUi.getMargin();
 
     // Buttons at the bottom
     wOk = new Button(shell, SWT.PUSH);
@@ -285,7 +286,9 @@ public class LoadFileInputDialog extends BaseTransformDialog {
     wFilenameField.addFocusListener(
         new FocusListener() {
           @Override
-          public void focusLost(org.eclipse.swt.events.FocusEvent e) {}
+          public void focusLost(org.eclipse.swt.events.FocusEvent e) {
+            // Do Nothing
+          }
 
           @Override
           public void focusGained(org.eclipse.swt.events.FocusEvent e) {
@@ -536,7 +539,9 @@ public class LoadFileInputDialog extends BaseTransformDialog {
     wEncoding.addFocusListener(
         new FocusListener() {
           @Override
-          public void focusLost(org.eclipse.swt.events.FocusEvent e) {}
+          public void focusLost(org.eclipse.swt.events.FocusEvent e) {
+            // Do Nothing
+          }
 
           @Override
           public void focusGained(org.eclipse.swt.events.FocusEvent e) {
@@ -850,8 +855,8 @@ public class LoadFileInputDialog extends BaseTransformDialog {
               BaseMessages.getString(PKG, "LoadFileInputDialog.FieldsTable.Repeat.Column"),
               ColumnInfo.COLUMN_TYPE_CCOMBO,
               new String[] {
-                BaseMessages.getString(PKG, "System.Combo.Yes"),
-                BaseMessages.getString(PKG, "System.Combo.No")
+                BaseMessages.getString(PKG, CONST_COMBO_YES),
+                BaseMessages.getString(PKG, CONST_COMBO_NO)
               },
               true),
         };
@@ -1252,8 +1257,8 @@ public class LoadFileInputDialog extends BaseTransformDialog {
         String trim = field.getTrimTypeDesc();
         String rep =
             field.isRepeated()
-                ? BaseMessages.getString(PKG, "System.Combo.Yes")
-                : BaseMessages.getString(PKG, "System.Combo.No");
+                ? BaseMessages.getString(PKG, CONST_COMBO_YES)
+                : BaseMessages.getString(PKG, CONST_COMBO_NO);
 
         if (name != null) {
           item.setText(1, name);
@@ -1395,7 +1400,7 @@ public class LoadFileInputDialog extends BaseTransformDialog {
       field.setGroupSymbol(item.getText(9));
       field.setTrimType(LoadFileInputField.getTrimTypeByDesc(item.getText(10)));
       field.setRepeated(
-          BaseMessages.getString(PKG, "System.Combo.Yes").equalsIgnoreCase(item.getText(11)));
+          BaseMessages.getString(PKG, CONST_COMBO_YES).equalsIgnoreCase(item.getText(11)));
 
       in.getInputFields()[i] = field;
     }

--- a/plugins/transforms/loadfileinput/src/main/java/org/apache/hop/pipeline/transforms/loadfileinput/LoadFileInputField.java
+++ b/plugins/transforms/loadfileinput/src/main/java/org/apache/hop/pipeline/transforms/loadfileinput/LoadFileInputField.java
@@ -33,6 +33,7 @@ public class LoadFileInputField implements Cloneable {
   public static final int TYPE_TRIM_LEFT = 1;
   public static final int TYPE_TRIM_RIGHT = 2;
   public static final int TYPE_TRIM_BOTH = 3;
+  private static final String CONST_SPACE = "        ";
 
   public static final String[] trimTypeCode = {"none", "left", "right", "both"};
 
@@ -87,17 +88,17 @@ public class LoadFileInputField implements Cloneable {
     String retval = "";
 
     retval += "      <field>" + Const.CR;
-    retval += "        " + XmlHandler.addTagValue("name", getName());
-    retval += "        " + XmlHandler.addTagValue("element_type", getElementTypeCode());
-    retval += "        " + XmlHandler.addTagValue("type", getTypeDesc());
-    retval += "        " + XmlHandler.addTagValue("format", getFormat());
-    retval += "        " + XmlHandler.addTagValue("currency", getCurrencySymbol());
-    retval += "        " + XmlHandler.addTagValue("decimal", getDecimalSymbol());
-    retval += "        " + XmlHandler.addTagValue("group", getGroupSymbol());
-    retval += "        " + XmlHandler.addTagValue("length", getLength());
-    retval += "        " + XmlHandler.addTagValue("precision", getPrecision());
-    retval += "        " + XmlHandler.addTagValue("trim_type", getTrimTypeCode());
-    retval += "        " + XmlHandler.addTagValue("repeat", isRepeated());
+    retval += CONST_SPACE + XmlHandler.addTagValue("name", getName());
+    retval += CONST_SPACE + XmlHandler.addTagValue("element_type", getElementTypeCode());
+    retval += CONST_SPACE + XmlHandler.addTagValue("type", getTypeDesc());
+    retval += CONST_SPACE + XmlHandler.addTagValue("format", getFormat());
+    retval += CONST_SPACE + XmlHandler.addTagValue("currency", getCurrencySymbol());
+    retval += CONST_SPACE + XmlHandler.addTagValue("decimal", getDecimalSymbol());
+    retval += CONST_SPACE + XmlHandler.addTagValue("group", getGroupSymbol());
+    retval += CONST_SPACE + XmlHandler.addTagValue("length", getLength());
+    retval += CONST_SPACE + XmlHandler.addTagValue("precision", getPrecision());
+    retval += CONST_SPACE + XmlHandler.addTagValue("trim_type", getTrimTypeCode());
+    retval += CONST_SPACE + XmlHandler.addTagValue("repeat", isRepeated());
 
     retval += "        </field>" + Const.CR;
 
@@ -322,9 +323,7 @@ public class LoadFileInputField implements Cloneable {
   }
 
   public String getFieldPositionsCode() {
-    String enc = "";
-
-    return enc;
+    return "";
   }
 
   public void guess() {

--- a/plugins/transforms/mail/src/main/java/org/apache/hop/pipeline/transforms/mail/Mail.java
+++ b/plugins/transforms/mail/src/main/java/org/apache/hop/pipeline/transforms/mail/Mail.java
@@ -412,7 +412,7 @@ public class Mail extends BaseTransform<MailMeta, MailData> {
           for (int i = 0; i < meta.getEmbeddedImages().length; i++) {
             String imageFile = resolve(meta.getEmbeddedImages()[i]);
             String contentID = resolve(meta.getContentIds()[i]);
-            image = HopVfs.getFileObject(imageFile);
+            image = HopVfs.getFileObject(imageFile, variables);
 
             if (image.exists() && image.getType() == FileType.FILE) {
               // Create part for the image
@@ -847,7 +847,7 @@ public class Mail extends BaseTransform<MailMeta, MailData> {
       }
 
       if (!Utils.isEmpty(realSourceFileFoldername)) {
-        sourcefile = HopVfs.getFileObject(realSourceFileFoldername);
+        sourcefile = HopVfs.getFileObject(realSourceFileFoldername, variables);
         if (sourcefile.exists()) {
           long fileSize = 0;
           FileObject[] list = null;
@@ -874,7 +874,7 @@ public class Mail extends BaseTransform<MailMeta, MailData> {
 
             for (int i = 0; i < list.length; i++) {
 
-              file = HopVfs.getFileObject(HopVfs.getFilename(list[i]));
+              file = HopVfs.getFileObject(HopVfs.getFilename(list[i]), variables);
 
               if (zipFiles) {
 
@@ -918,7 +918,7 @@ public class Mail extends BaseTransform<MailMeta, MailData> {
 
                 for (int i = 0; i < list.length; i++) {
 
-                  file = HopVfs.getFileObject(HopVfs.getFilename(list[i]));
+                  file = HopVfs.getFileObject(HopVfs.getFilename(list[i]), variables);
 
                   ZipEntry zipEntry = new ZipEntry(file.getName().getBaseName());
                   zipOutputStream.putNextEntry(zipEntry);
@@ -935,7 +935,7 @@ public class Mail extends BaseTransform<MailMeta, MailData> {
                 }
               }
               if (data.zipFileLimit > 0 && fileSize > data.zipFileLimit || data.zipFileLimit == 0) {
-                file = HopVfs.getFileObject(masterZipfile.getAbsolutePath());
+                file = HopVfs.getFileObject(masterZipfile.getAbsolutePath(), variables);
                 addAttachedFilePart(file);
               }
             }
@@ -1009,7 +1009,7 @@ public class Mail extends BaseTransform<MailMeta, MailData> {
 
   private void addImagePart() throws Exception {
     data.nrEmbeddedImages = 0;
-    if (data.embeddedMimePart != null && data.embeddedMimePart.size() > 0) {
+    if (data.embeddedMimePart != null && !data.embeddedMimePart.isEmpty()) {
       for (Iterator<MimeBodyPart> i = data.embeddedMimePart.iterator(); i.hasNext(); ) {
         MimeBodyPart part = i.next();
         data.parts.addBodyPart(part);

--- a/plugins/transforms/mail/src/main/java/org/apache/hop/pipeline/transforms/mail/MailMeta.java
+++ b/plugins/transforms/mail/src/main/java/org/apache/hop/pipeline/transforms/mail/MailMeta.java
@@ -47,6 +47,8 @@ import org.w3c.dom.Node;
     documentationUrl = "/pipeline/transforms/mail.html")
 public class MailMeta extends BaseTransformMeta<Mail, MailData> {
   private static final Class<?> PKG = MailMeta.class; // For Translator
+  private static final String CONST_SPACE = "      ";
+  private static final String CONST_SPACE_SHORT = "    ";
 
   private String server;
 
@@ -157,8 +159,7 @@ public class MailMeta extends BaseTransformMeta<Mail, MailData> {
 
   @Override
   public Object clone() {
-    Object retval = super.clone();
-    return retval;
+    return super.clone();
   }
 
   public void allocate(int value) {
@@ -262,82 +263,89 @@ public class MailMeta extends BaseTransformMeta<Mail, MailData> {
     retval.append(super.getXml());
 
     retval
-        .append("      ")
+        .append(CONST_SPACE)
         .append(XmlHandler.addTagValue("include_message_in_output", this.addMessageToOutput));
     retval
-        .append("      ")
+        .append(CONST_SPACE)
         .append(XmlHandler.addTagValue("message_output_field", this.messageOutputField));
-    retval.append("      ").append(XmlHandler.addTagValue("server", this.server));
-    retval.append("      ").append(XmlHandler.addTagValue("port", this.port));
-    retval.append("      ").append(XmlHandler.addTagValue("destination", this.destination));
-    retval.append("      ").append(XmlHandler.addTagValue("destinationCc", this.destinationCc));
-    retval.append("      ").append(XmlHandler.addTagValue("destinationBCc", this.destinationBCc));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("server", this.server));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("port", this.port));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("destination", this.destination));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("destinationCc", this.destinationCc));
     retval
-        .append("      ")
+        .append(CONST_SPACE)
+        .append(XmlHandler.addTagValue("destinationBCc", this.destinationBCc));
+    retval
+        .append(CONST_SPACE)
         .append(XmlHandler.addTagValue("replyToAddresses", this.replyToAddresses));
-    retval.append("      ").append(XmlHandler.addTagValue("replyto", this.replyAddress));
-    retval.append("      ").append(XmlHandler.addTagValue("replytoname", this.replyName));
-    retval.append("      ").append(XmlHandler.addTagValue("subject", this.subject));
-    retval.append("      ").append(XmlHandler.addTagValue("include_date", this.includeDate));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("replyto", this.replyAddress));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("replytoname", this.replyName));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("subject", this.subject));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("include_date", this.includeDate));
     retval
-        .append("      ")
+        .append(CONST_SPACE)
         .append(XmlHandler.addTagValue("include_subfolders", this.includeSubFolders));
     retval
-        .append("      ")
+        .append(CONST_SPACE)
         .append(XmlHandler.addTagValue("zipFilenameDynamic", this.zipFilenameDynamic));
     retval
-        .append("      ")
+        .append(CONST_SPACE)
         .append(XmlHandler.addTagValue("isFilenameDynamic", this.isFilenameDynamic));
     retval
-        .append("      ")
+        .append(CONST_SPACE)
         .append(XmlHandler.addTagValue("attachContentFromField", this.attachContentFromField));
     retval
-        .append("      ")
+        .append(CONST_SPACE)
         .append(XmlHandler.addTagValue("attachContentField", this.attachContentField));
     retval
-        .append("      ")
+        .append(CONST_SPACE)
         .append(
             XmlHandler.addTagValue("attachContentFileNameField", this.attachContentFileNameField));
 
     retval
-        .append("      ")
+        .append(CONST_SPACE)
         .append(XmlHandler.addTagValue("dynamicFieldname", this.dynamicFieldname));
-    retval.append("      ").append(XmlHandler.addTagValue("dynamicWildcard", this.dynamicWildcard));
     retval
-        .append("      ")
+        .append(CONST_SPACE)
+        .append(XmlHandler.addTagValue("dynamicWildcard", this.dynamicWildcard));
+    retval
+        .append(CONST_SPACE)
         .append(XmlHandler.addTagValue("dynamicZipFilename", this.dynamicZipFilename));
     retval
-        .append("      ")
+        .append(CONST_SPACE)
         .append(XmlHandler.addTagValue("sourcefilefoldername", this.sourcefilefoldername));
-    retval.append("      ").append(XmlHandler.addTagValue("sourcewildcard", this.sourcewildcard));
-    retval.append("      ").append(XmlHandler.addTagValue("contact_person", this.contactPerson));
-    retval.append("      ").append(XmlHandler.addTagValue("contact_phone", this.contactPhone));
-    retval.append("      ").append(XmlHandler.addTagValue("comment", this.comment));
-    retval.append("      ").append(XmlHandler.addTagValue("include_files", this.includingFiles));
-    retval.append("      ").append(XmlHandler.addTagValue("zip_files", this.zipFiles));
-    retval.append("      ").append(XmlHandler.addTagValue("zip_name", this.zipFilename));
-    retval.append("      ").append(XmlHandler.addTagValue("zip_limit_size", this.ziplimitsize));
-    retval.append("      ").append(XmlHandler.addTagValue("use_auth", this.usingAuthentication));
-    retval.append("      ").append(XmlHandler.addTagValue("usexoauth2", usexoauth2));
     retval
-        .append("      ")
+        .append(CONST_SPACE)
+        .append(XmlHandler.addTagValue("sourcewildcard", this.sourcewildcard));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("contact_person", this.contactPerson));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("contact_phone", this.contactPhone));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("comment", this.comment));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("include_files", this.includingFiles));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("zip_files", this.zipFiles));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("zip_name", this.zipFilename));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("zip_limit_size", this.ziplimitsize));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("use_auth", this.usingAuthentication));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("usexoauth2", usexoauth2));
+    retval
+        .append(CONST_SPACE)
         .append(XmlHandler.addTagValue("use_secure_auth", this.usingSecureAuthentication));
-    retval.append("      ").append(XmlHandler.addTagValue("auth_user", this.authenticationUser));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("auth_user", this.authenticationUser));
     retval
-        .append("      ")
+        .append(CONST_SPACE)
         .append(
             XmlHandler.addTagValue(
                 "auth_password",
                 Encr.encryptPasswordIfNotUsingVariables(this.authenticationPassword)));
-    retval.append("      ").append(XmlHandler.addTagValue("only_comment", this.onlySendComment));
-    retval.append("      ").append(XmlHandler.addTagValue("use_HTML", this.useHTML));
-    retval.append("      ").append(XmlHandler.addTagValue("use_Priority", this.usePriority));
-    retval.append("    " + XmlHandler.addTagValue("encoding", this.encoding));
-    retval.append("    " + XmlHandler.addTagValue("priority", this.priority));
-    retval.append("    " + XmlHandler.addTagValue("importance", this.importance));
-    retval.append("    " + XmlHandler.addTagValue("sensitivity", this.sensitivity));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("only_comment", this.onlySendComment));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("use_HTML", this.useHTML));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("use_Priority", this.usePriority));
+    retval.append(CONST_SPACE_SHORT + XmlHandler.addTagValue("encoding", this.encoding));
+    retval.append(CONST_SPACE_SHORT + XmlHandler.addTagValue("priority", this.priority));
+    retval.append(CONST_SPACE_SHORT + XmlHandler.addTagValue("importance", this.importance));
+    retval.append(CONST_SPACE_SHORT + XmlHandler.addTagValue("sensitivity", this.sensitivity));
     retval.append(
-        "    " + XmlHandler.addTagValue("secureconnectiontype", this.secureConnectionType));
+        CONST_SPACE_SHORT
+            + XmlHandler.addTagValue("secureconnectiontype", this.secureConnectionType));
 
     retval.append("      <embeddedimages>").append(Const.CR);
     if (embeddedimages != null) {

--- a/plugins/transforms/mailinput/src/main/java/org/apache/hop/pipeline/transforms/mailinput/MailInputDialog.java
+++ b/plugins/transforms/mailinput/src/main/java/org/apache/hop/pipeline/transforms/mailinput/MailInputDialog.java
@@ -78,6 +78,7 @@ import org.eclipse.swt.widgets.Text;
 
 public class MailInputDialog extends BaseTransformDialog {
   private static final Class<?> PKG = MailInputMeta.class; // For Translator
+  private static final String CONST_BUTTON_OK = "System.Button.OK";
 
   private final MailInputMeta input;
   private TextVar wServerName;
@@ -212,12 +213,12 @@ public class MailInputDialog extends BaseTransformDialog {
     shell.setText(BaseMessages.getString(PKG, "MailInputdialog.Shell.Title"));
 
     int middle = props.getMiddlePct();
-    int margin = props.getMargin();
+    int margin = PropsUi.getMargin();
 
     // Buttons go at the buttom
     //
     wOk = new Button(shell, SWT.PUSH);
-    wOk.setText(BaseMessages.getString(PKG, "System.Button.OK"));
+    wOk.setText(BaseMessages.getString(PKG, CONST_BUTTON_OK));
     wOk.addListener(SWT.Selection, e -> ok());
     wPreview = new Button(shell, SWT.PUSH);
     wPreview.setText(BaseMessages.getString(PKG, "MailInputDialog.Preview"));
@@ -665,7 +666,9 @@ public class MailInputDialog extends BaseTransformDialog {
     wFolderField.addFocusListener(
         new FocusListener() {
           @Override
-          public void focusLost(FocusEvent e) {}
+          public void focusLost(FocusEvent e) {
+            // Do Nothing
+          }
 
           @Override
           public void focusGained(FocusEvent e) {
@@ -761,7 +764,9 @@ public class MailInputDialog extends BaseTransformDialog {
     wIMAPListmails.addSelectionListener(
         new SelectionAdapter() {
           @Override
-          public void widgetSelected(SelectionEvent e) {}
+          public void widgetSelected(SelectionEvent e) {
+            // Do Nothing
+          }
         });
 
     // Retrieve the first ... mails
@@ -1022,7 +1027,7 @@ public class MailInputDialog extends BaseTransformDialog {
             new Label(dialog, SWT.NONE);
 
             Button ok = new Button(dialog, SWT.PUSH);
-            ok.setText(BaseMessages.getString(PKG, "System.Button.OK"));
+            ok.setText(BaseMessages.getString(PKG, CONST_BUTTON_OK));
             ok.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false));
             ok.addSelectionListener(
                 new SelectionAdapter() {
@@ -1088,7 +1093,7 @@ public class MailInputDialog extends BaseTransformDialog {
             new Label(dialogto, SWT.NONE);
             new Label(dialogto, SWT.NONE);
             Button okto = new Button(dialogto, SWT.PUSH);
-            okto.setText(BaseMessages.getString(PKG, "System.Button.OK"));
+            okto.setText(BaseMessages.getString(PKG, CONST_BUTTON_OK));
             okto.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false));
             okto.addSelectionListener(
                 new SelectionAdapter() {
@@ -1728,23 +1733,21 @@ public class MailInputDialog extends BaseTransformDialog {
   }
 
   private void checkFolder(String folderName) {
-    if (!Utils.isEmpty(folderName)) {
-      if (connect()) {
-        // check folder
-        if (mailConn.folderExists(folderName)) {
-          MessageBox mb = new MessageBox(shell, SWT.OK | SWT.ICON_INFORMATION);
-          mb.setMessage(
-              BaseMessages.getString(PKG, "MailInput.IMAPFolderExists.OK", folderName) + Const.CR);
-          mb.setText(BaseMessages.getString(PKG, "MailInput.IMAPFolderExists.Title.Ok"));
-          mb.open();
-        } else {
-          MessageBox mb = new MessageBox(shell, SWT.OK | SWT.ICON_ERROR);
-          mb.setMessage(
-              BaseMessages.getString(PKG, "MailInput.Connected.NOK.IMAPFolderExists", folderName)
-                  + Const.CR);
-          mb.setText(BaseMessages.getString(PKG, "MailInput.IMAPFolderExists.Title.Bad"));
-          mb.open();
-        }
+    if (!Utils.isEmpty(folderName) && connect()) {
+      // check folder
+      if (mailConn.folderExists(folderName)) {
+        MessageBox mb = new MessageBox(shell, SWT.OK | SWT.ICON_INFORMATION);
+        mb.setMessage(
+            BaseMessages.getString(PKG, "MailInput.IMAPFolderExists.OK", folderName) + Const.CR);
+        mb.setText(BaseMessages.getString(PKG, "MailInput.IMAPFolderExists.Title.Ok"));
+        mb.open();
+      } else {
+        MessageBox mb = new MessageBox(shell, SWT.OK | SWT.ICON_ERROR);
+        mb.setMessage(
+            BaseMessages.getString(PKG, "MailInput.Connected.NOK.IMAPFolderExists", folderName)
+                + Const.CR);
+        mb.setText(BaseMessages.getString(PKG, "MailInput.IMAPFolderExists.Title.Bad"));
+        mb.open();
       }
     }
   }
@@ -1849,9 +1852,9 @@ public class MailInputDialog extends BaseTransformDialog {
     group.setLayout(groupLayout);
 
     FormData fdGroup = new FormData();
-    fdGroup.left = new FormAttachment(0, props.getMargin());
-    fdGroup.top = new FormAttachment(top, props.getMargin());
-    fdGroup.right = new FormAttachment(100, -props.getMargin());
+    fdGroup.left = new FormAttachment(0, PropsUi.getMargin());
+    fdGroup.top = new FormAttachment(top, PropsUi.getMargin());
+    fdGroup.right = new FormAttachment(100, -PropsUi.getMargin());
     group.setLayoutData(fdGroup);
 
     return group;
@@ -1865,8 +1868,8 @@ public class MailInputDialog extends BaseTransformDialog {
   private void addLabelBelow(Control label, Control widgetAbove) {
     PropsUi.setLook(label);
     FormData fData = new FormData();
-    fData.top = new FormAttachment(widgetAbove, props.getMargin());
-    fData.right = new FormAttachment(props.getMiddlePct(), -props.getMargin());
+    fData.top = new FormAttachment(widgetAbove, PropsUi.getMargin());
+    fData.right = new FormAttachment(props.getMiddlePct(), -PropsUi.getMargin());
     label.setLayoutData(fData);
   }
 
@@ -1874,8 +1877,8 @@ public class MailInputDialog extends BaseTransformDialog {
     PropsUi.setLook(control);
     FormData fData = new FormData();
     fData.top = new FormAttachment(label, 0, SWT.CENTER);
-    fData.left = new FormAttachment(props.getMiddlePct(), props.getMargin());
-    fData.right = new FormAttachment(100, -props.getMargin());
+    fData.left = new FormAttachment(props.getMiddlePct(), PropsUi.getMargin());
+    fData.right = new FormAttachment(100, -PropsUi.getMargin());
     control.setLayoutData(fData);
   }
 

--- a/plugins/transforms/mailinput/src/main/java/org/apache/hop/pipeline/transforms/mailinput/MailInputMeta.java
+++ b/plugins/transforms/mailinput/src/main/java/org/apache/hop/pipeline/transforms/mailinput/MailInputMeta.java
@@ -51,9 +51,11 @@ import org.w3c.dom.Node;
     documentationUrl = "/pipeline/transforms/emailinput.html")
 public class MailInputMeta extends BaseTransformMeta<MailInput, MailInputData> {
   private static final Class<?> PKG = MailInputMeta.class; // For Translator
+  private static final String CONST_SPACE = "      ";
+  private static final String CONST_FIELD = "field";
 
   public static final String DATE_PATTERN = "yyyy-MM-dd HH:mm:ss";
-  public static int DEFAULT_BATCH_SIZE = 500;
+  public static final int DEFAULT_BATCH_SIZE = 500;
 
   public int conditionReceivedDate;
 
@@ -184,11 +186,11 @@ public class MailInputMeta extends BaseTransformMeta<MailInput, MailInputData> {
 
     rowlimit = XmlHandler.getTagValue(transformNode, "rowlimit");
     Node fields = XmlHandler.getSubNode(transformNode, "fields");
-    int nrFields = XmlHandler.countNodes(fields, "field");
+    int nrFields = XmlHandler.countNodes(fields, CONST_FIELD);
 
     allocate(nrFields);
     for (int i = 0; i < nrFields; i++) {
-      Node fnode = XmlHandler.getSubNodeByNr(fields, "field", i);
+      Node fnode = XmlHandler.getSubNodeByNr(fields, CONST_FIELD, i);
       inputFields[i] = new MailInputField();
       inputFields[i].setName(XmlHandler.getTagValue(fnode, "name"));
       inputFields[i].setColumn(
@@ -238,7 +240,7 @@ public class MailInputMeta extends BaseTransformMeta<MailInput, MailInputData> {
     allocate(nrFields);
 
     for (int i = 0; i < nrFields; i++) {
-      inputFields[i] = new MailInputField("field" + (i + 1));
+      inputFields[i] = new MailInputField(CONST_FIELD + (i + 1));
     }
   }
 
@@ -253,58 +255,60 @@ public class MailInputMeta extends BaseTransformMeta<MailInput, MailInputData> {
   @Override
   public String getXml() {
     StringBuilder retval = new StringBuilder();
-    String tab = "      ";
-    retval.append("      ").append(XmlHandler.addTagValue("servername", servername));
-    retval.append("      ").append(XmlHandler.addTagValue("username", username));
+    String tab = CONST_SPACE;
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("servername", servername));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("username", username));
     retval
-        .append("      ")
+        .append(CONST_SPACE)
         .append(
             XmlHandler.addTagValue("password", Encr.encryptPasswordIfNotUsingVariables(password)));
-    retval.append("      ").append(XmlHandler.addTagValue("usessl", usessl));
-    retval.append("      ").append(XmlHandler.addTagValue("usexoauth2", usexoauth2));
-    retval.append("      ").append(XmlHandler.addTagValue("sslport", sslport));
-    retval.append("      ").append(XmlHandler.addTagValue("retrievemails", retrievemails));
-    retval.append("      ").append(XmlHandler.addTagValue("firstmails", firstmails));
-    retval.append("      ").append(XmlHandler.addTagValue("delete", delete));
-    retval.append("      ").append(XmlHandler.addTagValue("protocol", protocol));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("usessl", usessl));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("usexoauth2", usexoauth2));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("sslport", sslport));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("retrievemails", retrievemails));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("firstmails", firstmails));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("delete", delete));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("protocol", protocol));
     retval
-        .append("      ")
+        .append(CONST_SPACE)
         .append(
             XmlHandler.addTagValue(
                 "valueimaplist", MailConnectionMeta.getValueImapListCode(valueimaplist)));
-    retval.append("      ").append(XmlHandler.addTagValue("imapfirstmails", imapfirstmails));
-    retval.append("      ").append(XmlHandler.addTagValue("imapfolder", imapfolder));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("imapfirstmails", imapfirstmails));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("imapfolder", imapfolder));
     // search term
-    retval.append("      ").append(XmlHandler.addTagValue("sendersearch", senderSearch));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("sendersearch", senderSearch));
     retval
-        .append("      ")
+        .append(CONST_SPACE)
         .append(XmlHandler.addTagValue("nottermsendersearch", notTermSenderSearch));
 
-    retval.append("      ").append(XmlHandler.addTagValue("recipientsearch", recipientSearch));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("recipientsearch", recipientSearch));
     retval
-        .append("      ")
+        .append(CONST_SPACE)
         .append(XmlHandler.addTagValue("notTermRecipientSearch", notTermRecipientSearch));
-    retval.append("      ").append(XmlHandler.addTagValue("subjectsearch", subjectSearch));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("subjectsearch", subjectSearch));
     retval
-        .append("      ")
+        .append(CONST_SPACE)
         .append(XmlHandler.addTagValue("nottermsubjectsearch", notTermSubjectSearch));
     retval
-        .append("      ")
+        .append(CONST_SPACE)
         .append(
             XmlHandler.addTagValue(
                 "conditionreceiveddate",
                 MailConnectionMeta.getConditionDateCode(conditionReceivedDate)));
     retval
-        .append("      ")
+        .append(CONST_SPACE)
         .append(XmlHandler.addTagValue("nottermreceiveddatesearch", notTermReceivedDateSearch));
-    retval.append("      ").append(XmlHandler.addTagValue("receiveddate1", receivedDate1));
-    retval.append("      ").append(XmlHandler.addTagValue("receiveddate2", receivedDate2));
-    retval.append("      ").append(XmlHandler.addTagValue("includesubfolders", includesubfolders));
-    retval.append("      ").append(XmlHandler.addTagValue("useproxy", useproxy));
-    retval.append("      ").append(XmlHandler.addTagValue("proxyusername", proxyusername));
-    retval.append("      ").append(XmlHandler.addTagValue("usedynamicfolder", usedynamicfolder));
-    retval.append("      ").append(XmlHandler.addTagValue("folderfield", folderfield));
-    retval.append("      ").append(XmlHandler.addTagValue("rowlimit", rowlimit));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("receiveddate1", receivedDate1));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("receiveddate2", receivedDate2));
+    retval
+        .append(CONST_SPACE)
+        .append(XmlHandler.addTagValue("includesubfolders", includesubfolders));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("useproxy", useproxy));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("proxyusername", proxyusername));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("usedynamicfolder", usedynamicfolder));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("folderfield", folderfield));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("rowlimit", rowlimit));
     retval.append(tab).append(XmlHandler.addTagValue(Tags.USE_BATCH, useBatch));
     retval.append(tab).append(XmlHandler.addTagValue(Tags.BATCH_SIZE, batchSize));
     retval.append(tab).append(XmlHandler.addTagValue(Tags.START_MSG, start));
@@ -655,21 +659,20 @@ public class MailInputMeta extends BaseTransformMeta<MailInput, MailInputData> {
       MailInputField field = inputFields[i];
       IValueMeta v = new ValueMetaString(variables.resolve(field.getName()));
       switch (field.getColumn()) {
-        case MailInputField.COLUMN_MESSAGE_NR:
-        case MailInputField.COLUMN_SIZE:
-        case MailInputField.COLUMN_ATTACHED_FILES_COUNT:
+        case MailInputField.COLUMN_MESSAGE_NR,
+            MailInputField.COLUMN_SIZE,
+            MailInputField.COLUMN_ATTACHED_FILES_COUNT:
           v = new ValueMetaInteger(variables.resolve(field.getName()));
           v.setLength(IValueMeta.DEFAULT_INTEGER_LENGTH, 0);
           break;
-        case MailInputField.COLUMN_RECEIVED_DATE:
-        case MailInputField.COLUMN_SENT_DATE:
+        case MailInputField.COLUMN_RECEIVED_DATE, MailInputField.COLUMN_SENT_DATE:
           v = new ValueMetaDate(variables.resolve(field.getName()));
           break;
-        case MailInputField.COLUMN_FLAG_DELETED:
-        case MailInputField.COLUMN_FLAG_DRAFT:
-        case MailInputField.COLUMN_FLAG_FLAGGED:
-        case MailInputField.COLUMN_FLAG_NEW:
-        case MailInputField.COLUMN_FLAG_READ:
+        case MailInputField.COLUMN_FLAG_DELETED,
+            MailInputField.COLUMN_FLAG_DRAFT,
+            MailInputField.COLUMN_FLAG_FLAGGED,
+            MailInputField.COLUMN_FLAG_NEW,
+            MailInputField.COLUMN_FLAG_READ:
           v = new ValueMetaBoolean(variables.resolve(field.getName()));
           break;
         default:

--- a/plugins/transforms/metadata/src/main/java/org/apache/hop/pipeline/transforms/metainput/MetadataInputDialog.java
+++ b/plugins/transforms/metadata/src/main/java/org/apache/hop/pipeline/transforms/metainput/MetadataInputDialog.java
@@ -95,7 +95,7 @@ public class MetadataInputDialog extends BaseTransformDialog {
 
     // See if the transform receives input.
     //
-    boolean isReceivingInput = pipelineMeta.findPreviousTransforms(transformMeta).size() > 0;
+    boolean isReceivingInput = !pipelineMeta.findPreviousTransforms(transformMeta).isEmpty();
 
     // TransformName line
     Label wlTransformName = new Label(shell, SWT.RIGHT);

--- a/plugins/transforms/metainject/src/main/java/org/apache/hop/pipeline/transforms/metainject/MetaInject.java
+++ b/plugins/transforms/metainject/src/main/java/org/apache/hop/pipeline/transforms/metainject/MetaInject.java
@@ -309,7 +309,7 @@ public class MetaInject extends BaseTransform<MetaInjectMeta, MetaInjectData> {
         createParentFolder(targetFilePath);
       }
 
-      os = HopVfs.getOutputStream(targetFilePath, false);
+      os = HopVfs.getOutputStream(targetFilePath, false, variables);
       os.write(XmlHandler.getXmlHeader().getBytes(Const.XML_ENCODING));
       os.write(data.pipelineMeta.getXml(this).getBytes(Const.XML_ENCODING));
     } catch (Exception e) {
@@ -332,7 +332,7 @@ public class MetaInject extends BaseTransform<MetaInjectMeta, MetaInjectData> {
 
     try {
       // Get parent folder
-      parentfolder = HopVfs.getFileObject(filename).getParent();
+      parentfolder = HopVfs.getFileObject(filename, variables).getParent();
 
       if (parentfolder.exists()) {
         if (isDetailed()) {
@@ -361,7 +361,7 @@ public class MetaInject extends BaseTransform<MetaInjectMeta, MetaInjectData> {
                   PKG,
                   "MetaInject.Log.ParentFolderNotExistCreateIt",
                   HopVfs.getFriendlyURI(parentfolder),
-                  HopVfs.getFriendlyURI(filename)));
+                  HopVfs.getFriendlyURI(filename, variables)));
         }
       }
     } finally {

--- a/plugins/transforms/metainject/src/main/java/org/apache/hop/pipeline/transforms/metainject/MetaInjectMeta.java
+++ b/plugins/transforms/metainject/src/main/java/org/apache/hop/pipeline/transforms/metainject/MetaInjectMeta.java
@@ -93,6 +93,8 @@ public class MetaInjectMeta extends BaseTransformMeta<MetaInject, MetaInjectData
   private static final String SOURCE_OUTPUT_FIELD_PRECISION = "source_output_field_precision";
 
   private static final String GROUP_AND_NAME_DELIMITER = ".";
+  private static final String CONST_SPACE = "      ";
+  private static final String CONST_SPACE_LONG = "        ";
 
   // description of the transformation to execute...
   //
@@ -132,7 +134,6 @@ public class MetaInjectMeta extends BaseTransformMeta<MetaInject, MetaInjectData
     sourceOutputFields = new ArrayList<>();
   }
 
-  // TODO: deep copy
   @Override
   public Object clone() {
     Object retval = super.clone();
@@ -150,20 +151,20 @@ public class MetaInjectMeta extends BaseTransformMeta<MetaInject, MetaInjectData
     retval.append("    ").append(XmlHandler.addTagValue(SOURCE_TRANSFORM, sourceTransformName));
     retval.append("    ").append(XmlHandler.openTag(SOURCE_OUTPUT_FIELDS));
     for (MetaInjectOutputField field : sourceOutputFields) {
-      retval.append("      ").append(XmlHandler.openTag(SOURCE_OUTPUT_FIELD));
+      retval.append(CONST_SPACE).append(XmlHandler.openTag(SOURCE_OUTPUT_FIELD));
       retval
-          .append("        ")
+          .append(CONST_SPACE_LONG)
           .append(XmlHandler.addTagValue(SOURCE_OUTPUT_FIELD_NAME, field.getName()));
       retval
-          .append("        ")
+          .append(CONST_SPACE_LONG)
           .append(XmlHandler.addTagValue(SOURCE_OUTPUT_FIELD_TYPE, field.getTypeDescription()));
       retval
-          .append("        ")
+          .append(CONST_SPACE_LONG)
           .append(XmlHandler.addTagValue(SOURCE_OUTPUT_FIELD_LENGTH, field.getLength()));
       retval
-          .append("        ")
+          .append(CONST_SPACE_LONG)
           .append(XmlHandler.addTagValue(SOURCE_OUTPUT_FIELD_PRECISION, field.getPrecision()));
-      retval.append("      ").append(XmlHandler.closeTag(SOURCE_OUTPUT_FIELD));
+      retval.append(CONST_SPACE).append(XmlHandler.closeTag(SOURCE_OUTPUT_FIELD));
     }
     retval.append("    ").append(XmlHandler.closeTag(SOURCE_OUTPUT_FIELDS));
 
@@ -183,20 +184,24 @@ public class MetaInjectMeta extends BaseTransformMeta<MetaInject, MetaInjectData
 
     retval.append("    ").append(XmlHandler.openTag(MAPPINGS));
     for (TargetTransformAttribute target : targetSourceMapping.keySet()) {
-      retval.append("      ").append(XmlHandler.openTag(MAPPING));
+      retval.append(CONST_SPACE).append(XmlHandler.openTag(MAPPING));
       SourceTransformField source = targetSourceMapping.get(target);
       retval
-          .append("        ")
+          .append(CONST_SPACE_LONG)
           .append(XmlHandler.addTagValue(TARGET_TRANSFORM_NAME, target.getTransformName()));
       retval
-          .append("        ")
+          .append(CONST_SPACE_LONG)
           .append(XmlHandler.addTagValue(TARGET_ATTRIBUTE_KEY, target.getAttributeKey()));
-      retval.append("        ").append(XmlHandler.addTagValue(TARGET_DETAIL, target.isDetail()));
       retval
-          .append("        ")
+          .append(CONST_SPACE_LONG)
+          .append(XmlHandler.addTagValue(TARGET_DETAIL, target.isDetail()));
+      retval
+          .append(CONST_SPACE_LONG)
           .append(XmlHandler.addTagValue(SOURCE_TRANSFORM, source.getTransformName()));
-      retval.append("        ").append(XmlHandler.addTagValue(SOURCE_FIELD, source.getField()));
-      retval.append("      ").append(XmlHandler.closeTag(MAPPING));
+      retval
+          .append(CONST_SPACE_LONG)
+          .append(XmlHandler.addTagValue(SOURCE_FIELD, source.getField()));
+      retval.append(CONST_SPACE).append(XmlHandler.closeTag(MAPPING));
     }
     retval.append("    ").append(XmlHandler.closeTag(MAPPINGS));
 

--- a/plugins/transforms/orabulkloader/src/main/java/org/apache/hop/pipeline/transforms/orabulkloader/OraBulkDataOutput.java
+++ b/plugins/transforms/orabulkloader/src/main/java/org/apache/hop/pipeline/transforms/orabulkloader/OraBulkDataOutput.java
@@ -239,6 +239,6 @@ public class OraBulkDataOutput {
 
   @VisibleForTesting
   FileObject getFileObject(String fileName, IVariables variables) throws HopFileException {
-    return HopVfs.getFileObject(variables.resolve(fileName));
+    return HopVfs.getFileObject(variables.resolve(fileName), variables);
   }
 }

--- a/plugins/transforms/orabulkloader/src/main/java/org/apache/hop/pipeline/transforms/orabulkloader/OraBulkLoader.java
+++ b/plugins/transforms/orabulkloader/src/main/java/org/apache/hop/pipeline/transforms/orabulkloader/OraBulkLoader.java
@@ -690,6 +690,6 @@ public class OraBulkLoader extends BaseTransform<OraBulkLoaderMeta, OraBulkLoade
 
   @VisibleForTesting
   FileObject getFileObject(String fileName, IVariables variables) throws HopFileException {
-    return HopVfs.getFileObject(variables.resolve(fileName));
+    return HopVfs.getFileObject(variables.resolve(fileName), variables);
   }
 }

--- a/plugins/transforms/pgp/src/main/java/org/apache/hop/pipeline/transforms/pgpdecryptstream/PGPDecryptStream.java
+++ b/plugins/transforms/pgp/src/main/java/org/apache/hop/pipeline/transforms/pgpdecryptstream/PGPDecryptStream.java
@@ -181,7 +181,7 @@ public class PGPDecryptStream extends BaseTransform<PGPDecryptStreamMeta, PGPDec
 
       try {
         // initiate a new GPG encryptor
-        data.gpg = new GPG(resolve(meta.getGPGLocation()), log);
+        data.gpg = new GPG(resolve(meta.getGPGLocation()), log, variables);
       } catch (Exception e) {
         logError(BaseMessages.getString(PKG, "PGPDecryptStream.Init.Error"), e);
         return false;

--- a/plugins/transforms/pgp/src/main/java/org/apache/hop/pipeline/transforms/pgpencryptstream/PGPEncryptStream.java
+++ b/plugins/transforms/pgp/src/main/java/org/apache/hop/pipeline/transforms/pgpencryptstream/PGPEncryptStream.java
@@ -186,7 +186,7 @@ public class PGPEncryptStream extends BaseTransform<PGPEncryptStreamMeta, PGPEnc
 
       try {
         // initiate a new GPG encryptor
-        data.gpg = new GPG(resolve(meta.getGPGLocation()), log);
+        data.gpg = new GPG(resolve(meta.getGPGLocation()), log, variables);
       } catch (Exception e) {
         logError(BaseMessages.getString(PKG, "PGPEncryptStream.Init.Error"), e);
         return false;

--- a/plugins/transforms/pipelineexecutor/src/main/java/org/apache/hop/pipeline/transforms/pipelineexecutor/PipelineExecutorDialog.java
+++ b/plugins/transforms/pipelineexecutor/src/main/java/org/apache/hop/pipeline/transforms/pipelineexecutor/PipelineExecutorDialog.java
@@ -390,7 +390,7 @@ public class PipelineExecutorDialog extends BaseTransformDialog {
     String parentFolder = null;
     try {
       parentFolder =
-          HopVfs.getFileObject(variables.resolve(pipelineMeta.getFilename()))
+          HopVfs.getFileObject(variables.resolve(pipelineMeta.getFilename()), variables)
               .getParent()
               .toString();
     } catch (Exception e) {

--- a/plugins/transforms/processfiles/src/main/java/org/apache/hop/pipeline/transforms/processfiles/ProcessFiles.java
+++ b/plugins/transforms/processfiles/src/main/java/org/apache/hop/pipeline/transforms/processfiles/ProcessFiles.java
@@ -102,7 +102,7 @@ public class ProcessFiles extends BaseTransform<ProcessFilesMeta, ProcessFilesDa
         logError(BaseMessages.getString(PKG, "ProcessFiles.Error.SourceFileEmpty"));
         throw new HopException(BaseMessages.getString(PKG, "ProcessFiles.Error.SourceFileEmpty"));
       }
-      data.sourceFile = HopVfs.getFileObject(sourceFilename);
+      data.sourceFile = HopVfs.getFileObject(sourceFilename, variables);
 
       if (!data.sourceFile.exists()) {
         logError(
@@ -125,7 +125,7 @@ public class ProcessFiles extends BaseTransform<ProcessFilesMeta, ProcessFilesDa
           logError(BaseMessages.getString(PKG, "ProcessFiles.Error.TargetFileEmpty"));
           throw new HopException(BaseMessages.getString(PKG, "ProcessFiles.Error.TargetFileEmpty"));
         }
-        data.targetFile = HopVfs.getFileObject(targetFilename);
+        data.targetFile = HopVfs.getFileObject(targetFilename, variables);
         if (data.targetFile.exists()) {
           if (log.isDetailed()) {
             logDetailed(
@@ -190,7 +190,7 @@ public class ProcessFiles extends BaseTransform<ProcessFilesMeta, ProcessFilesDa
           if (((meta.isOverwriteTargetFile() && data.targetFile.exists())
                   || !data.targetFile.exists())
               && !meta.simulate) {
-            data.sourceFile.moveTo(HopVfs.getFileObject(targetFilename));
+            data.sourceFile.moveTo(HopVfs.getFileObject(targetFilename, variables));
             if (log.isDetailed()) {
               logDetailed(
                   BaseMessages.getString(

--- a/plugins/transforms/propertyinput/src/main/java/org/apache/hop/pipeline/transforms/propertyinput/PropertyInput.java
+++ b/plugins/transforms/propertyinput/src/main/java/org/apache/hop/pipeline/transforms/propertyinput/PropertyInput.java
@@ -405,7 +405,7 @@ public class PropertyInput extends BaseTransform<PropertyInputMeta, PropertyInpu
                   filename));
         }
 
-        data.file = HopVfs.getFileObject(filename);
+        data.file = HopVfs.getFileObject(filename, variables);
         // Check if file exists!
       }
 

--- a/plugins/transforms/propertyoutput/src/main/java/org/apache/hop/pipeline/transforms/propertyoutput/PropertyOutput.java
+++ b/plugins/transforms/propertyoutput/src/main/java/org/apache/hop/pipeline/transforms/propertyoutput/PropertyOutput.java
@@ -178,7 +178,7 @@ public class PropertyOutput extends BaseTransform<PropertyOutputMeta, PropertyOu
   }
 
   private void openNewFile() throws HopException {
-    try (FileObject newFile = HopVfs.getFileObject(data.filename)) {
+    try (FileObject newFile = HopVfs.getFileObject(data.filename, variables)) {
       data.pro = new Properties();
       data.KeySet.clear();
 

--- a/plugins/transforms/sasinput/src/main/java/org/apache/hop/pipeline/transforms/sasinput/SasInput.java
+++ b/plugins/transforms/sasinput/src/main/java/org/apache/hop/pipeline/transforms/sasinput/SasInput.java
@@ -98,7 +98,7 @@ public class SasInput extends BaseTransform<SasInputMeta, SasInputData> {
     ResultFile resultFile =
         new ResultFile(
             ResultFile.FILE_TYPE_GENERAL,
-            HopVfs.getFileObject(filename),
+            HopVfs.getFileObject(filename, variables),
             getPipelineMeta().getName(),
             getTransformName());
     resultFile.setComment(BaseMessages.getString(PKG, "SASInput.ResultFile.Comment"));
@@ -106,7 +106,7 @@ public class SasInput extends BaseTransform<SasInputMeta, SasInputData> {
 
     // Read the SAS File
     //
-    try (InputStream inputStream = HopVfs.getInputStream(filename)) {
+    try (InputStream inputStream = HopVfs.getInputStream(filename, variables)) {
       SasFileReaderImpl sasFileReader = new SasFileReaderImpl(inputStream);
       SasFileProperties sasFileProperties = sasFileReader.getSasFileProperties();
 

--- a/plugins/transforms/sasinput/src/main/java/org/apache/hop/pipeline/transforms/sasinput/SasInputDialog.java
+++ b/plugins/transforms/sasinput/src/main/java/org/apache/hop/pipeline/transforms/sasinput/SasInputDialog.java
@@ -328,7 +328,7 @@ public class SasInputDialog extends BaseTransformDialog {
               true);
       if (filename != null) {
         String realFilename = variables.resolve(filename);
-        try (InputStream inputStream = HopVfs.getInputStream(realFilename)) {
+        try (InputStream inputStream = HopVfs.getInputStream(realFilename, variables)) {
           SasFileReaderImpl sasFileReader = new SasFileReaderImpl(inputStream);
           SasFileProperties fileProperties = sasFileReader.getSasFileProperties();
 

--- a/plugins/transforms/sasinput/src/main/java/org/apache/hop/pipeline/transforms/sasinput/types/SasExplorerFileTypeHandler.java
+++ b/plugins/transforms/sasinput/src/main/java/org/apache/hop/pipeline/transforms/sasinput/types/SasExplorerFileTypeHandler.java
@@ -69,7 +69,8 @@ public class SasExplorerFileTypeHandler extends BaseExplorerFileTypeHandler
     message += Const.CR;
 
     try {
-      try (InputStream inputStream = HopVfs.getInputStream(explorerFile.getFilename())) {
+      try (InputStream inputStream =
+          HopVfs.getInputStream(explorerFile.getFilename(), getVariables())) {
         SasFileReaderImpl sasFileReader = new SasFileReaderImpl(inputStream);
 
         List<Column> columns = sasFileReader.getColumns();

--- a/plugins/transforms/snowflake/src/main/java/org/apache/hop/pipeline/transforms/snowflake/bulkloader/SnowflakeBulkLoader.java
+++ b/plugins/transforms/snowflake/src/main/java/org/apache/hop/pipeline/transforms/snowflake/bulkloader/SnowflakeBulkLoader.java
@@ -629,7 +629,8 @@ public class SnowflakeBulkLoader
       data.writer = new BufferedOutputStream(data.out, 5000);
 
       if (log.isDetailed()) {
-        logDetailed("Opened new file with name [" + HopVfs.getFriendlyURI(filename) + "]");
+        logDetailed(
+            "Opened new file with name [" + HopVfs.getFriendlyURI(filename, variables) + "]");
       }
 
     } catch (Exception e) {
@@ -779,7 +780,7 @@ public class SnowflakeBulkLoader
         || !Boolean.parseBoolean(resolve(SnowflakeBulkLoaderMeta.DEBUG_MODE_VAR))) {
       for (String filename : data.previouslyOpenedFiles) {
         try {
-          HopVfs.getFileObject(filename).delete();
+          HopVfs.getFileObject(filename, variables).delete();
           logDetailed("Deleted temp file " + filename);
         } catch (Exception ex) {
           logMinimal("Unable to delete temp file", ex);
@@ -872,7 +873,7 @@ public class SnowflakeBulkLoader
    * @throws HopFileException
    */
   protected FileObject getFileObject(String vfsFilename) throws HopFileException {
-    return HopVfs.getFileObject(vfsFilename);
+    return HopVfs.getFileObject(vfsFilename, variables);
   }
 
   /**
@@ -885,7 +886,7 @@ public class SnowflakeBulkLoader
    */
   protected FileObject getFileObject(String vfsFilename, IVariables variables)
       throws HopFileException {
-    return HopVfs.getFileObject(vfsFilename);
+    return HopVfs.getFileObject(vfsFilename, variables);
   }
 
   /**
@@ -899,6 +900,6 @@ public class SnowflakeBulkLoader
    */
   private OutputStream getOutputStream(String vfsFilename, IVariables variables, boolean append)
       throws HopFileException {
-    return HopVfs.getOutputStream(vfsFilename, append);
+    return HopVfs.getOutputStream(vfsFilename, append, variables);
   }
 }

--- a/plugins/transforms/snowflake/src/main/java/org/apache/hop/pipeline/transforms/snowflake/bulkloader/SnowflakeBulkLoaderMeta.java
+++ b/plugins/transforms/snowflake/src/main/java/org/apache/hop/pipeline/transforms/snowflake/bulkloader/SnowflakeBulkLoaderMeta.java
@@ -981,7 +981,7 @@ public class SnowflakeBulkLoaderMeta
     returnValue.append("FILES = (");
     boolean first = true;
     for (String filename : filenames) {
-      String shortFile = HopVfs.getFileObject(filename).getName().getBaseName();
+      String shortFile = HopVfs.getFileObject(filename, variables).getName().getBaseName();
       if (first) {
         returnValue.append("'");
         first = false;

--- a/plugins/transforms/sort/src/main/java/org/apache/hop/pipeline/transforms/sort/SortRows.java
+++ b/plugins/transforms/sort/src/main/java/org/apache/hop/pipeline/transforms/sort/SortRows.java
@@ -129,7 +129,7 @@ public class SortRows extends BaseTransform<SortRowsMeta, SortRowsData> {
 
     try {
       FileObject fileObject =
-          HopVfs.createTempFile(meta.getPrefix(), ".tmp", resolve(meta.getDirectory()));
+          HopVfs.createTempFile(meta.getPrefix(), ".tmp", resolve(meta.getDirectory()), variables);
 
       data.files.add(fileObject); // Remember the files!
       OutputStream outputStream = HopVfs.getOutputStream(fileObject, false);

--- a/plugins/transforms/sort/src/main/java/org/apache/hop/pipeline/transforms/sort/SortRowsMeta.java
+++ b/plugins/transforms/sort/src/main/java/org/apache/hop/pipeline/transforms/sort/SortRowsMeta.java
@@ -59,6 +59,9 @@ public class SortRowsMeta extends BaseTransformMeta<SortRows, SortRowsData>
     implements Serializable {
   private static final long serialVersionUID = -9075883720765645655L;
   private static final Class<?> PKG = SortRowsMeta.class; // For Translator
+  private static final String CONST_SPACE = "      ";
+  private static final String CONST_SPACE_LONG = "        ";
+  private static final String CONST_FIELD = "field";
 
   /** order by which fields? */
   @Injection(name = "NAME", group = "FIELDS")
@@ -221,13 +224,13 @@ public class SortRowsMeta extends BaseTransformMeta<SortRows, SortRowsData>
           "Y".equalsIgnoreCase(XmlHandler.getTagValue(transformNode, "unique_rows"));
 
       Node fields = XmlHandler.getSubNode(transformNode, "fields");
-      int nrFields = XmlHandler.countNodes(fields, "field");
+      int nrFields = XmlHandler.countNodes(fields, CONST_FIELD);
 
       allocate(nrFields);
       String defaultStrength = Integer.toString(this.getDefaultCollationStrength());
 
       for (int i = 0; i < nrFields; i++) {
-        Node fnode = XmlHandler.getSubNodeByNr(fields, "field", i);
+        Node fnode = XmlHandler.getSubNodeByNr(fields, CONST_FIELD, i);
 
         fieldName[i] = XmlHandler.getTagValue(fnode, "name");
         String asc = XmlHandler.getTagValue(fnode, "ascending");
@@ -262,7 +265,7 @@ public class SortRowsMeta extends BaseTransformMeta<SortRows, SortRowsData>
     allocate(nrFields);
 
     for (int i = 0; i < nrFields; i++) {
-      fieldName[i] = "field" + i;
+      fieldName[i] = CONST_FIELD + i;
       caseSensitive[i] = true;
       collatorEnabled[i] = false;
       collatorStrength[i] = 0;
@@ -273,29 +276,33 @@ public class SortRowsMeta extends BaseTransformMeta<SortRows, SortRowsData>
   @Override
   public String getXml() {
     StringBuilder retval = new StringBuilder(256);
-    retval.append("      ").append(XmlHandler.addTagValue("directory", directory));
-    retval.append("      ").append(XmlHandler.addTagValue("prefix", prefix));
-    retval.append("      ").append(XmlHandler.addTagValue("sort_size", sortSize));
-    retval.append("      ").append(XmlHandler.addTagValue("free_memory", freeMemoryLimit));
-    retval.append("      ").append(XmlHandler.addTagValue("compress", compressFiles));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("directory", directory));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("prefix", prefix));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("sort_size", sortSize));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("free_memory", freeMemoryLimit));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("compress", compressFiles));
     retval
-        .append("      ")
+        .append(CONST_SPACE)
         .append(XmlHandler.addTagValue("compress_variable", compressFilesVariable));
-    retval.append("      ").append(XmlHandler.addTagValue("unique_rows", onlyPassingUniqueRows));
+    retval.append(CONST_SPACE).append(XmlHandler.addTagValue("unique_rows", onlyPassingUniqueRows));
 
     retval.append("    <fields>").append(Const.CR);
     for (int i = 0; i < fieldName.length; i++) {
       retval.append("      <field>").append(Const.CR);
-      retval.append("        ").append(XmlHandler.addTagValue("name", fieldName[i]));
-      retval.append("        ").append(XmlHandler.addTagValue("ascending", ascending[i]));
-      retval.append("        ").append(XmlHandler.addTagValue("case_sensitive", caseSensitive[i]));
+      retval.append(CONST_SPACE_LONG).append(XmlHandler.addTagValue("name", fieldName[i]));
+      retval.append(CONST_SPACE_LONG).append(XmlHandler.addTagValue("ascending", ascending[i]));
       retval
-          .append("        ")
+          .append(CONST_SPACE_LONG)
+          .append(XmlHandler.addTagValue("case_sensitive", caseSensitive[i]));
+      retval
+          .append(CONST_SPACE_LONG)
           .append(XmlHandler.addTagValue("collator_enabled", collatorEnabled[i]));
       retval
-          .append("        ")
+          .append(CONST_SPACE_LONG)
           .append(XmlHandler.addTagValue("collator_strength", collatorStrength[i]));
-      retval.append("        ").append(XmlHandler.addTagValue("presorted", preSortedField[i]));
+      retval
+          .append(CONST_SPACE_LONG)
+          .append(XmlHandler.addTagValue("presorted", preSortedField[i]));
       retval.append("      </field>").append(Const.CR);
     }
     retval.append("    </fields>").append(Const.CR);

--- a/plugins/transforms/sqlfileoutput/src/main/java/org/apache/hop/pipeline/transforms/sqlfileoutput/SQLFileOutput.java
+++ b/plugins/transforms/sqlfileoutput/src/main/java/org/apache/hop/pipeline/transforms/sqlfileoutput/SQLFileOutput.java
@@ -191,7 +191,7 @@ public class SQLFileOutput extends BaseTransform<SQLFileOutputMeta, SQLFileOutpu
         ResultFile resultFile =
             new ResultFile(
                 ResultFile.FILE_TYPE_GENERAL,
-                HopVfs.getFileObject(filename),
+                HopVfs.getFileObject(filename, variables),
                 getPipelineMeta().getName(),
                 getTransformName());
         resultFile.setComment("This file was created with a text file output transform");
@@ -202,7 +202,7 @@ public class SQLFileOutput extends BaseTransform<SQLFileOutputMeta, SQLFileOutpu
       if (log.isDetailed()) {
         logDetailed("Opening output stream in nocompress mode");
       }
-      OutputStream fos = HopVfs.getOutputStream(filename, meta.isFileAppended());
+      OutputStream fos = HopVfs.getOutputStream(filename, meta.isFileAppended(), variables);
       outputStream = fos;
 
       if (log.isDetailed()) {
@@ -297,7 +297,7 @@ public class SQLFileOutput extends BaseTransform<SQLFileOutputMeta, SQLFileOutpu
           try {
             // Get parent folder
             String filename = resolve(meta.getFileName());
-            parentfolder = HopVfs.getFileObject(filename).getParent();
+            parentfolder = HopVfs.getFileObject(filename, variables).getParent();
             if (!parentfolder.exists()) {
               log.logBasic(
                   "Folder parent", "Folder parent " + parentfolder.getName() + " does not exist !");

--- a/plugins/transforms/sqlfileoutput/src/main/java/org/apache/hop/pipeline/transforms/sqlfileoutput/SQLFileOutputMeta.java
+++ b/plugins/transforms/sqlfileoutput/src/main/java/org/apache/hop/pipeline/transforms/sqlfileoutput/SQLFileOutputMeta.java
@@ -59,6 +59,8 @@ import org.w3c.dom.Node;
     documentationUrl = "/pipeline/transforms/sqlfileoutput.html")
 public class SQLFileOutputMeta extends BaseTransformMeta<SQLFileOutput, SQLFileOutputData> {
   private static final Class<?> PKG = SQLFileOutputMeta.class; // For Translator
+  private static final String CONST_SPACE = "      ";
+  private static final String CONST_SPACE_SHORT = "    ";
 
   private String connection;
   private String schemaName;
@@ -118,9 +120,7 @@ public class SQLFileOutputMeta extends BaseTransformMeta<SQLFileOutput, SQLFileO
   @Override
   public Object clone() {
 
-    SQLFileOutputMeta retval = (SQLFileOutputMeta) super.clone();
-
-    return retval;
+    return (SQLFileOutputMeta) super.clone();
   }
 
   /**
@@ -487,28 +487,29 @@ public class SQLFileOutputMeta extends BaseTransformMeta<SQLFileOutput, SQLFileO
   public String getXml() {
     StringBuilder retval = new StringBuilder();
 
-    retval.append("    " + XmlHandler.addTagValue("connection", connection));
-    retval.append("    " + XmlHandler.addTagValue("schema", schemaName));
-    retval.append("    " + XmlHandler.addTagValue("table", tableName));
-    retval.append("    " + XmlHandler.addTagValue("truncate", truncateTable));
-    retval.append("    " + XmlHandler.addTagValue("create", createTable));
-    retval.append("    " + XmlHandler.addTagValue("encoding", encoding));
-    retval.append("    " + XmlHandler.addTagValue("dateformat", dateformat));
-    retval.append("    " + XmlHandler.addTagValue("addtoresult", addToResult));
+    retval.append(CONST_SPACE_SHORT + XmlHandler.addTagValue("connection", connection));
+    retval.append(CONST_SPACE_SHORT + XmlHandler.addTagValue("schema", schemaName));
+    retval.append(CONST_SPACE_SHORT + XmlHandler.addTagValue("table", tableName));
+    retval.append(CONST_SPACE_SHORT + XmlHandler.addTagValue("truncate", truncateTable));
+    retval.append(CONST_SPACE_SHORT + XmlHandler.addTagValue("create", createTable));
+    retval.append(CONST_SPACE_SHORT + XmlHandler.addTagValue("encoding", encoding));
+    retval.append(CONST_SPACE_SHORT + XmlHandler.addTagValue("dateformat", dateformat));
+    retval.append(CONST_SPACE_SHORT + XmlHandler.addTagValue("addtoresult", addToResult));
 
-    retval.append("    " + XmlHandler.addTagValue("startnewline", startNewLine));
+    retval.append(CONST_SPACE_SHORT + XmlHandler.addTagValue("startnewline", startNewLine));
 
     retval.append("    <file>" + Const.CR);
-    retval.append("      " + XmlHandler.addTagValue("name", fileName));
-    retval.append("      " + XmlHandler.addTagValue("extention", extension));
-    retval.append("      " + XmlHandler.addTagValue("append", fileAppended));
-    retval.append("      " + XmlHandler.addTagValue("split", transformNrInFilename));
-    retval.append("      " + XmlHandler.addTagValue("haspartno", partNrInFilename));
-    retval.append("      " + XmlHandler.addTagValue("add_date", dateInFilename));
-    retval.append("      " + XmlHandler.addTagValue("add_time", timeInFilename));
-    retval.append("      " + XmlHandler.addTagValue("splitevery", splitEvery));
-    retval.append("      " + XmlHandler.addTagValue("create_parent_folder", createparentfolder));
-    retval.append("      " + XmlHandler.addTagValue("DoNotOpenNewFileInit", doNotOpenNewFileInit));
+    retval.append(CONST_SPACE + XmlHandler.addTagValue("name", fileName));
+    retval.append(CONST_SPACE + XmlHandler.addTagValue("extention", extension));
+    retval.append(CONST_SPACE + XmlHandler.addTagValue("append", fileAppended));
+    retval.append(CONST_SPACE + XmlHandler.addTagValue("split", transformNrInFilename));
+    retval.append(CONST_SPACE + XmlHandler.addTagValue("haspartno", partNrInFilename));
+    retval.append(CONST_SPACE + XmlHandler.addTagValue("add_date", dateInFilename));
+    retval.append(CONST_SPACE + XmlHandler.addTagValue("add_time", timeInFilename));
+    retval.append(CONST_SPACE + XmlHandler.addTagValue("splitevery", splitEvery));
+    retval.append(CONST_SPACE + XmlHandler.addTagValue("create_parent_folder", createparentfolder));
+    retval.append(
+        CONST_SPACE + XmlHandler.addTagValue("DoNotOpenNewFileInit", doNotOpenNewFileInit));
 
     retval.append("      </file>" + Const.CR);
 
@@ -924,7 +925,7 @@ public class SQLFileOutputMeta extends BaseTransformMeta<SQLFileOutput, SQLFileO
       // From : ${Internal.Pipeline.Filename.Directory}/../foo/bar.data
       // To : /home/matt/test/files/foo/bar.data
       //
-      FileObject fileObject = HopVfs.getFileObject(variables.resolve(fileName));
+      FileObject fileObject = HopVfs.getFileObject(variables.resolve(fileName), variables);
 
       // If the file doesn't exist, forget about this effort too!
       //

--- a/plugins/transforms/ssh/src/main/java/org/apache/hop/pipeline/transforms/ssh/SshData.java
+++ b/plugins/transforms/ssh/src/main/java/org/apache/hop/pipeline/transforms/ssh/SshData.java
@@ -38,6 +38,7 @@ import org.apache.hop.pipeline.transform.BaseTransformData;
 import org.apache.hop.pipeline.transform.ITransformData;
 
 public class SshData extends BaseTransformData implements ITransformData {
+  private static final Class<?> PKG = SshMeta.class; // For Translator
   public int indexOfCommand;
   public Connection conn;
   public boolean wroteOneRow;
@@ -79,14 +80,13 @@ public class SshData extends BaseTransformData implements ITransformData {
       if (meta.isUsePrivateKey()) {
         String keyFilename = variables.resolve(meta.getKeyFileName());
         if (StringUtils.isEmpty(keyFilename)) {
-          throw new HopException(
-              BaseMessages.getString(SshMeta.PKG, "SSH.Error.PrivateKeyFileMissing"));
+          throw new HopException(BaseMessages.getString(PKG, "SSH.Error.PrivateKeyFileMissing"));
         }
-        FileObject keyFileObject = HopVfs.getFileObject(keyFilename);
+        FileObject keyFileObject = HopVfs.getFileObject(keyFilename, variables);
 
         if (!keyFileObject.exists()) {
           throw new HopException(
-              BaseMessages.getString(SshMeta.PKG, "SSH.Error.PrivateKeyNotExist", keyFilename));
+              BaseMessages.getString(PKG, "SSH.Error.PrivateKeyNotExist", keyFilename));
         }
 
         FileContent keyFileContent = keyFileObject.getContent();
@@ -139,7 +139,7 @@ public class SshData extends BaseTransformData implements ITransformData {
       }
       if (!isAuthenticated) {
         throw new HopException(
-            BaseMessages.getString(SshMeta.PKG, "SSH.Error.AuthenticationFailed", username));
+            BaseMessages.getString(PKG, "SSH.Error.AuthenticationFailed", username));
       }
     } catch (Exception e) {
       // Something wrong happened
@@ -148,7 +148,7 @@ public class SshData extends BaseTransformData implements ITransformData {
         connection.close();
       }
       throw new HopException(
-          BaseMessages.getString(SshMeta.PKG, "SSH.Error.ErrorConnecting", hostname, username), e);
+          BaseMessages.getString(PKG, "SSH.Error.ErrorConnecting", hostname, username), e);
     }
     return connection;
   }

--- a/plugins/transforms/ssh/src/main/java/org/apache/hop/pipeline/transforms/ssh/SshMeta.java
+++ b/plugins/transforms/ssh/src/main/java/org/apache/hop/pipeline/transforms/ssh/SshMeta.java
@@ -45,8 +45,8 @@ import org.apache.hop.pipeline.transform.TransformMeta;
     keywords = "i18n::SSHMeta.keyword",
     documentationUrl = "/pipeline/transforms/runssh.html")
 public class SshMeta extends BaseTransformMeta<Ssh, SshData> {
-  static Class<?> PKG = SshMeta.class; // For Translator
-  private static int DEFAULT_PORT = 22;
+  private static final Class<?> PKG = SshMeta.class; // For Translator
+  private static final int DEFAULT_PORT = 22;
 
   @HopMetadataProperty private String command;
   @HopMetadataProperty private boolean dynamicCommandField;
@@ -133,7 +133,7 @@ public class SshMeta extends BaseTransformMeta<Ssh, SshData> {
         remarks.add(cr);
         boolean keyFileExists = false;
         try {
-          keyFileExists = HopVfs.fileExists(keyfilename);
+          keyFileExists = HopVfs.fileExists(keyfilename, variables);
         } catch (Exception e) {
           /* Ignore */
         }

--- a/plugins/transforms/terafast/src/main/java/org/apache/hop/pipeline/transforms/terafast/TeraFast.java
+++ b/plugins/transforms/terafast/src/main/java/org/apache/hop/pipeline/transforms/terafast/TeraFast.java
@@ -83,7 +83,7 @@ public class TeraFast extends AbstractTransform<TeraFastMeta, GenericTransformDa
     final StringBuilder builder = new StringBuilder();
     try {
       final FileObject fileObject =
-          HopVfs.getFileObject(resolve(this.meta.getFastloadPath().getValue()));
+          HopVfs.getFileObject(resolve(this.meta.getFastloadPath().getValue()), variables);
       final String fastloadExec = HopVfs.getFilename(fileObject);
       builder.append(fastloadExec);
     } catch (Exception e) {
@@ -92,7 +92,8 @@ public class TeraFast extends AbstractTransform<TeraFastMeta, GenericTransformDa
     // Add log error log, if set.
     if (StringUtils.isNotBlank(this.meta.getLogFile().getValue())) {
       try {
-        FileObject fileObject = HopVfs.getFileObject(resolve(this.meta.getLogFile().getValue()));
+        FileObject fileObject =
+            HopVfs.getFileObject(resolve(this.meta.getLogFile().getValue()), variables);
         builder.append(" -e ");
         builder.append("\"" + HopVfs.getFilename(fileObject) + "\"");
       } catch (Exception e) {
@@ -418,7 +419,7 @@ public class TeraFast extends AbstractTransform<TeraFastMeta, GenericTransformDa
    * @throws IOException ...
    */
   private String resolveFileName(final String fileName) throws HopException {
-    final FileObject fileObject = HopVfs.getFileObject(resolve(fileName));
+    final FileObject fileObject = HopVfs.getFileObject(resolve(fileName), variables);
     return HopVfs.getFilename(fileObject);
   }
 }

--- a/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/csvinput/CsvInput.java
+++ b/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/csvinput/CsvInput.java
@@ -190,7 +190,7 @@ public class CsvInput extends BaseTransform<CsvInputMeta, CsvInputData> {
       // We'll use the same algorithm...
       //
       for (String filename : data.filenames) {
-        long size = HopVfs.getFileObject(filename).getContent().getSize();
+        long size = HopVfs.getFileObject(filename, variables).getContent().getSize();
         data.fileSizes.add(size);
         data.totalFileSize += size;
       }
@@ -332,7 +332,7 @@ public class CsvInput extends BaseTransform<CsvInputMeta, CsvInputData> {
       // Open the next one...
       //
       data.fieldsMapping = createFieldMapping(data.filenames[data.filenr], meta);
-      FileObject fileObject = HopVfs.getFileObject(data.filenames[data.filenr]);
+      FileObject fileObject = HopVfs.getFileObject(data.filenames[data.filenr], variables);
       if (!(fileObject instanceof LocalFile)) {
         // We can only use NIO on local files at the moment, so that's what we limit ourselves to.
         //
@@ -467,7 +467,7 @@ public class CsvInput extends BaseTransform<CsvInputMeta, CsvInputData> {
     String enclosure = resolve(csvInputMeta.getEnclosure());
     String realEncoding = resolve(csvInputMeta.getEncoding());
 
-    try (FileObject fileObject = HopVfs.getFileObject(fileName);
+    try (FileObject fileObject = HopVfs.getFileObject(fileName, variables);
         BOMInputStream inputStream =
             new BOMInputStream(
                 HopVfs.getInputStream(fileObject),

--- a/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputDialog.java
+++ b/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputDialog.java
@@ -929,7 +929,7 @@ public class CsvInputDialog extends BaseTransformDialog
     try {
       String filename = variables.resolve(meta.getFilename());
 
-      FileObject fileObject = HopVfs.getFileObject(filename);
+      FileObject fileObject = HopVfs.getFileObject(filename, variables);
       if (!(fileObject instanceof LocalFile)) {
         // We can only use NIO on local files at the moment, so that's what we
         // limit ourselves to.
@@ -962,7 +962,7 @@ public class CsvInputDialog extends BaseTransformDialog
     try {
       final String filename = variables.resolve(meta.getFilename());
 
-      final FileObject fileObject = HopVfs.getFileObject(filename);
+      final FileObject fileObject = HopVfs.getFileObject(filename, variables);
       if (!(fileObject instanceof LocalFile)) {
         // We can only use NIO on local files at the moment, so that's what we
         // limit ourselves to.

--- a/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputMeta.java
+++ b/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputMeta.java
@@ -683,7 +683,7 @@ public class CsvInputMeta extends BaseTransformMeta<CsvInput, CsvInputData>
         // From : ${Internal.Pipeline.Filename.Directory}/../foo/bar.csv
         // To : /home/matt/test/files/foo/bar.csv
         //
-        FileObject fileObject = HopVfs.getFileObject(variables.resolve(filename));
+        FileObject fileObject = HopVfs.getFileObject(variables.resolve(filename), variables);
 
         // If the file doesn't exist, forget about this effort too!
         //
@@ -724,7 +724,7 @@ public class CsvInputMeta extends BaseTransformMeta<CsvInput, CsvInputData>
   public FileObject getHeaderFileObject(final IVariables variables) {
     final String filename = variables.resolve(getFilename());
     try {
-      return HopVfs.getFileObject(filename);
+      return HopVfs.getFileObject(filename, variables);
     } catch (final HopFileException e) {
       return null;
     }

--- a/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/fileinput/TextFileInput.java
+++ b/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/fileinput/TextFileInput.java
@@ -1078,7 +1078,7 @@ public class TextFileInput extends BaseTransform<TextFileInputMeta, TextFileInpu
           }
           String fileValue = prevInfoFields.getString(fileRow, idx);
           try {
-            FileObject fileObject = HopVfs.getFileObject(fileValue);
+            FileObject fileObject = HopVfs.getFileObject(fileValue, variables);
             data.getFiles().addFile(fileObject);
             if (meta.isPassingThruFields()) {
               data.passThruFields.put(fileObject, fileRow);

--- a/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/fileinput/TextFileInputMeta.java
+++ b/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/fileinput/TextFileInputMeta.java
@@ -1840,7 +1840,7 @@ public class TextFileInputMeta extends BaseTransformMeta<TextFileInput, TextFile
         // Replace the filename ONLY (folder or filename)
         //
         for (int i = 0; i < fileName.length; i++) {
-          FileObject fileObject = HopVfs.getFileObject(variables.resolve(fileName[i]));
+          FileObject fileObject = HopVfs.getFileObject(variables.resolve(fileName[i]), variables);
           fileName[i] =
               iResourceNaming.nameResource(fileObject, variables, Utils.isEmpty(fileMask[i]));
         }

--- a/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/fileinput/text/TextFileInputMeta.java
+++ b/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/fileinput/text/TextFileInputMeta.java
@@ -1229,7 +1229,7 @@ public class TextFileInputMeta
 
   /** For testing */
   FileObject getFileObject(String vfsFileName, IVariables variables) throws HopFileException {
-    return HopVfs.getFileObject(variables.resolve(vfsFileName));
+    return HopVfs.getFileObject(variables.resolve(vfsFileName), variables);
   }
 
   @Override

--- a/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/textfileoutput/TextFileOutput.java
+++ b/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/textfileoutput/TextFileOutput.java
@@ -1029,17 +1029,17 @@ public class TextFileOutput<Meta extends TextFileOutputMeta, Data extends TextFi
   }
 
   protected FileObject getFileObject(String vfsFilename) throws HopFileException {
-    return HopVfs.getFileObject(vfsFilename);
+    return HopVfs.getFileObject(vfsFilename, variables);
   }
 
   protected FileObject getFileObject(String vfsFilename, IVariables variables)
       throws HopFileException {
-    return HopVfs.getFileObject(vfsFilename);
+    return HopVfs.getFileObject(vfsFilename, variables);
   }
 
   protected OutputStream getOutputStream(String vfsFilename, IVariables variables, boolean append)
       throws HopFileException {
-    return HopVfs.getOutputStream(vfsFilename, append);
+    return HopVfs.getOutputStream(vfsFilename, append, variables);
   }
 
   @Override

--- a/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/textfileoutput/TextFileOutputMeta.java
+++ b/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/textfileoutput/TextFileOutputMeta.java
@@ -1040,7 +1040,7 @@ public class TextFileOutputMeta extends BaseTransformMeta<TextFileOutput, TextFi
       if (!fileNameInField) {
 
         if (!Utils.isEmpty(fileName)) {
-          FileObject fileObject = HopVfs.getFileObject(variables.resolve(fileName));
+          FileObject fileObject = HopVfs.getFileObject(variables.resolve(fileName), variables);
           fileName = iResourceNaming.nameResource(fileObject, variables, true);
         }
       }

--- a/plugins/transforms/tika/src/main/java/org/apache/hop/pipeline/transforms/tika/Tika.java
+++ b/plugins/transforms/tika/src/main/java/org/apache/hop/pipeline/transforms/tika/Tika.java
@@ -131,7 +131,7 @@ public class Tika extends BaseTransform<TikaMeta, TikaData> {
 
         try {
           // Source is a file.
-          data.file = HopVfs.getFileObject(fieldvalue);
+          data.file = HopVfs.getFileObject(fieldvalue, variables);
         } catch (HopFileException e) {
           throw new HopException(e);
         } finally {
@@ -290,7 +290,7 @@ public class Tika extends BaseTransform<TikaMeta, TikaData> {
       if (vfsFilename.startsWith("file:")) {
         inputStream = new FileInputStream(vfsFilename.substring(5));
       } else {
-        inputStream = HopVfs.getInputStream(vfsFilename);
+        inputStream = HopVfs.getInputStream(vfsFilename, variables);
       }
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
       data.tikaOutput.parse(inputStream, meta.getOutputFormat(), baos);

--- a/plugins/transforms/tika/src/main/java/org/apache/hop/pipeline/transforms/tika/TikaMeta.java
+++ b/plugins/transforms/tika/src/main/java/org/apache/hop/pipeline/transforms/tika/TikaMeta.java
@@ -420,7 +420,8 @@ public class TikaMeta extends BaseTransformMeta<Tika, TikaData> {
       //
       if (!fileInField) {
         for (TikaFile file : files) {
-          FileObject fileObject = HopVfs.getFileObject(variables.resolve(file.getName()));
+          FileObject fileObject =
+              HopVfs.getFileObject(variables.resolve(file.getName()), variables);
           file.setName(
               iResourceNaming.nameResource(
                   fileObject, variables, StringUtils.isEmpty(file.getMask())));

--- a/plugins/transforms/tokenreplacement/src/main/java/org/apache/hop/pipeline/transforms/tokenreplacement/TokenReplacement.java
+++ b/plugins/transforms/tokenreplacement/src/main/java/org/apache/hop/pipeline/transforms/tokenreplacement/TokenReplacement.java
@@ -180,13 +180,13 @@ public class TokenReplacement extends BaseTransform<TokenReplacementMeta, TokenR
       if (Utils.isEmpty(inputFilename)) {
         throw new HopValueException("Input filename cannot be empty");
       }
-      if (!HopVfs.fileExists(inputFilename)) {
+      if (!HopVfs.fileExists(inputFilename, variables)) {
         throw new HopException("Input file " + inputFilename + " does not exist.");
       }
       reader =
           new TokenReplacingReader(
               resolver,
-              new InputStreamReader(HopVfs.getInputStream(inputFilename)),
+              new InputStreamReader(HopVfs.getInputStream(inputFilename, variables)),
               resolve(meta.getTokenStartString()),
               resolve(meta.getTokenEndString()));
 
@@ -194,7 +194,7 @@ public class TokenReplacement extends BaseTransform<TokenReplacementMeta, TokenR
         ResultFile resultFile =
             new ResultFile(
                 ResultFile.FILE_TYPE_GENERAL,
-                HopVfs.getFileObject(inputFilename),
+                HopVfs.getFileObject(inputFilename, variables),
                 getTransformMeta().getName(),
                 getTransformName());
         resultFile.setComment(BaseMessages.getString(PKG, "TokenReplacement.AddInputResultFile"));
@@ -315,9 +315,10 @@ public class TokenReplacement extends BaseTransform<TokenReplacementMeta, TokenR
       }
     }
 
-    boolean fileExists = HopVfs.fileExists(filename);
+    boolean fileExists = HopVfs.fileExists(filename, variables);
 
-    OutputStream writer = HopVfs.getOutputStream(filename, meta.isAppendOutputFileName());
+    OutputStream writer =
+        HopVfs.getOutputStream(filename, meta.isAppendOutputFileName(), variables);
     OutputStream bufferedWriter = new BufferedOutputStream(writer, 5000);
 
     try {
@@ -343,7 +344,7 @@ public class TokenReplacement extends BaseTransform<TokenReplacementMeta, TokenR
           ResultFile resultFile =
               new ResultFile(
                   ResultFile.FILE_TYPE_GENERAL,
-                  HopVfs.getFileObject(itFilename.next()),
+                  HopVfs.getFileObject(itFilename.next(), variables),
                   getTransformMeta().getName(),
                   getTransformName());
           resultFile.setComment(
@@ -380,7 +381,7 @@ public class TokenReplacement extends BaseTransform<TokenReplacementMeta, TokenR
     FileObject parentfolder = null;
     try {
       // Get parent folder
-      parentfolder = HopVfs.getFileObject(filename).getParent();
+      parentfolder = HopVfs.getFileObject(filename, variables).getParent();
       if (parentfolder.exists()) {
         if (isDetailed()) {
           logDetailed(

--- a/plugins/transforms/workflowexecutor/src/main/java/org/apache/hop/pipeline/transforms/workflowexecutor/WorkflowExecutorDialog.java
+++ b/plugins/transforms/workflowexecutor/src/main/java/org/apache/hop/pipeline/transforms/workflowexecutor/WorkflowExecutorDialog.java
@@ -298,7 +298,7 @@ public class WorkflowExecutorDialog extends BaseTransformDialog {
     String parentFolder = null;
     try {
       parentFolder =
-          HopVfs.getFileObject(variables.resolve(pipelineMeta.getFilename()))
+          HopVfs.getFileObject(variables.resolve(pipelineMeta.getFilename()), variables)
               .getParent()
               .toString();
     } catch (Exception e) {

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/getxmldata/GetXmlData.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/getxmldata/GetXmlData.java
@@ -165,8 +165,8 @@ public class GetXmlData extends BaseTransform<GetXmlDataMeta, GetXmlDataData> {
       if (isInXMLField) {
         // read string to parse
         data.document = reader.read(new StringReader(stringXML));
-      } else if (readurl && HopVfs.startsWithScheme(stringXML)) {
-        data.document = reader.read(HopVfs.getInputStream(stringXML));
+      } else if (readurl && HopVfs.startsWithScheme(stringXML, variables)) {
+        data.document = reader.read(HopVfs.getInputStream(stringXML, variables));
       } else if (readurl) {
         // read url as source
         HttpClient client = HttpClientManager.getInstance().createDefaultClient();
@@ -415,7 +415,7 @@ public class GetXmlData extends BaseTransform<GetXmlDataMeta, GetXmlDataData> {
           FileObject file = null;
           try {
             // XML source is a file.
-            file = HopVfs.getFileObject(resolve(fieldvalue));
+            file = HopVfs.getFileObject(resolve(fieldvalue), variables);
 
             if (meta.isIgnoreEmptyFile() && file.getContent().getSize() == 0) {
               logBasic(

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/getxmldata/GetXmlDataDialog.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/getxmldata/GetXmlDataDialog.java
@@ -2219,7 +2219,7 @@ public class GetXmlDataDialog extends BaseTransformDialog {
       return;
     }
     String[] listXpath;
-    listXpath = pd.open();
+    listXpath = pd.open(variables);
     if (listXpath != null) {
       EnterSelectionDialog s =
           new EnterSelectionDialog(
@@ -2248,7 +2248,7 @@ public class GetXmlDataDialog extends BaseTransformDialog {
     RowMetaAndData[] fields = null;
 
     if (prd != null) {
-      fields = prd.open();
+      fields = prd.open(variables);
       if (fields != null) {
         if (clearFields == SWT.YES) {
           wFields.clearAll(false);

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/getxmldata/LoopNodesImportProgressDialog.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/getxmldata/LoopNodesImportProgressDialog.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.apache.hop.core.IProgressMonitor;
 import org.apache.hop.core.IRunnableWithProgress;
 import org.apache.hop.core.util.Utils;
+import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.core.vfs.HopVfs;
 import org.apache.hop.i18n.BaseMessages;
 import org.apache.hop.pipeline.transforms.xml.Dom4JUtil;
@@ -87,11 +88,11 @@ public class LoopNodesImportProgressDialog {
     this.nr = 0;
   }
 
-  public String[] open() {
+  public String[] open(IVariables variables) {
     IRunnableWithProgress op =
         monitor -> {
           try {
-            xpaths = doScan(monitor);
+            xpaths = doScan(monitor, variables);
           } catch (Exception e) {
             e.printStackTrace();
             throw new InvocationTargetException(
@@ -128,7 +129,7 @@ public class LoopNodesImportProgressDialog {
     return xpaths;
   }
 
-  private String[] doScan(IProgressMonitor monitor) throws Exception {
+  private String[] doScan(IProgressMonitor monitor, IVariables variables) throws Exception {
     monitor.beginTask(
         BaseMessages.getString(
             PKG, "GetXMLDateLoopNodesImportProgressDialog.Task.ScanningFile", filename),
@@ -158,7 +159,7 @@ public class LoopNodesImportProgressDialog {
     try {
       Document document = null;
       if (!Utils.isEmpty(filename)) {
-        is = HopVfs.getInputStream(filename);
+        is = HopVfs.getInputStream(filename, variables);
         document = reader.read(is, encoding);
       } else {
         if (!Utils.isEmpty(xml)) {

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/getxmldata/XmlInputFieldsImportProgressDialog.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/getxmldata/XmlInputFieldsImportProgressDialog.java
@@ -30,6 +30,7 @@ import org.apache.hop.core.IRunnableWithProgress;
 import org.apache.hop.core.RowMetaAndData;
 import org.apache.hop.core.row.IValueMeta;
 import org.apache.hop.core.util.Utils;
+import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.core.vfs.HopVfs;
 import org.apache.hop.i18n.BaseMessages;
 import org.apache.hop.pipeline.transforms.xml.Dom4JUtil;
@@ -106,11 +107,11 @@ public class XmlInputFieldsImportProgressDialog {
     this.fields = null;
   }
 
-  public RowMetaAndData[] open() {
+  public RowMetaAndData[] open(IVariables variables) {
     IRunnableWithProgress op =
         monitor -> {
           try {
-            fields = doScan(monitor);
+            fields = doScan(monitor, variables);
           } catch (Exception e) {
             e.printStackTrace();
             throw new InvocationTargetException(
@@ -139,7 +140,7 @@ public class XmlInputFieldsImportProgressDialog {
     return fields;
   }
 
-  private RowMetaAndData[] doScan(IProgressMonitor monitor) throws Exception {
+  private RowMetaAndData[] doScan(IProgressMonitor monitor, IVariables variables) throws Exception {
     monitor.beginTask(
         BaseMessages.getString(
             PKG, "GetXMLDateLoopNodesImportProgressDialog.Task.ScanningFile", filename),
@@ -170,7 +171,7 @@ public class XmlInputFieldsImportProgressDialog {
 
       Document document = null;
       if (!Utils.isEmpty(filename)) {
-        is = HopVfs.getInputStream(filename);
+        is = HopVfs.getInputStream(filename, variables);
         document = reader.read(is, encoding);
       } else {
         if (!Utils.isEmpty(xml)) {

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xmlinputstream/XmlInputStream.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xmlinputstream/XmlInputStream.java
@@ -187,7 +187,7 @@ public class XmlInputStream extends BaseTransform<XmlInputStreamMeta, XmlInputSt
       if (data.filenr >= data.filenames.length) {
         return false;
       }
-      data.fileObject = HopVfs.getFileObject(data.filenames[data.filenr]);
+      data.fileObject = HopVfs.getFileObject(data.filenames[data.filenr], variables);
       data.inputStream = HopVfs.getInputStream(data.fileObject);
       data.xmlEventReader = data.staxInstance.createXMLEventReader(data.inputStream, data.encoding);
     } catch (IOException e) {

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xmloutput/XmlOutput.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xmloutput/XmlOutput.java
@@ -264,7 +264,7 @@ public class XmlOutput extends BaseTransform<XmlOutputMeta, XmlOutputData> {
 
     try {
 
-      FileObject file = HopVfs.getFileObject(buildFilename(true));
+      FileObject file = HopVfs.getFileObject(buildFilename(true), variables);
 
       if (meta.isAddToResultFiles()) {
         // Add this to the result file names...

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xmloutput/XmlOutputMeta.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xmloutput/XmlOutputMeta.java
@@ -749,7 +749,7 @@ public class XmlOutputMeta extends BaseTransformMeta<XmlOutput, XmlOutputData> {
       // So let's change the filename from relative to absolute by grabbing the file object...
       //
       if (!Utils.isEmpty(fileName)) {
-        FileObject fileObject = HopVfs.getFileObject(variables.resolve(fileName));
+        FileObject fileObject = HopVfs.getFileObject(variables.resolve(fileName), variables);
         fileName = resourceNamingInterface.nameResource(fileObject, variables, true);
       }
 

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xsdvalidator/XsdValidator.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xsdvalidator/XsdValidator.java
@@ -128,7 +128,7 @@ public class XsdValidator extends BaseTransform<XsdValidatorMeta, XsdValidatorDa
 
       // Get XSD file
       FileObject xsdfile =
-          StringUtils.isNotEmpty(xsdfilename) ? HopVfs.getFileObject(xsdfilename) : null;
+          StringUtils.isNotEmpty(xsdfilename) ? HopVfs.getFileObject(xsdfilename, variables) : null;
 
       try {
 
@@ -315,7 +315,7 @@ public class XsdValidator extends BaseTransform<XsdValidatorMeta, XsdValidatorDa
       // Is XSD file exists ?
       FileObject xsdfile = null;
       try {
-        xsdfile = HopVfs.getFileObject(resolve(meta.getXSDFilename()));
+        xsdfile = HopVfs.getFileObject(resolve(meta.getXSDFilename()), variables);
         if (!xsdfile.exists()) {
           logError(BaseMessages.getString(PKG, "XsdValidator.Log.Error.XSDFileNotExists"));
           throw new HopTransformException(
@@ -346,7 +346,7 @@ public class XsdValidator extends BaseTransform<XsdValidatorMeta, XsdValidatorDa
 
       // We deal with XML file
       // Get XML File
-      FileObject xmlfileValidator = HopVfs.getFileObject(xmlFieldvalue);
+      FileObject xmlfileValidator = HopVfs.getFileObject(xmlFieldvalue, variables);
       if (xmlfileValidator == null || !xmlfileValidator.exists()) {
         logError(
             BaseMessages.getString(PKG, "XsdValidator.Log.Error.XMLfileMissing", xmlFieldvalue));

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xsdvalidator/XsdValidatorMeta.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xsdvalidator/XsdValidatorMeta.java
@@ -427,7 +427,7 @@ public class XsdValidatorMeta extends BaseTransformMeta<XsdValidator, XsdValidat
       // To : /home/matt/test/files/foo/bar.xsd
       //
       if (!Utils.isEmpty(xsdFilename)) {
-        FileObject fileObject = HopVfs.getFileObject(variables.resolve(xsdFilename));
+        FileObject fileObject = HopVfs.getFileObject(variables.resolve(xsdFilename), variables);
         xsdFilename = resourceNamingInterface.nameResource(fileObject, variables, true);
         return xsdFilename;
       }

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xslt/Xslt.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xslt/Xslt.java
@@ -138,7 +138,7 @@ public class Xslt extends BaseTransform<XsltMeta, XsltData> {
         data.xslfilename = resolve(meta.getXslFilename());
         FileObject file = null;
         try {
-          file = HopVfs.getFileObject(data.xslfilename);
+          file = HopVfs.getFileObject(data.xslfilename, variables);
           if (!file.exists()) {
             logError(
                 BaseMessages.getString(PKG, "Xslt.Log.ErrorXSLFileNotExists", data.xslfilename));
@@ -230,7 +230,7 @@ public class Xslt extends BaseTransform<XsltMeta, XsltData> {
       }
 
       // Get the template from the cache
-      Transformer transformer = data.getTemplate(data.xslfilename, data.xslIsAfile);
+      Transformer transformer = data.getTemplate(data.xslfilename, data.xslIsAfile, variables);
 
       // Do we need to set output properties?
       if (data.setOutputProperties) {

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xslt/XsltData.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xslt/XsltData.java
@@ -26,6 +26,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamSource;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.hop.core.row.IRowMeta;
+import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.core.vfs.HopVfs;
 import org.apache.hop.pipeline.transform.BaseTransformData;
 import org.apache.hop.pipeline.transform.ITransformData;
@@ -62,23 +63,25 @@ public class XsltData extends BaseTransformData implements ITransformData {
     setOutputProperties = false;
   }
 
-  public Transformer getTemplate(String xslFilename, boolean isAfile) throws Exception {
+  public Transformer getTemplate(String xslFilename, boolean isAfile, IVariables variables)
+      throws Exception {
     Transformer template = transformers.get(xslFilename);
     if (template != null) {
       template.clearParameters();
       return template;
     }
 
-    return createNewTemplate(xslFilename, isAfile);
+    return createNewTemplate(xslFilename, isAfile, variables);
   }
 
-  private Transformer createNewTemplate(String xslSource, boolean isAfile) throws Exception {
+  private Transformer createNewTemplate(String xslSource, boolean isAfile, IVariables variables)
+      throws Exception {
     FileObject file = null;
     InputStream xslInputStream = null;
     Transformer transformer = null;
     try {
       if (isAfile) {
-        file = HopVfs.getFileObject(xslSource);
+        file = HopVfs.getFileObject(xslSource, variables);
         xslInputStream = HopVfs.getInputStream(file);
       } else {
         xslInputStream = new ByteArrayInputStream(xslSource.getBytes("UTF-8"));

--- a/plugins/transforms/xml/src/test/java/org/apache/hop/pipeline/transforms/xml/xsdvalidator/XsdValidatorIntTest.java
+++ b/plugins/transforms/xml/src/test/java/org/apache/hop/pipeline/transforms/xml/xsdvalidator/XsdValidatorIntTest.java
@@ -36,6 +36,7 @@ import org.apache.hop.core.row.IRowMeta;
 import org.apache.hop.core.row.IValueMeta;
 import org.apache.hop.core.row.RowMeta;
 import org.apache.hop.core.row.value.ValueMetaString;
+import org.apache.hop.core.variables.Variables;
 import org.apache.hop.core.vfs.HopVfs;
 import org.apache.hop.pipeline.PipelineMeta;
 import org.apache.hop.pipeline.transforms.xml.PipelineTestFactory;
@@ -129,7 +130,7 @@ public class XsdValidatorIntTest {
   private FileObject loadRamFile(String filename) throws Exception {
     String targetUrl = RAMDIR + "/" + filename;
     try (InputStream source = getFileInputStream(filename)) {
-      FileObject fileObject = HopVfs.getFileObject(targetUrl);
+      FileObject fileObject = HopVfs.getFileObject(targetUrl, new Variables());
       try (OutputStream targetStream = fileObject.getContent().getOutputStream()) {
         copy(source, targetStream, -1);
       }
@@ -141,8 +142,8 @@ public class XsdValidatorIntTest {
       throws Exception {
     assertNotNull(dataFilename);
     assertNotNull(schemaFilename);
-    assertTrue(HopVfs.getFileObject(dataFilename).exists());
-    assertTrue(HopVfs.getFileObject(schemaFilename).exists());
+    assertTrue(HopVfs.getFileObject(dataFilename, new Variables()).exists());
+    assertTrue(HopVfs.getFileObject(schemaFilename, new Variables()).exists());
 
     IRowMeta inputRowMeta = new RowMeta();
     inputRowMeta.addValueMeta(new ValueMetaString("DataFile"));

--- a/plugins/transforms/yamlinput/src/main/java/org/apache/hop/pipeline/transforms/yamlinput/YamlInput.java
+++ b/plugins/transforms/yamlinput/src/main/java/org/apache/hop/pipeline/transforms/yamlinput/YamlInput.java
@@ -132,7 +132,7 @@ public class YamlInput extends BaseTransform<YamlInputMeta, YamlInputData> {
         // source is a file.
 
         data.yaml = new YamlReader();
-        data.yaml.loadFile(HopVfs.getFileObject(fieldvalue));
+        data.yaml.loadFile(HopVfs.getFileObject(fieldvalue, variables));
 
         addFileToResultFilesname(data.yaml.getFile());
 

--- a/plugins/transforms/yamlinput/src/main/java/org/apache/hop/pipeline/transforms/yamlinput/YamlReader.java
+++ b/plugins/transforms/yamlinput/src/main/java/org/apache/hop/pipeline/transforms/yamlinput/YamlReader.java
@@ -36,6 +36,7 @@ import org.apache.hop.core.row.RowMeta;
 import org.apache.hop.core.row.value.ValueMetaFactory;
 import org.apache.hop.core.row.value.ValueMetaNone;
 import org.apache.hop.core.util.Utils;
+import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.core.vfs.HopVfs;
 import org.yaml.snakeyaml.Yaml;
 
@@ -82,12 +83,6 @@ public class YamlReader {
   public void loadFile(FileObject file) throws Exception {
     this.file = file;
     this.filename = HopVfs.getFilename(file);
-    loadFile(filename);
-  }
-
-  public void loadFile(String filename) throws Exception {
-    this.filename = filename;
-    this.file = HopVfs.getFileObject(filename);
 
     InputStream is = null;
     try {
@@ -105,6 +100,13 @@ public class YamlReader {
         is.close();
       }
     }
+  }
+
+  public void loadFile(String filename, IVariables variables) throws Exception {
+    this.filename = filename;
+    this.file = HopVfs.getFileObject(filename, variables);
+
+    loadFile(this.file);
   }
 
   private Yaml getYaml() {

--- a/plugins/transforms/zipfile/src/main/java/org/apache/hop/pipeline/transforms/zipfile/ZipFile.java
+++ b/plugins/transforms/zipfile/src/main/java/org/apache/hop/pipeline/transforms/zipfile/ZipFile.java
@@ -144,7 +144,7 @@ public class ZipFile extends BaseTransform<ZipFileMeta, ZipFileData> {
         log.logError(toString(), BaseMessages.getString(PKG, "ZipFile.Error.SourceFileEmpty"));
         throw new HopException(BaseMessages.getString(PKG, "ZipFile.Error.SourceFileEmpty"));
       }
-      data.sourceFile = HopVfs.getFileObject(sourceFilename);
+      data.sourceFile = HopVfs.getFileObject(sourceFilename, variables);
 
       // Check sourcefile
       boolean skip = false;
@@ -186,7 +186,7 @@ public class ZipFile extends BaseTransform<ZipFileMeta, ZipFileData> {
           log.logError(toString(), BaseMessages.getString(PKG, "ZipFile.Error.TargetFileEmpty"));
           throw new HopException(BaseMessages.getString(PKG, "ZipFile.Error.TargetFileEmpty"));
         }
-        data.zipFile = HopVfs.getFileObject(targetFilename);
+        data.zipFile = HopVfs.getFileObject(targetFilename, variables);
         if (data.zipFile.exists()) {
           if (log.isDetailed()) {
             log.logDetailed(
@@ -268,7 +268,7 @@ public class ZipFile extends BaseTransform<ZipFileMeta, ZipFileData> {
         FileObject moveToFolder = null;
         try {
           // Move to folder
-          moveToFolder = HopVfs.getFileObject(folder);
+          moveToFolder = HopVfs.getFileObject(folder, variables);
 
           if (moveToFolder.exists()) {
             if (moveToFolder.getType() != FileType.FOLDER) {
@@ -284,7 +284,7 @@ public class ZipFile extends BaseTransform<ZipFileMeta, ZipFileData> {
               HopVfs.getFilename(moveToFolder)
                   + Const.FILE_SEPARATOR
                   + data.sourceFile.getName().getBaseName();
-          file = HopVfs.getFileObject(targetfilename);
+          file = HopVfs.getFileObject(targetfilename, variables);
 
           // Move file
           data.sourceFile.moveTo(file);
@@ -378,7 +378,7 @@ public class ZipFile extends BaseTransform<ZipFileMeta, ZipFileData> {
 
       // Prepare Zip File
       buffer = new byte[18024];
-      dest = HopVfs.getOutputStream(localrealZipfilename, false);
+      dest = HopVfs.getOutputStream(localrealZipfilename, false, variables);
       buff = new BufferedOutputStream(dest);
       out = new ZipOutputStream(buff);
 

--- a/ui/src/main/java/org/apache/hop/ui/core/vfs/HopVfsFileDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/vfs/HopVfsFileDialog.java
@@ -650,7 +650,7 @@ public class HopVfsFileDialog implements IFileDialog, IDirectoryDialog {
 
   private void okButton() {
     try {
-      activeFileObject = HopVfs.getFileObject(wFilename.getText());
+      activeFileObject = HopVfs.getFileObject(wFilename.getText(), variables);
 
       if (!this.browsingDirectories && activeFileObject.isFolder()) {
         navigateTo(HopVfs.getFilename(activeFileObject), true);
@@ -669,7 +669,7 @@ public class HopVfsFileDialog implements IFileDialog, IDirectoryDialog {
   private void enteredFilenameOrFolder() {
     if (StringUtils.isNotEmpty(saveFilename)) {
       try {
-        FileObject fullObject = HopVfs.getFileObject(wFilename.getText());
+        FileObject fullObject = HopVfs.getFileObject(wFilename.getText(), variables);
         if (!fullObject.isFolder()) {
           // We're saving a filename and now if we hit enter we want this to select the file and
           // close the dialog
@@ -876,7 +876,7 @@ public class HopVfsFileDialog implements IFileDialog, IDirectoryDialog {
     // Browse to the selected file location...
     //
     try {
-      activeFileObject = HopVfs.getFileObject(filename);
+      activeFileObject = HopVfs.getFileObject(filename, variables);
       if (activeFileObject.isFolder()) {
         activeFolder = activeFileObject;
       } else {
@@ -1224,7 +1224,7 @@ public class HopVfsFileDialog implements IFileDialog, IDirectoryDialog {
         String oldFull = wFilename.getText();
         if (StringUtils.isNotEmpty(oldFull)) {
           try {
-            FileObject oldFullObject = HopVfs.getFileObject(oldFull);
+            FileObject oldFullObject = HopVfs.getFileObject(oldFull, variables);
             if (!oldFullObject.isFolder()) {
               saveFilename = oldFullObject.getName().getBaseName();
             }
@@ -1284,7 +1284,7 @@ public class HopVfsFileDialog implements IFileDialog, IDirectoryDialog {
       image = "ui/images/navigate-up.svg")
   public void navigateUp() {
     try {
-      FileObject fileObject = HopVfs.getFileObject(wFilename.getText());
+      FileObject fileObject = HopVfs.getFileObject(wFilename.getText(), variables);
       if (fileObject.isFile()) {
         fileObject = fileObject.getParent();
       }
@@ -1321,7 +1321,7 @@ public class HopVfsFileDialog implements IFileDialog, IDirectoryDialog {
       }
       newPath += folder;
       try {
-        FileObject newFolder = HopVfs.getFileObject(newPath);
+        FileObject newFolder = HopVfs.getFileObject(newPath, variables);
         newFolder.createFolder();
         refreshBrowser();
       } catch (Throwable e) {
@@ -1365,7 +1365,7 @@ public class HopVfsFileDialog implements IFileDialog, IDirectoryDialog {
 
                     FileObject newFile =
                         HopVfs.getFileObject(
-                            HopVfs.getFilename(file.getParent()) + "/" + text.getText());
+                            HopVfs.getFilename(file.getParent()) + "/" + text.getText(), variables);
                     file.moveTo(newFile);
                   } catch (Exception e) {
                     showError(
@@ -1490,7 +1490,7 @@ public class HopVfsFileDialog implements IFileDialog, IDirectoryDialog {
     //
     boolean canGoUp;
     try {
-      FileObject fileObject = HopVfs.getFileObject(wFilename.getText());
+      FileObject fileObject = HopVfs.getFileObject(wFilename.getText(), variables);
       if (fileObject.isFile()) {
         canGoUp = fileObject.getParent().getParent() != null;
       } else {

--- a/ui/src/main/java/org/apache/hop/ui/pipeline/transform/BaseTransformDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/pipeline/transform/BaseTransformDialog.java
@@ -1290,7 +1290,8 @@ public abstract class BaseTransformDialog extends Dialog implements ITransformDi
     int answer = box.open();
     if ((answer & SWT.YES) != 0) {
       try {
-        String baseName = HopVfs.getFileObject(variables.resolve(filename)).getName().getBaseName();
+        String baseName =
+            HopVfs.getFileObject(variables.resolve(filename), variables).getName().getBaseName();
         wTransformName.setText(baseName);
       } catch (Exception e) {
         new ErrorDialog(


### PR DESCRIPTION
This PR adds multi account support to VFS. You can dynamically add new schema's which are tied to a specific configuration.
![image](https://github.com/apache/hop/assets/1140235/f52fd4f2-c3f7-456c-88e5-16260c1b7343)

This example will create a storage2:// prefix which is linked to storage account knowbistorage2
Following components already support reading/writing to these new prefixes:

File browser/dialog
Transforms:
- list file name
- text file input
- text file output
- parquet output
- avro output
- PGP decrypt stream
- PGP encrypt stream

Actions:
- file exists
- files exists
- Copy files
- Delete File
- Delete Files
- Check if folder is empty
- Create folder
- Create file
- compare folders
- file compare
- evaluate file metrics
- zip file
- unzip file
- write to file
- check files locked
- Decrypt files with PGP
- Encrypt fileswith PGP
- Verify file signature with PGP

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [ ] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [ ] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
