### PR TITLE
Improve Documentation for Running Apache Hop in Airflow

### DIFF
--- a/docs/hop-user-manual/modules/ROOT/pages/how-to-guides/run-hop-in-apache-airflow.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/how-to-guides/run-hop-in-apache-airflow.adoc
@@ -203,6 +203,8 @@ Save the DAG we just created in your dags folder as apache-hop-dag-simple.py. Af
 
 If there are any syntax errors in your DAG, Airflow will let you know. Expand the error dialog for more details about the error.
 
+Note: If you're using `DockerOperator` and need to access a database or service running on your host machine, be sure to set the host as `host.docker.internal` in the Hop connection configuration to allow the container to access the host services.
+
 image:how-to-guides/run-hop-in-apache-airflow/apache-airflow-dag-error.png[Apache Airflow - DAG error, width="45%"]
 
 image:how-to-guides/run-hop-in-apache-airflow/apache-airflow-dag-available.png[Apache Airflow - DAG available, width="75%"]


### PR DESCRIPTION
This pull request updates the `run-hop-in-apache-airflow.adoc` file with more detailed instructions on how to configure Apache Hop to interact with services on the host machine when running in a Docker environment. Specifically, it includes guidance on setting `host.docker.internal` in the Hop connection configuration to allow seamless communication between the Docker container and host services.

**Changes made:**
- Added a note about using `host.docker.internal` for database and service access on the host machine from within Docker containers.
- Clarified interaction with host services in a development environment.
- Ensured the content improves clarity for developers working with Apache Hop and DockerOperator in Airflow.

**Reason for the change:**
This change aims to improve developer experience by providing clear instructions on how to interact with services running on the host machine when Apache Hop is running inside Docker containers managed by Airflow. This ensures that developers can quickly resolve connectivity issues.






