### PR TITLE
First round of optimisation about getFileNames()

### DIFF
--- a/integration-tests/azure/0002-read_parquet_from_azure_azure_scheme.hpl
+++ b/integration-tests/azure/0002-read_parquet_from_azure_azure_scheme.hpl
@@ -44,7 +44,7 @@ limitations under the License.
       <enabled>Y</enabled>
     </hop>
     <hop>
-      <from>Generate rows Azurite (azfs scheme)</from>
+      <from>Generate rows Azurite (azure scheme)</from>
       <to>Parquet File Input</to>
       <enabled>Y</enabled>
     </hop>
@@ -67,7 +67,7 @@ limitations under the License.
     </GUI>
   </transform>
   <transform>
-    <name>Generate rows Azurite (azfs scheme)</name>
+    <name>Generate rows Azurite (azure scheme)</name>
     <type>RowGenerator</type>
     <description/>
     <distribute>Y</distribute>
@@ -79,9 +79,13 @@ limitations under the License.
     </partitioning>
     <fields>
       <field>
+        <currency/>
+        <decimal/>
+        <format/>
+        <group/>
         <length>-1</length>
         <name>filename</name>
-        <nullif>azfs://devstoreaccount1/mycontainer/azfs-scheme.parquet</nullif>
+        <nullif>azure:///mycontainer/azure-scheme.parquet</nullif>
         <precision>-1</precision>
         <set_empty_string>N</set_empty_string>
         <type>String</type>

--- a/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/AzureFileObject.java
+++ b/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/AzureFileObject.java
@@ -204,6 +204,14 @@ public class AzureFileObject extends AbstractFileObject<AzureFileSystem> {
     }
   }
 
+  @Override
+  public FileType getType() throws FileSystemException {
+    if (type == null) {
+      type = super.getType();
+    }
+    return type;
+  }
+
   private boolean pathsMatch(String path, String currentPath) {
     return path.replace("/" + ((AzureFileSystem) getFileSystem()).getAccount(), "")
         .equals(currentPath);
@@ -234,11 +242,12 @@ public class AzureFileObject extends AbstractFileObject<AzureFileSystem> {
   }
 
   public boolean canRenameTo(FileObject newfile) {
-    throw new UnsupportedOperationException();
+    return true;
   }
 
   @Override
   protected void doDelete() throws Exception {
+    doAttach();
     if (container == null) {
       throw new UnsupportedOperationException();
     } else {
@@ -354,7 +363,7 @@ public class AzureFileObject extends AbstractFileObject<AzureFileSystem> {
   }
 
   @Override
-  protected FileType doGetType() throws Exception {
+  protected FileType doGetType() {
     return type;
   }
 


### PR DESCRIPTION
Fix #4065. Or, at least, this is a first round of performance optimisations.

We are now preventing to invoke the parent method of `AzureFileObject.getType()` multiple times, namely when the getType() method is invoked. This will prevent to pass through the `synchronized` block in the `AbstractFileObject.getType()` method.

Moreover, there are small fixes for:

- Action Move Files
- Action Delete Files

without such fixes, integration tests were not passing

Next round should happen once the migration to the new Azure Storage library has been completed.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
