### PR TITLE
Fix CLI commands on Linux and macOS when variables contain spaces and more ShellCheck fixes

### DIFF
--- a/assemblies/static/src/main/resources/hop-conf.sh
+++ b/assemblies/static/src/main/resources/hop-conf.sh
@@ -19,23 +19,24 @@
 #
 
 ORIGINDIR=$(pwd)
-BASEDIR=$(dirname $0)
-cd $BASEDIR
+BASEDIR=$(dirname "$0")
+cd "${BASEDIR}" || exit 1
 
 # set java primary is HOP_JAVA_HOME fallback to JAVA_HOME or default java
-if [ -n "$HOP_JAVA_HOME" ]; then
-  _HOP_JAVA=$HOP_JAVA_HOME/bin/java
-elif [ -n "$JAVA_HOME" ]; then
-  _HOP_JAVA=$JAVA_HOME/bin/java
+if [ -n "${HOP_JAVA_HOME}" ]; then
+  _HOP_JAVA="${HOP_JAVA_HOME}/bin/java"
+elif [ -n "${JAVA_HOME}" ]; then
+  _HOP_JAVA="${JAVA_HOME}/bin/java"
 else
   _HOP_JAVA="java"
 fi
 
 # Settings for all OSses
 #
-if [ -z "$HOP_OPTIONS" ]; then
+if [ -z "${HOP_OPTIONS}" ]; then
   HOP_OPTIONS="-Xmx2048m"
 fi
+
 # optional line for attaching a debugger
 #
 #HOP_OPTIONS="${HOP_OPTIONS} -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5009"
@@ -68,14 +69,14 @@ HOP_OPTIONS="${HOP_OPTIONS} --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED --
 
 case $(uname -s) in
 Linux)
-    if $($_HOP_JAVA -XshowSettings:properties -version 2>&1| grep -q "os.arch = aarch64"); then
+    if "${_HOP_JAVA}" -XshowSettings:properties -version 2>&1 | grep -q "os.arch = aarch64"; then
         CLASSPATH="lib/core/*:lib/beam/*:lib/swt/linux/arm64/*"
     else
         CLASSPATH="lib/core/*:lib/beam/*:lib/swt/linux/$(uname -m)/*"
     fi
   ;;
 Darwin)
-  if $($_HOP_JAVA -XshowSettings:properties -version 2>&1| grep -q "os.arch = aarch64"); then
+  if "${_HOP_JAVA}" -XshowSettings:properties -version 2>&1 | grep -q "os.arch = aarch64"; then
       CLASSPATH="lib/core/*:lib/beam/*:lib/swt/osx/arm64/*"
   else
       CLASSPATH="lib/core/*:lib/beam/*:lib/swt/osx/x86_64/*"
@@ -84,8 +85,8 @@ Darwin)
   ;;
 esac
 
-"$_HOP_JAVA" ${HOP_OPTIONS} -Djava.library.path=$LIBPATH -classpath "${CLASSPATH}" org.apache.hop.config.HopConfig "$@"
+"${_HOP_JAVA}" ${HOP_OPTIONS} -Djava.library.path="${LIBPATH}" -classpath "${CLASSPATH}" org.apache.hop.config.HopConfig "$@"
 EXITCODE=$?
 
-cd ${ORIGINDIR}
+cd "${ORIGINDIR}" || exit 1
 exit $EXITCODE

--- a/assemblies/static/src/main/resources/hop-gui.sh
+++ b/assemblies/static/src/main/resources/hop-gui.sh
@@ -19,28 +19,28 @@
 #
 
 ORIGINDIR=$(pwd)
-BASEDIR=$(dirname $0)
-cd $BASEDIR
+BASEDIR=$(dirname "$0")
+cd "${BASEDIR}" || exit 1
 
 # set java primary is HOP_JAVA_HOME fallback to JAVA_HOME or default java
