### PR TITLE
Deprecate ActionBase.getUsedDatabaseConnections method #2041

### DIFF
--- a/engine/src/main/java/org/apache/hop/workflow/action/ActionBase.java
+++ b/engine/src/main/java/org/apache/hop/workflow/action/ActionBase.java
@@ -476,9 +476,8 @@ public abstract class ActionBase
   }
 
   /**
-   * Gets all the database connections that are used by the action. For ActionBase, this method
-   * returns an empty (non-null) array
-   *
+   * @deprecated Gets all the database connections that are used by the action. For ActionBase, this
+   *     method returns an empty (non-null) array
    * @return an empty (non-null) array
    */
   @Deprecated(since = "2.10")

--- a/engine/src/main/java/org/apache/hop/workflow/action/ActionBase.java
+++ b/engine/src/main/java/org/apache/hop/workflow/action/ActionBase.java
@@ -481,6 +481,7 @@ public abstract class ActionBase
    *
    * @return an empty (non-null) array
    */
+  @Deprecated(since = "2.10")
   public DatabaseMeta[] getUsedDatabaseConnections() {
     return new DatabaseMeta[] {};
   }

--- a/plugins/actions/checkdbconnection/src/main/java/org/apache/hop/workflow/actions/checkdbconnection/ActionCheckDbConnections.java
+++ b/plugins/actions/checkdbconnection/src/main/java/org/apache/hop/workflow/actions/checkdbconnection/ActionCheckDbConnections.java
@@ -196,17 +196,6 @@ public class ActionCheckDbConnections extends ActionBase implements Cloneable, I
   }
 
   @Override
-  public DatabaseMeta[] getUsedDatabaseConnections() {
-    List<DatabaseMeta> used = new ArrayList<>();
-    for (CDConnection connection : connections) {
-      if (connection.getDatabaseMeta() != null) {
-        used.add(connection.getDatabaseMeta());
-      }
-    }
-    return used.toArray(new DatabaseMeta[0]);
-  }
-
-  @Override
   public List<ResourceReference> getResourceDependencies(
       IVariables variables, WorkflowMeta workflowMeta) {
     List<ResourceReference> references = super.getResourceDependencies(variables, workflowMeta);

--- a/plugins/actions/columnsexist/src/main/java/org/apache/hop/workflow/actions/columnsexist/ActionColumnsExist.java
+++ b/plugins/actions/columnsexist/src/main/java/org/apache/hop/workflow/actions/columnsexist/ActionColumnsExist.java
@@ -227,13 +227,6 @@ public class ActionColumnsExist extends ActionBase implements Cloneable, IAction
   }
 
   @Override
-  public DatabaseMeta[] getUsedDatabaseConnections() {
-    return new DatabaseMeta[] {
-      databaseMeta,
-    };
-  }
-
-  @Override
   public List<ResourceReference> getResourceDependencies(
       IVariables variables, WorkflowMeta workflowMeta) {
     List<ResourceReference> references = super.getResourceDependencies(variables, workflowMeta);

--- a/plugins/actions/evaluatetablecontent/src/main/java/org/apache/hop/workflow/actions/evaluatetablecontent/ActionEvalTableContent.java
+++ b/plugins/actions/evaluatetablecontent/src/main/java/org/apache/hop/workflow/actions/evaluatetablecontent/ActionEvalTableContent.java
@@ -406,13 +406,6 @@ public class ActionEvalTableContent extends ActionBase implements Cloneable, IAc
   }
 
   @Override
-  public DatabaseMeta[] getUsedDatabaseConnections() {
-    return new DatabaseMeta[] {
-      connection,
-    };
-  }
-
-  @Override
   public List<ResourceReference> getResourceDependencies(
       IVariables variables, WorkflowMeta workflowMeta) {
     List<ResourceReference> references = super.getResourceDependencies(variables, workflowMeta);

--- a/plugins/actions/mssqlbulkload/src/main/java/org/apache/hop/workflow/actions/mssqlbulkload/ActionMssqlBulkLoad.java
+++ b/plugins/actions/mssqlbulkload/src/main/java/org/apache/hop/workflow/actions/mssqlbulkload/ActionMssqlBulkLoad.java
@@ -559,13 +559,6 @@ public class ActionMssqlBulkLoad extends ActionBase implements Cloneable, IActio
     return result;
   }
 
-  @Override
-  public DatabaseMeta[] getUsedDatabaseConnections() {
-    return new DatabaseMeta[] {
-      connection,
-    };
-  }
-
   public void setFilename(String filename) {
     this.filename = filename;
   }

--- a/plugins/actions/mysqlbulkfile/src/main/java/org/apache/hop/workflow/actions/mysqlbulkfile/ActionMysqlBulkFile.java
+++ b/plugins/actions/mysqlbulkfile/src/main/java/org/apache/hop/workflow/actions/mysqlbulkfile/ActionMysqlBulkFile.java
@@ -424,13 +424,6 @@ public class ActionMysqlBulkFile extends ActionBase implements Cloneable, IActio
     return result;
   }
 
-  @Override
-  public DatabaseMeta[] getUsedDatabaseConnections() {
-    return new DatabaseMeta[] {
-      connection,
-    };
-  }
-
   public void setHighPriority(boolean highpriority) {
     this.highPriority = highpriority;
   }

--- a/plugins/actions/mysqlbulkload/src/main/java/org/apache/hop/workflow/actions/mysqlbulkload/ActionMysqlBulkLoad.java
+++ b/plugins/actions/mysqlbulkload/src/main/java/org/apache/hop/workflow/actions/mysqlbulkload/ActionMysqlBulkLoad.java
@@ -431,13 +431,6 @@ public class ActionMysqlBulkLoad extends ActionBase implements Cloneable, IActio
     return result;
   }
 
-  @Override
-  public DatabaseMeta[] getUsedDatabaseConnections() {
-    return new DatabaseMeta[] {
-      connection,
-    };
-  }
-
   public boolean isReplacedata() {
     return replacedata;
   }

--- a/plugins/actions/sql/src/main/java/org/apache/hop/workflow/actions/sql/ActionSql.java
+++ b/plugins/actions/sql/src/main/java/org/apache/hop/workflow/actions/sql/ActionSql.java
@@ -255,11 +255,6 @@ public class ActionSql extends ActionBase implements Cloneable, IAction {
   }
 
   @Override
-  public DatabaseMeta[] getUsedDatabaseConnections() {
-    return new DatabaseMeta[0];
-  }
-
-  @Override
   public List<ResourceReference> getResourceDependencies(
       IVariables variables, WorkflowMeta workflowMeta) {
     List<ResourceReference> references = super.getResourceDependencies(variables, workflowMeta);

--- a/plugins/actions/waitforsql/src/main/java/org/apache/hop/workflow/actions/waitforsql/ActionWaitForSql.java
+++ b/plugins/actions/waitforsql/src/main/java/org/apache/hop/workflow/actions/waitforsql/ActionWaitForSql.java
@@ -472,11 +472,6 @@ public class ActionWaitForSql extends ActionBase implements Cloneable, IAction {
   }
 
   @Override
-  public DatabaseMeta[] getUsedDatabaseConnections() {
-    return new DatabaseMeta[0];
-  }
-
-  @Override
   public List<ResourceReference> getResourceDependencies(
       IVariables variables, WorkflowMeta workflowMeta) {
     List<ResourceReference> references = super.getResourceDependencies(variables, workflowMeta);


### PR DESCRIPTION
Already remove existing internal use, but retain method until 3.0