### PR TITLE
fix: add missing volume mounts to docker-compose.yaml

### DIFF
--- a/docs/hop-user-manual/modules/ROOT/assets/files/how-to-guides/apache-airflow/docker-compose.yaml
+++ b/docs/hop-user-manual/modules/ROOT/assets/files/how-to-guides/apache-airflow/docker-compose.yaml
@@ -77,6 +77,7 @@ x-airflow-common:
     - ${AIRFLOW_PROJ_DIR:-.}/logs:/opt/airflow/logs
     - ${AIRFLOW_PROJ_DIR:-.}/config:/opt/airflow/config
     - ${AIRFLOW_PROJ_DIR:-.}/plugins:/opt/airflow/plugins
+    - /var/run/docker.sock:/var/run/docker.sock
   user: "${AIRFLOW_UID:-50000}:0"
   depends_on:
     &airflow-common-depends-on


### PR DESCRIPTION
**Description:**

Added missing volume mounts to `docker-compose.yaml` for Apache Hop.

The `docker-compose.yaml` for Airflow was not working with Apache Hop without this volume mount. Although the documentation mentions this requirement, it was not specified in the file. This fix ensures that the volume is correctly mounted, allowing Airflow to function properly with Apache Hop as intended.