-if [ -n "$HOP_JAVA_HOME" ]; then
-  _HOP_JAVA=$HOP_JAVA_HOME/bin/java
-elif [ -n "$JAVA_HOME" ]; then
-  _HOP_JAVA=$JAVA_HOME/bin/java
+if [ -n "${HOP_JAVA_HOME}" ]; then
+  _HOP_JAVA="${HOP_JAVA_HOME}/bin/java"
+elif [ -n "${JAVA_HOME}" ]; then
+  _HOP_JAVA="${JAVA_HOME}/bin/java"
 else
   _HOP_JAVA="java"
 fi
 
 # Settings for all OSses
 #
-if [ -z "$HOP_OPTIONS" ]; then
+if [ -z "${HOP_OPTIONS}" ]; then
   HOP_OPTIONS="-Xmx2048m"
 fi
 
 # optional line for attaching a debugger
 #
 if [ "$1" = "debug" ] || [ "$1" = "DEBUG" ]; then
- HOP_OPTIONS="${HOP_OPTIONS} -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005"
+  HOP_OPTIONS="${HOP_OPTIONS} -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005"
 fi
 
 # Add HOP variables if they're set:
@@ -71,14 +71,14 @@ HOP_OPTIONS="${HOP_OPTIONS} --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED --
 
 case $(uname -s) in
 Linux)
-    if $($_HOP_JAVA -XshowSettings:properties -version 2>&1| grep -q "os.arch = aarch64"); then
+    if "${_HOP_JAVA}" -XshowSettings:properties -version 2>&1 | grep -q "os.arch = aarch64"; then
         CLASSPATH="lib/core/*:lib/beam/*:lib/swt/linux/arm64/*"
     else
         CLASSPATH="lib/core/*:lib/beam/*:lib/swt/linux/$(uname -m)/*"
     fi
   ;;
 Darwin)
-  if $($_HOP_JAVA -XshowSettings:properties -version 2>&1| grep -q "os.arch = aarch64"); then
+  if "${_HOP_JAVA}" -XshowSettings:properties -version 2>&1 | grep -q "os.arch = aarch64"; then
       CLASSPATH="lib/core/*:lib/beam/*:lib/swt/osx/arm64/*"
   else
       CLASSPATH="lib/core/*:lib/beam/*:lib/swt/osx/x86_64/*"
@@ -87,8 +87,8 @@ Darwin)
   ;;
 esac
 
-"$_HOP_JAVA" ${HOP_OPTIONS} -Djava.library.path=$LIBPATH -classpath "${CLASSPATH}" org.apache.hop.ui.hopgui.HopGui $@
+"${_HOP_JAVA}" ${HOP_OPTIONS} -Djava.library.path="${LIBPATH}" -classpath "${CLASSPATH}" org.apache.hop.ui.hopgui.HopGui "$@"
 EXITCODE=$?
 
-cd ${ORIGINDIR}
+cd "${ORIGINDIR}" || exit 1
 exit $EXITCODE

--- a/assemblies/static/src/main/resources/hop-import.sh
+++ b/assemblies/static/src/main/resources/hop-import.sh
@@ -16,25 +16,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+#
 
 ORIGINDIR=$(pwd)
-BASEDIR=$(dirname $0)
-cd $BASEDIR
+BASEDIR=$(dirname "$0")
+cd "${BASEDIR}" || exit 1
 
 # set java primary is HOP_JAVA_HOME fallback to JAVA_HOME or default java
-if [ -n "$HOP_JAVA_HOME" ]; then
-  _HOP_JAVA=$HOP_JAVA_HOME/bin/java
-elif [ -n "$JAVA_HOME" ]; then
-  _HOP_JAVA=$JAVA_HOME/bin/java
+if [ -n "${HOP_JAVA_HOME}" ]; then
+  _HOP_JAVA="${HOP_JAVA_HOME}/bin/java"
+elif [ -n "${JAVA_HOME}" ]; then
+  _HOP_JAVA="${JAVA_HOME}/bin/java"
 else
   _HOP_JAVA="java"
 fi
 
 # Settings for all OSses
 #
-if [ -z "$HOP_OPTIONS" ]; then
+if [ -z "${HOP_OPTIONS}" ]; then
   HOP_OPTIONS="-Xmx2048m"
 fi
