### PR TITLE
Fix #4341: Use correct logging and hide private Methods as fake data types

### DIFF
--- a/plugins/transforms/fake/src/main/java/org/apache/hop/pipeline/transforms/fake/FakeDialog.java
+++ b/plugins/transforms/fake/src/main/java/org/apache/hop/pipeline/transforms/fake/FakeDialog.java
@@ -18,6 +18,7 @@
 package org.apache.hop.pipeline.transforms.fake;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -202,6 +203,7 @@ public class FakeDialog extends BaseTransformDialog {
         // Ignore methods needing parameters for now
         // or that doesn't return type (String, long or Date)
         if (method.getParameterCount() == 0
+            && Modifier.isPublic(method.getModifiers())
             && (method.getReturnType().isAssignableFrom(String.class)
                 || method.getReturnType().isAssignableFrom(long.class)
                 || method.getReturnType().isAssignableFrom(Date.class))) {

--- a/plugins/transforms/fake/src/main/java/org/apache/hop/pipeline/transforms/fake/FakeMeta.java
+++ b/plugins/transforms/fake/src/main/java/org/apache/hop/pipeline/transforms/fake/FakeMeta.java
@@ -105,10 +105,10 @@ public class FakeMeta extends BaseTransformMeta<Fake, FakeData> {
             valueMeta.setOrigin(name);
             rowMeta.addValueMeta(valueMeta);
           } else {
-            log.logError("Error unsupported faker return type");
+            logError("Error unsupported faker return type");
           }
         } catch (NoSuchMethodException e) {
-          log.logError(
+          logError(
               "Error getting faker object or method for type "
                   + field.getType()
                   + " and topic "


### PR DESCRIPTION
1. NullPointer Exception fix: Changed logging from log.error() to logError() since log is not available in FakeMeta.class.

2. Fix reason for error log: When generating the available Options in FakeDialog.class, private Methods are listed as well. This results into the option, to select a private message and the error, that this method can not be called or is not available. Therefore I added a filter to exclude private Methods from the list of fake topics.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
