### PR TITLE
Segregate the schema definitions under relevant sub folders

### DIFF
--- a/core/src/main/java/org/apache/hop/metadata/api/HopMetadata.java
+++ b/core/src/main/java/org/apache/hop/metadata/api/HopMetadata.java
@@ -51,4 +51,12 @@ public @interface HopMetadata {
    * @return the type of metadata this property represents.
    */
   HopMetadataPropertyType hopMetadataPropertyType() default HopMetadataPropertyType.NONE;
+
+  /**
+   * A boolean flag, represented as a string, which tells whether the given HopMetadata
+   * implementation has to be shown into a tree of folders
+   *
+   * @return a boolean as string flag that will enable the UI to allow folders creation
+   */
+  String subfoldersEnabled() default "false";
 }

--- a/core/src/main/java/org/apache/hop/metadata/api/HopMetadataBase.java
+++ b/core/src/main/java/org/apache/hop/metadata/api/HopMetadataBase.java
@@ -22,6 +22,8 @@ import java.util.Objects;
 
 public class HopMetadataBase implements IHopMetadata {
 
+  @HopMetadataProperty protected String path;
+
   /** All metadata objects have a name to uniquely identify it. */
   @HopMetadataProperty protected String name;
 
@@ -36,6 +38,13 @@ public class HopMetadataBase implements IHopMetadata {
   public HopMetadataBase(String name) {
     this();
     this.name = name;
+    this.path = "";
+  }
+
+  public HopMetadataBase(String name, String path) {
+    this();
+    this.name = name;
+    this.path = path;
   }
 
   @Override
@@ -95,5 +104,28 @@ public class HopMetadataBase implements IHopMetadata {
   @Override
   public void setMetadataProviderName(String metadataProviderName) {
     this.metadataProviderName = metadataProviderName;
+  }
+
+  @Override
+  public String getPath() {
+    return path;
+  }
+
+  @Override
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  @Override
+  public String getFullName() {
+    if (path == null || path.isBlank()) {
+      return name;
+    } else {
+      if (path.endsWith("/")) {
+        return path + name;
+      } else {
+        return path + "/" + name;
+      }
+    }
   }
 }

--- a/core/src/main/java/org/apache/hop/metadata/api/IHopMetadata.java
+++ b/core/src/main/java/org/apache/hop/metadata/api/IHopMetadata.java
@@ -52,4 +52,10 @@ public interface IHopMetadata {
    * @param metadataProviderName The source of metadata or null if it's not specified
    */
   void setMetadataProviderName(String metadataProviderName);
+
+  String getPath();
+
+  void setPath(String path);
+
+  String getFullName();
 }

--- a/core/src/main/java/org/apache/hop/metadata/api/IHopMetadataSerializer.java
+++ b/core/src/main/java/org/apache/hop/metadata/api/IHopMetadataSerializer.java
@@ -19,6 +19,7 @@ package org.apache.hop.metadata.api;
 
 import java.util.List;
 import org.apache.hop.core.exception.HopException;
+import org.apache.hop.metadata.serializer.FileSystemNode;
 
 /**
  * This metadata interface describes how an object T can be serialized and analyzed.
@@ -66,6 +67,11 @@ public interface IHopMetadataSerializer<T extends IHopMetadata> {
    * @throws HopException
    */
   List<String> listObjectNames() throws HopException;
+
+  default FileSystemNode getFileSystemTree() throws HopException {
+    throw new UnsupportedOperationException(
+        "listObjectNames(String folderName, Boolean recursive) is not supported by this metadata serializer");
+  }
 
   /**
    * See if an object with the given name exists.

--- a/core/src/main/java/org/apache/hop/metadata/serializer/FileSystemNode.java
+++ b/core/src/main/java/org/apache/hop/metadata/serializer/FileSystemNode.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.metadata.serializer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+// Represents a node in the file system tree
+public class FileSystemNode {
+  private String name; // Name of the file or folder
+  private String path; // Absolute path to the file or folder
+  private Type type; // Type (file or folder)
+  private FileSystemNode parent; // Parent node
+  private List<FileSystemNode> children; // Children nodes (only for folder)
+
+  // Enum for node type
+  public enum Type {
+    FILE,
+    FOLDER
+  }
+
+  // Constructor
+
+  public FileSystemNode(String name, String path, Type type, FileSystemNode parent) {
+    this.name = name;
+    this.path = path;
+    this.type = type;
+    this.parent = parent;
+    this.children = new ArrayList<>();
+
+    if (this.parent != null) {
+      this.parent.addChild(this);
+    }
+  }
+
+  // Add a child node
+
+  public void addChild(FileSystemNode child) {
+    if (this.type == Type.FOLDER) {
+      this.children.add(child);
+    }
+  }
+
+  // Getters
+
+  public String getName() {
+    return name;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public Type getType() {
+    return type;
+  }
+
+  public FileSystemNode getParent() {
+    return parent;
+  }
+
+  public List<FileSystemNode> getChildren() {
+    return children;
+  }
+
+  public boolean isFolder() {
+    return type == Type.FOLDER;
+  }
+
+  public boolean isFile() {
+    return type == Type.FILE;
+  }
+}

--- a/core/src/main/java/org/apache/hop/metadata/serializer/json/JsonMetadataSerializer.java
+++ b/core/src/main/java/org/apache/hop/metadata/serializer/json/JsonMetadataSerializer.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.commons.lang.StringUtils;
@@ -39,6 +40,7 @@ import org.apache.hop.metadata.api.HopMetadata;
 import org.apache.hop.metadata.api.IHopMetadata;
 import org.apache.hop.metadata.api.IHopMetadataProvider;
 import org.apache.hop.metadata.api.IHopMetadataSerializer;
+import org.apache.hop.metadata.serializer.FileSystemNode;
 import org.json.simple.JSONObject;
 
 /**
@@ -140,11 +142,11 @@ public class JsonMetadataSerializer<T extends IHopMetadata> implements IHopMetad
 
   @Override
   public void save(T t) throws HopException {
-    if (StringUtils.isEmpty(t.getName())) {
+    if (StringUtils.isEmpty(t.getFullName())) {
       throw new HopException("Error: To save a metadata object it needs to have a name");
     }
 
-    String filename = calculateFilename(t.getName());
+    String filename = calculateFilename(t);
     try {
 
       JSONObject jObject = parser.getJsonObject(t);
@@ -170,8 +172,26 @@ public class JsonMetadataSerializer<T extends IHopMetadata> implements IHopMetad
     }
   }
 
+  public String calculateFilename(T t) {
+    String prefix = t.getPath() == null ? baseFolder : t.getPath();
+    if (!prefix.endsWith("/")) {
+      prefix += "/";
+    }
+    return prefix + t.getName() + ".json";
+  }
+
   public String calculateFilename(String name) {
+    if (name.startsWith(baseFolder)) {
+      return name;
+    }
     return baseFolder + "/" + name + ".json";
+  }
+
+  public String calculateFolderName(String name) {
+    if (name.startsWith(baseFolder)) {
+      return name;
+    }
+    return baseFolder + "/" + name;
   }
 
   @Override
@@ -180,19 +200,35 @@ public class JsonMetadataSerializer<T extends IHopMetadata> implements IHopMetad
       throw new HopException(
           "Error: you need to specify the name of the metadata object to delete");
     }
-    if (!exists(name)) {
+    boolean exists = exists(name);
+    if (!exists) {
       throw new HopException("Error: Object '" + name + "' doesn't exist");
     }
-    T t = load(name);
-    String filename = calculateFilename(name);
+
+    T t = null;
+    String objectName = null;
+    if (existsFolder(name)) {
+      objectName = calculateFolderName(name);
+    }
+    if (existsFile(name)) {
+      t = load(name);
+      objectName = calculateFilename(name);
+    }
+
     try {
-      boolean deleted = HopVfs.getFileObject(filename).delete();
+      var object = HopVfs.getFileObject(objectName);
+      boolean deleted = false;
+      if (object.isFolder()) {
+        deleted = object.deleteAll() > 0;
+      } else {
+        deleted = object.delete();
+      }
       if (!deleted) {
         throw new HopException(
-            "Error: Object '" + name + "' could not be deleted, filename : " + filename);
+            "Error: Object '" + name + "' could not be deleted, name : " + objectName);
       }
     } catch (FileSystemException e) {
-      throw new HopException("Error deleting Object '" + name + "' with filename : " + filename);
+      throw new HopException("Error deleting Object '" + name + "' with name : " + objectName);
     }
     return t;
   }
@@ -215,8 +251,76 @@ public class JsonMetadataSerializer<T extends IHopMetadata> implements IHopMetad
   }
 
   @Override
+  public FileSystemNode getFileSystemTree() throws HopException {
+    FileObject currentItem = HopVfs.getFileObject(baseFolder);
+    FileSystemNode root =
+        new FileSystemNode(
+            currentItem.getName().getBaseName(),
+            currentItem.getName().getPath(),
+            FileSystemNode.Type.FOLDER,
+            null);
+    return getFileSystemTree(root);
+  }
+
+  private FileSystemNode getFileSystemTree(FileSystemNode parent) throws HopException {
+    FileObject currentItem = HopVfs.getFileObject(parent.getPath());
+    try {
+      Arrays.asList(currentItem.getChildren()).stream()
+          .forEach(
+              f -> {
+                try {
+                  if (f.isFolder()) {
+                    FileSystemNode currentFolder =
+                        new FileSystemNode(
+                            f.getName().getBaseName(),
+                            f.getName().getPath(),
+                            FileSystemNode.Type.FOLDER,
+                            parent);
+                    getFileSystemTree(currentFolder); // Recursive call for the folder
+                  } else {
+                    if (f.getName().getExtension().equals("json")) {
+                      FileSystemNode currentFile =
+                          new FileSystemNode(
+                              f.getName().getBaseName().replaceAll("\\.json$", ""),
+                              f.getName().getPath(),
+                              FileSystemNode.Type.FILE,
+                              parent);
+                    }
+                  }
+                } catch (FileSystemException | HopException e) {
+                  throw new RuntimeException(e);
+                }
+              });
+    } catch (Exception e) {
+      throw new HopException("Error searching for JSON files", e);
+    }
+    return parent;
+  }
+
+  //    try {
+  //      List<FileObject> jsonFiles = HopVfs.findFiles(folder, "json", false);
+  //      List<String> names = new ArrayList<>();
+  //      for (FileObject jsonFile : jsonFiles) {
+  //        String baseName = jsonFile.getName().getBaseName();
+  //        names.add(baseName.replaceAll("\\.json$", ""));
+  //      }
+  //      return names;
+  //    } catch (Exception e) {
+  //      throw new HopException("Error searching for JSON files", e);
+  //    }
+  @Override
   public boolean exists(String name) throws HopException {
-    return HopVfs.fileExists(calculateFilename(name));
+    return existsFolder(name) || existsFile(name);
+  }
+
+  private boolean existsFile(String name) throws HopException {
+
+    return !existsFolder(name)
+        && (HopVfs.fileExists(name) || HopVfs.fileExists(calculateFilename(name)));
+  }
+
+  private boolean existsFolder(String name) throws HopException {
+    return HopVfs.fileExists(name) || HopVfs.fileExists(calculateFolderName(name));
   }
 
   /**

--- a/core/src/main/java/org/apache/hop/metadata/serializer/multi/MultiMetadataSerializer.java
+++ b/core/src/main/java/org/apache/hop/metadata/serializer/multi/MultiMetadataSerializer.java
@@ -29,6 +29,7 @@ import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.metadata.api.IHopMetadata;
 import org.apache.hop.metadata.api.IHopMetadataProvider;
 import org.apache.hop.metadata.api.IHopMetadataSerializer;
+import org.apache.hop.metadata.serializer.FileSystemNode;
 
 public class MultiMetadataSerializer<T extends IHopMetadata> implements IHopMetadataSerializer<T> {
 
@@ -139,6 +140,15 @@ public class MultiMetadataSerializer<T extends IHopMetadata> implements IHopMeta
       set.addAll(provider.getSerializer(managedClass).listObjectNames());
     }
     return new ArrayList<>(set);
+  }
+
+  @Override
+  public FileSystemNode getFileSystemTree() throws HopException {
+    FileSystemNode root = new FileSystemNode("root", "/", FileSystemNode.Type.FOLDER, null);
+    for (IHopMetadataProvider provider : multiProvider.getProviders()) {
+      root.addChild(provider.getSerializer(managedClass).getFileSystemTree());
+    }
+    return root;
   }
 
   @Override

--- a/core/src/test/java/org/apache/hop/metadata/serializer/json/JsonMetadataSerializerTest.java
+++ b/core/src/test/java/org/apache/hop/metadata/serializer/json/JsonMetadataSerializerTest.java
@@ -41,10 +41,11 @@ public class JsonMetadataSerializerTest extends TestCase {
 
   @Override
   protected void setUp() throws Exception {
-    String baseFolder =
-        System.getProperty("java.io.tmpdir")
-            + Const.FILE_SEPARATOR
-            + "metadata"; // UUID.randomUUID();
+    String tmpDir = System.getProperty("java.io.tmpdir");
+    if (!tmpDir.endsWith(Const.FILE_SEPARATOR)) {
+      tmpDir += Const.FILE_SEPARATOR;
+    }
+    String baseFolder = tmpDir + "metadata"; // UUID.randomUUID();
     metadataProvider =
         new JsonMetadataProvider(
             new HopTwoWayPasswordEncoder(), baseFolder, Variables.getADefaultVariableSpace());

--- a/plugins/misc/static-schema/src/main/java/org/apache/hop/staticschema/metadata/SchemaDefinition.java
+++ b/plugins/misc/static-schema/src/main/java/org/apache/hop/staticschema/metadata/SchemaDefinition.java
@@ -38,7 +38,8 @@ import org.apache.hop.metadata.api.IHopMetadata;
     description = "i18n::SchemaDefinition.Description",
     image = "ui/images/folder.svg",
     documentationUrl = "/metadata-types/static-schema-definition.html",
-    hopMetadataPropertyType = HopMetadataPropertyType.STATIC_SCHEMA_DEFINITION)
+    hopMetadataPropertyType = HopMetadataPropertyType.STATIC_SCHEMA_DEFINITION,
+    subfoldersEnabled = "true")
 public class SchemaDefinition extends HopMetadataBase implements Serializable, IHopMetadata {
 
   private static final Class<?> PKG = SchemaDefinition.class;

--- a/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelinput/ExcelInputDialog.java
+++ b/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelinput/ExcelInputDialog.java
@@ -888,7 +888,7 @@ public class ExcelInputDialog extends BaseTransformDialog {
     wSchemaDefinition.setLayoutData(fdSchemaDefinition);
 
     try {
-      wSchemaDefinition.fillItems();
+      wSchemaDefinition.fillTreeItems();
     } catch (Exception e) {
       log.logError("Error getting schema definition items", e);
     }

--- a/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelwriter/ExcelWriterTransformDialog.java
+++ b/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelwriter/ExcelWriterTransformDialog.java
@@ -1401,7 +1401,7 @@ public class ExcelWriterTransformDialog extends BaseTransformDialog {
     wSchemaDefinition.setLayoutData(fdSchemaDefinition);
 
     try {
-      wSchemaDefinition.fillItems();
+      wSchemaDefinition.fillTreeItems();
     } catch (Exception e) {
       log.logError("Error getting schema definition items", e);
     }

--- a/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputDialog.java
+++ b/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputDialog.java
@@ -533,7 +533,7 @@ public class CsvInputDialog extends BaseTransformDialog
     wSchemaDefinition.setLayoutData(fdSchemaDefinition);
 
     try {
-      wSchemaDefinition.fillItems();
+      wSchemaDefinition.fillTreeItems();
     } catch (Exception e) {
       log.logError("Error getting schema definition items", e);
     }

--- a/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/fileinput/text/TextFileInputDialog.java
+++ b/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/fileinput/text/TextFileInputDialog.java
@@ -1983,7 +1983,7 @@ public class TextFileInputDialog extends BaseTransformDialog
     wSchemaDefinition.setLayoutData(fdSchemaDefinition);
 
     try {
-      wSchemaDefinition.fillItems();
+      wSchemaDefinition.fillTreeItems();
     } catch (Exception e) {
       log.logError("Error getting schema definition items", e);
     }

--- a/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/textfileoutput/TextFileOutputDialog.java
+++ b/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/textfileoutput/TextFileOutputDialog.java
@@ -1097,7 +1097,7 @@ public class TextFileOutputDialog extends BaseTransformDialog {
     wSchemaDefinition.setLayoutData(fdSchemaDefinition);
 
     try {
-      wSchemaDefinition.fillItems();
+      wSchemaDefinition.fillTreeItems();
     } catch (Exception e) {
       log.logError("Error getting schema definition items", e);
     }

--- a/ui/src/main/java/org/apache/hop/ui/core/metadata/MetadataManager.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/metadata/MetadataManager.java
@@ -448,6 +448,10 @@ public class MetadataManager<T extends IHopMetadata> {
   }
 
   public T newMetadataWithEditor() {
+    return newMetadataWithEditor("");
+  }
+
+  public T newMetadataWithEditor(String path) {
     HopGui hopGui = HopGui.getInstance();
 
     try {
@@ -455,6 +459,7 @@ public class MetadataManager<T extends IHopMetadata> {
       // Create a new instance of the managed class
       //
       T element = managedClass.getDeclaredConstructor().newInstance();
+      element.setPath(path);
       initializeElementVariables(element);
 
       ExtensionPointHandler.callExtensionPoint(

--- a/ui/src/main/java/org/apache/hop/ui/core/widget/TableView.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/widget/TableView.java
@@ -2665,10 +2665,8 @@ public class TableView extends Composite {
     int strmax = TextSizeUtilFacade.textExtent(str).x + 20;
     int colmax = tableColumn[colNr].getWidth();
     if (strmax > colmax) {
-      if (!EnvironmentUtils.getInstance().isWeb()) {
-        if (Const.isOSX() || Const.isLinux()) {
-          strmax *= 1.4;
-        }
+      if (!EnvironmentUtils.getInstance().isWeb() && (Const.isOSX() || Const.isLinux())) {
+        strmax *= 1.4;
       }
       tableColumn[colNr].setWidth(strmax + 30);
 
@@ -3047,14 +3045,14 @@ public class TableView extends Composite {
     if (item != null) {
       if (colNr >= 0) {
         String str = item.getText(colNr);
-        if (str == null || str.length() == 0) {
+        if (str == null || str.isEmpty()) {
           empty = true;
         }
       } else {
         empty = true;
         for (int j = 1; j < table.getColumnCount(); j++) {
           String str = item.getText(j);
-          if (str != null && str.length() > 0) {
+          if (str != null && !str.isEmpty()) {
             empty = false;
           }
         }

--- a/ui/src/main/resources/org/apache/hop/ui/hopgui/perspective/metadata/messages/messages_en_US.properties
+++ b/ui/src/main/resources/org/apache/hop/ui/hopgui/perspective/metadata/messages/messages_en_US.properties
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+MetadataPerspective.CreateFolder.Message=Enter name of the folder to create
 MetadataPerspective.CreateMetadata.Error.Header=Error
 MetadataPerspective.CreateMetadata.Error.Message=Error creating metadata
 MetadataPerspective.Description=The Hop Metatada Perspective
@@ -23,11 +24,28 @@ MetadataPerspective.DuplicateMetadata.Error.Message=Error duplicating metadata
 MetadataPerspective.EditMetadata.Error.Header=Error
 MetadataPerspective.EditMetadata.Error.Message=Error editing metadata
 MetadataPerspective.GuiPlugin.Description=This perspective allows you to see and edit all available metadata
+MetadataPerspective.Menu.Edit.Label=Edit
+MetadataPerspective.Menu.Edit.Tooltip=Edit selected metadata element
+MetadataPerspective.Menu.New.Label=New
+MetadataPerspective.Menu.New.Tooltip=Create a new metadata element
+MetadataPerspective.Menu.NewFolder.Label=Create folder
+MetadataPerspective.Menu.NewFolder.Tooltip=Create a new metadata folder
+MetadataPerspective.Menu.Refresh.Label=Refresh
+MetadataPerspective.Menu.Refresh.Tooltip=Refresh metadata tree
+MetadataPerspective.Menu.Rename.Label=Rename
+MetadataPerspective.Menu.Rename.Tooltip=Rename selected metadata element
+MetadataPerspective.Menu.Delete.Label=Delete
+MetadataPerspective.Menu.Delete.Tooltip=Delete selected metadata element
+MetadataPerspective.Menu.Duplicate.Label=Duplicate
+MetadataPerspective.Menu.Duplicate.Tooltip=Duplicate selected metadata element
+MetadataPerspective.Menu.Help.Label=Help
+MetadataPerspective.Menu.Help.Tooltip=Help on the metadata perspective
+
 MetadataPerspective.Name=Metadata
 MetadataPerspective.RefreshMetadata.Error.Header=Error
 MetadataPerspective.RefreshMetadata.Error.Message=Error refreshing metadata tree
 MetadataPerspective.ToolbarElement.CreateCopy.Tooltip=Create a copy
 MetadataPerspective.ToolbarElement.Delete.Tooltip=Delete
-MetadataPerspective.ToolbarElement.Edit.Tooltip=Edit
+MetadataPerspective.ToolbarElement.Edit.Tooltip=Edit selected metadata element
 MetadataPerspective.ToolbarElement.New.Tooltip=Create a new metadata element
 MetadataPerspective.ToolbarElement.Refresh.Tooltip=Refresh


### PR DESCRIPTION
This PR is linked to [issue #4308](https://github.com/apache/hop/issues/4308), specifically the second point, namely the ability to organise schema definitions in subfolder.

However, this will impact any metadata provider, not just the Static Schema Definition.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [ ] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [ ] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