+
 # optional line for attaching a debugger
 #
 #HOP_OPTIONS="${HOP_OPTIONS} -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5009"
@@ -67,14 +69,14 @@ HOP_OPTIONS="${HOP_OPTIONS} --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED --
 
 case $(uname -s) in
 Linux)
-    if $($_HOP_JAVA -XshowSettings:properties -version 2>&1| grep -q "os.arch = aarch64"); then
+    if "${_HOP_JAVA}" -XshowSettings:properties -version 2>&1 | grep -q "os.arch = aarch64"; then
         CLASSPATH="lib/core/*:lib/beam/*:lib/swt/linux/arm64/*"
     else
         CLASSPATH="lib/core/*:lib/beam/*:lib/swt/linux/$(uname -m)/*"
     fi
   ;;
 Darwin)
-  if $($_HOP_JAVA -XshowSettings:properties -version 2>&1| grep -q "os.arch = aarch64"); then
+  if "${_HOP_JAVA}" -XshowSettings:properties -version 2>&1 | grep -q "os.arch = aarch64"; then
       CLASSPATH="lib/core/*:lib/beam/*:lib/swt/osx/arm64/*"
   else
       CLASSPATH="lib/core/*:lib/beam/*:lib/swt/osx/x86_64/*"
@@ -83,8 +85,8 @@ Darwin)
   ;;
 esac
 
-"$_HOP_JAVA" ${HOP_OPTIONS} -Djava.library.path=$LIBPATH -classpath "${CLASSPATH}" org.apache.hop.imp.HopImport "$@"
+"${_HOP_JAVA}" ${HOP_OPTIONS} -Djava.library.path="${LIBPATH}" -classpath "${CLASSPATH}" org.apache.hop.imp.HopImport "$@"
 EXITCODE=$?
 
-cd ${ORIGINDIR}
+cd "${ORIGINDIR}" || exit 1
 exit $EXITCODE

--- a/assemblies/static/src/main/resources/hop-run.sh
+++ b/assemblies/static/src/main/resources/hop-run.sh
@@ -19,23 +19,24 @@
 #
 
 ORIGINDIR=$(pwd)
-BASEDIR=$(dirname $0)
-cd $BASEDIR
+BASEDIR=$(dirname "$0")
+cd "${BASEDIR}" || exit 1
 
 # set java primary is HOP_JAVA_HOME fallback to JAVA_HOME or default java
-if [ -n "$HOP_JAVA_HOME" ]; then
-  _HOP_JAVA=$HOP_JAVA_HOME/bin/java
-elif [ -n "$JAVA_HOME" ]; then
-  _HOP_JAVA=$JAVA_HOME/bin/java
+if [ -n "${HOP_JAVA_HOME}" ]; then
+  _HOP_JAVA="${HOP_JAVA_HOME}/bin/java"
+elif [ -n "${JAVA_HOME}" ]; then
+  _HOP_JAVA="${JAVA_HOME}/bin/java"
 else
   _HOP_JAVA="java"
 fi
 
 # Settings for all OSses
 #
-if [ -z "$HOP_OPTIONS" ]; then
+if [ -z "${HOP_OPTIONS}" ]; then
   HOP_OPTIONS="-Xmx2048m"
 fi
+
 # optional line for attaching a debugger
 #
 #HOP_OPTIONS="${HOP_OPTIONS} -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5006"
@@ -68,14 +69,14 @@ HOP_OPTIONS="${HOP_OPTIONS} --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED --
 
 case $(uname -s) in
 Linux)
-    if $($_HOP_JAVA -XshowSettings:properties -version 2>&1| grep -q "os.arch = aarch64"); then
+    if "${_HOP_JAVA}" -XshowSettings:properties -version 2>&1 | grep -q "os.arch = aarch64"; then
         CLASSPATH="lib/core/*:lib/beam/*:lib/swt/linux/arm64/*"
     else
         CLASSPATH="lib/core/*:lib/beam/*:lib/swt/linux/$(uname -m)/*"
     fi
   ;;
 Darwin)
