### PR TITLE
Fix: Set FTP file type to binary if binaryMode is enabled

### DIFF
--- a/plugins/actions/ftp/src/main/java/org/apache/hop/workflow/actions/ftp/ActionFtp.java
+++ b/plugins/actions/ftp/src/main/java/org/apache/hop/workflow/actions/ftp/ActionFtp.java
@@ -27,6 +27,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.commons.net.ftp.FTP;
 import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPFile;
 import org.apache.commons.vfs2.FileObject;
@@ -434,6 +435,10 @@ public class ActionFtp extends ActionBase implements Cloneable, IAction, IFtpCon
 
         if (!getSuccessCondition().equals(SUCCESS_IF_NO_ERRORS)) {
           limitFiles = Const.toInt(resolve(getNrLimit()), 10);
+        }
+
+        if (binaryMode) {
+          ftpClient.setFileType(FTP.BINARY_FILE_TYPE);
         }
 
         // Get the files in the list...


### PR DESCRIPTION
Added a check to ensure that the FTP file type is set to binary when the binaryMode flag is enabled. This ensures that files are transferred in binary mode, which is necessary for handling non-text files correctly.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [ X] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [X ] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [X ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [X ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
