### PR TITLE
Change the colors in the file explorer when GIT is activated #4316

### DIFF
--- a/plugins/misc/git/src/main/java/org/apache/hop/git/info/GitInfoExplorerFileTypeHandler.java
+++ b/plugins/misc/git/src/main/java/org/apache/hop/git/info/GitInfoExplorerFileTypeHandler.java
@@ -199,11 +199,12 @@ public class GitInfoExplorerFileTypeHandler extends BaseExplorerFileTypeHandler
       new ColumnInfo("Comment", ColumnInfo.COLUMN_TYPE_TEXT),
     };
     wRevisions =
-        new TableView(hopGui.getVariables(), composite, SWT.NONE, revisionColumns, 1, null, props);
+        new TableView(
+            hopGui.getVariables(), composite, SWT.BORDER, revisionColumns, 1, null, props);
     wRevisions.setReadonly(true);
     PropsUi.setLook(wRevisions);
     FormData fdRevisions = new FormData();
-    fdRevisions.left = new FormAttachment(0, margin);
+    fdRevisions.left = new FormAttachment(0, 0);
     fdRevisions.top = new FormAttachment(lastControl, margin);
     fdRevisions.right = new FormAttachment(100, 0);
     fdRevisions.bottom = new FormAttachment(40, 0);
@@ -235,9 +236,10 @@ public class GitInfoExplorerFileTypeHandler extends BaseExplorerFileTypeHandler
     ColumnInfo[] filesColumns = {
       new ColumnInfo("Filename", ColumnInfo.COLUMN_TYPE_TEXT),
       new ColumnInfo("Status", ColumnInfo.COLUMN_TYPE_TEXT),
-      new ColumnInfo("Staged?", ColumnInfo.COLUMN_TYPE_CCOMBO, new String[] {"Y", "N"}),
+      new ColumnInfo("Staged", ColumnInfo.COLUMN_TYPE_CCOMBO, new String[] {"Y", "N"}),
     };
-    wFiles = new TableView(hopGui.getVariables(), sashForm, SWT.NONE, filesColumns, 1, null, props);
+    wFiles =
+        new TableView(hopGui.getVariables(), sashForm, SWT.BORDER, filesColumns, 1, null, props);
     wFiles.setReadonly(true);
     PropsUi.setLook(wFiles);
     wFiles.table.addListener(SWT.Selection, e -> fileSelected());

--- a/plugins/misc/git/src/main/java/org/apache/hop/git/model/UIGit.java
+++ b/plugins/misc/git/src/main/java/org/apache/hop/git/model/UIGit.java
@@ -274,7 +274,7 @@ public class UIGit extends VCS {
 
   public void removeRemote() {
     RemoteRemoveCommand cmd = git.remoteRemove();
-    cmd.setName(Constants.DEFAULT_REMOTE_NAME);
+    cmd.setRemoteName(Constants.DEFAULT_REMOTE_NAME);
     try {
       cmd.call();
     } catch (GitAPIException e) {


### PR DESCRIPTION
Ignored Git files are not correctly detected
Replace deprecated method setName() for RemoteRemoveCommand Add BORDER to TableView in GitInfo