-  if $($_HOP_JAVA -XshowSettings:properties -version 2>&1| grep -q "os.arch = aarch64"); then
+  if "${_HOP_JAVA}" -XshowSettings:properties -version 2>&1 | grep -q "os.arch = aarch64"; then
       CLASSPATH="lib/core/*:lib/beam/*:lib/swt/osx/arm64/*"
   else
       CLASSPATH="lib/core/*:lib/beam/*:lib/swt/osx/x86_64/*"
@@ -84,8 +85,8 @@ Darwin)
   ;;
 esac
 
-"$_HOP_JAVA" ${HOP_OPTIONS} -Djava.library.path=$LIBPATH -classpath "${CLASSPATH}" org.apache.hop.run.HopRun "$@"
+"${_HOP_JAVA}" ${HOP_OPTIONS} -Djava.library.path="${LIBPATH}" -classpath "${CLASSPATH}" org.apache.hop.run.HopRun "$@"
 EXITCODE=$?
 
-cd ${ORIGINDIR}
+cd "${ORIGINDIR}" || exit 1
 exit $EXITCODE

--- a/assemblies/static/src/main/resources/hop-search.sh
+++ b/assemblies/static/src/main/resources/hop-search.sh
@@ -19,23 +19,24 @@
 #
 
 ORIGINDIR=$(pwd)
-BASEDIR=$(dirname $0)
-cd $BASEDIR
+BASEDIR=$(dirname "$0")
+cd "${BASEDIR}" || exit 1
 
 # set java primary is HOP_JAVA_HOME fallback to JAVA_HOME or default java
-if [ -n "$HOP_JAVA_HOME" ]; then
-  _HOP_JAVA=$HOP_JAVA_HOME/bin/java
-elif [ -n "$JAVA_HOME" ]; then
-  _HOP_JAVA=$JAVA_HOME/bin/java
+if [ -n "${HOP_JAVA_HOME}" ]; then
+  _HOP_JAVA="${HOP_JAVA_HOME}/bin/java"
+elif [ -n "${JAVA_HOME}" ]; then
+  _HOP_JAVA="${JAVA_HOME}/bin/java"
 else
   _HOP_JAVA="java"
 fi
 
 # Settings for all OSses
 #
-if [ -z "$HOP_OPTIONS" ]; then
+if [ -z "${HOP_OPTIONS}" ]; then
   HOP_OPTIONS="-Xmx2048m"
 fi
+
 # optional line for attaching a debugger
 #
 #HOP_OPTIONS="${HOP_OPTIONS} -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5009"
@@ -68,14 +69,14 @@ HOP_OPTIONS="${HOP_OPTIONS} --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED --
 
 case $(uname -s) in
 Linux)
-    if $($_HOP_JAVA -XshowSettings:properties -version 2>&1| grep -q "os.arch = aarch64"); then
+    if "${_HOP_JAVA}" -XshowSettings:properties -version 2>&1 | grep -q "os.arch = aarch64"; then
         CLASSPATH="lib/core/*:lib/beam/*:lib/swt/linux/arm64/*"
     else
         CLASSPATH="lib/core/*:lib/beam/*:lib/swt/linux/$(uname -m)/*"
     fi
   ;;
 Darwin)
-  if $($_HOP_JAVA -XshowSettings:properties -version 2>&1| grep -q "os.arch = aarch64"); then
+  if "${_HOP_JAVA}" -XshowSettings:properties -version 2>&1 | grep -q "os.arch = aarch64"; then
       CLASSPATH="lib/core/*:lib/beam/*:lib/swt/osx/arm64/*"
   else
       CLASSPATH="lib/core/*:lib/beam/*:lib/swt/osx/x86_64/*"
@@ -84,8 +85,8 @@ Darwin)
   ;;
 esac
 
-"$_HOP_JAVA" ${HOP_OPTIONS} -Djava.library.path=$LIBPATH -classpath "${CLASSPATH}" org.apache.hop.search.HopSearch "$@"
+"${_HOP_JAVA}" ${HOP_OPTIONS} -Djava.library.path="${LIBPATH}" -classpath "${CLASSPATH}" org.apache.hop.search.HopSearch "$@"
 EXITCODE=$?
 
-cd ${ORIGINDIR}
+cd "${ORIGINDIR}" || exit 1
 exit $EXITCODE

--- a/assemblies/static/src/main/resources/hop-server.sh
+++ b/assemblies/static/src/main/resources/hop-server.sh
@@ -19,23 +19,24 @@
 #
 
 ORIGINDIR=$(pwd)
-BASEDIR=$(dirname $0)
-cd $BASEDIR
+BASEDIR=$(dirname "$0")
+cd "${BASEDIR}" || exit 1
 
 # set java primary is HOP_JAVA_HOME fallback to JAVA_HOME or default java
-if [ -n "$HOP_JAVA_HOME" ]; then
-  _HOP_JAVA=$HOP_JAVA_HOME/bin/java
-elif [ -n "$JAVA_HOME" ]; then
-  _HOP_JAVA=$JAVA_HOME/bin/java
+if [ -n "${HOP_JAVA_HOME}" ]; then
+  _HOP_JAVA="${HOP_JAVA_HOME}/bin/java"
+elif [ -n "${JAVA_HOME}" ]; then
+  _HOP_JAVA="${JAVA_HOME}/bin/java"
 else
   _HOP_JAVA="java"
 fi
 
 # Settings for all OSses
 #
-if [ -z "$HOP_OPTIONS" ]; then
+if [ -z "${HOP_OPTIONS}" ]; then
   HOP_OPTIONS="-Xmx2048m"
 fi
+
 # optional line for attaching a debugger
 #
 #HOP_OPTIONS="${HOP_OPTIONS} -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5007"
@@ -68,14 +69,14 @@ HOP_OPTIONS="${HOP_OPTIONS} --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED --
 
 case $(uname -s) in
 Linux)
-    if $($_HOP_JAVA -XshowSettings:properties -version 2>&1| grep -q "os.arch = aarch64"); then
+    if "${_HOP_JAVA}" -XshowSettings:properties -version 2>&1 | grep -q "os.arch = aarch64"; then
         CLASSPATH="lib/core/*:lib/beam/*:lib/swt/linux/arm64/*"
     else
         CLASSPATH="lib/core/*:lib/beam/*:lib/swt/linux/$(uname -m)/*"
     fi
   ;;
 Darwin)
-  if $($_HOP_JAVA -XshowSettings:properties -version 2>&1| grep -q "os.arch = aarch64"); then
+  if "${_HOP_JAVA}" -XshowSettings:properties -version 2>&1 | grep -q "os.arch = aarch64"; then
       CLASSPATH="lib/core/*:lib/beam/*:lib/swt/osx/arm64/*"
   else
       CLASSPATH="lib/core/*:lib/beam/*:lib/swt/osx/x86_64/*"
@@ -84,13 +85,13 @@ Darwin)
   ;;
 esac
 
-if [ ! "x$JAAS_LOGIN_MODULE_CONFIG" = "x" -a ! "x$JAAS_LOGIN_MODULE_NAME" = "x" ]; then
-  HOP_OPTIONS=$HOP_OPTIONS" -Djava.security.auth.login.config=$JAAS_LOGIN_MODULE_CONFIG"
-  HOP_OPTIONS=$HOP_OPTIONS" -Dloginmodulename=$JAAS_LOGIN_MODULE_NAME"
+if [ ! "x${JAAS_LOGIN_MODULE_CONFIG}" = "x" ] && [ ! "x${JAAS_LOGIN_MODULE_NAME}" = "x" ]; then
+  HOP_OPTIONS="${HOP_OPTIONS} -Djava.security.auth.login.config=${JAAS_LOGIN_MODULE_CONFIG}"
+  HOP_OPTIONS="${HOP_OPTIONS} -Dloginmodulename=${JAAS_LOGIN_MODULE_NAME}"
 fi
 
-"$_HOP_JAVA" ${HOP_OPTIONS} -Djava.library.path=$LIBPATH -classpath "${CLASSPATH}" org.apache.hop.www.HopServer "$@"
+"${_HOP_JAVA}" ${HOP_OPTIONS} -Djava.library.path="${LIBPATH}" -classpath "${CLASSPATH}" org.apache.hop.www.HopServer "$@"
 EXITCODE=$?
 
-cd ${ORIGINDIR}
+cd "${ORIGINDIR}" || exit 1
 exit $EXITCODE

--- a/assemblies/static/src/main/resources/hop-translator.sh
+++ b/assemblies/static/src/main/resources/hop-translator.sh
@@ -19,27 +19,27 @@
 #
 
 ORIGINDIR=$(pwd)
-BASEDIR=$(dirname $0)
-cd $BASEDIR
+BASEDIR=$(dirname "$0")
+cd "${BASEDIR}" || exit 1
 
 # set java primary is HOP_JAVA_HOME fallback to JAVA_HOME or default java
-if [ -n "$HOP_JAVA_HOME" ]; then
-  _HOP_JAVA=$HOP_JAVA_HOME/bin/java
-elif [ -n "$JAVA_HOME" ]; then
-  _HOP_JAVA=$JAVA_HOME/bin/java
+if [ -n "${HOP_JAVA_HOME}" ]; then
+  _HOP_JAVA="${HOP_JAVA_HOME}/bin/java"
+elif [ -n "${JAVA_HOME}" ]; then
+  _HOP_JAVA="${JAVA_HOME}/bin/java"
 else
   _HOP_JAVA="java"
 fi
 
 # Settings for all OSses
 #
-if [ -z "$HOP_OPTIONS" ]; then
+if [ -z "${HOP_OPTIONS}" ]; then
   HOP_OPTIONS="-Xmx2048m"
 fi
 
 # optional line for attaching a debugger
 #
-# OPTIONS="${OPTIONS} -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5008"
+#HOP_OPTIONS="${HOP_OPTIONS} -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5008"
 
 # Add HOP variables if they're set:
 #
@@ -69,14 +69,14 @@ HOP_OPTIONS="${HOP_OPTIONS} --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED --
 
 case $(uname -s) in
 Linux)
-    if $($_HOP_JAVA -XshowSettings:properties -version 2>&1| grep -q "os.arch = aarch64"); then
+    if "${_HOP_JAVA}" -XshowSettings:properties -version 2>&1 | grep -q "os.arch = aarch64"; then
         CLASSPATH="lib/core/*:lib/beam/*:lib/swt/linux/arm64/*"
     else
         CLASSPATH="lib/core/*:lib/beam/*:lib/swt/linux/$(uname -m)/*"
     fi
   ;;
 Darwin)
-  if $($_HOP_JAVA -XshowSettings:properties -version 2>&1| grep -q "os.arch = aarch64"); then
+  if "${_HOP_JAVA}" -XshowSettings:properties -version 2>&1 | grep -q "os.arch = aarch64"; then
       CLASSPATH="lib/core/*:lib/beam/*:lib/swt/osx/arm64/*"
   else
       CLASSPATH="lib/core/*:lib/beam/*:lib/swt/osx/x86_64/*"
@@ -85,8 +85,8 @@ Darwin)
   ;;
 esac
 
-"$_HOP_JAVA" ${HOP_OPTIONS} -classpath "${CLASSPATH}" org.apache.hop.ui.i18n.editor.Translator $@
+"${_HOP_JAVA}" ${HOP_OPTIONS} -classpath "${CLASSPATH}" org.apache.hop.ui.i18n.editor.Translator "$@"
 EXITCODE=$?
 
-cd ${ORIGINDIR}
+cd "${ORIGINDIR}" || exit 1
 exit $EXITCODE


### PR DESCRIPTION
The `hop-encrypt.sh`, `hop-gui.sh` and `hop-translator.sh` scripts do not quote the `$@` variable, which causes them to fail if one of their arguments contains spaces ([SC2068](https://www.shellcheck.net/wiki/SC2068)). There are other variables like `BASEDIR`, `ORIGINDIR` and `LIBPATH` that need to be quoted for the same reason.

In this PR I apply these fixes plus a few more found by ShellCheck.