### PR TITLE
Revert "remove some of the github discussions mails., fixes #4695"

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -63,10 +63,13 @@ github:
     close_issue: "Re: [I] {title} ({repository})"
     catchall: "[GH] {title} ({repository})"
     new_discussion: "[D] {title} ({repository})"
+    edit_discussion: "Re: [D] {title} ({repository})"
     close_discussion: "Re: [D] {title} ({repository})"
     close_discussion_with_comment: "Re: [D] {title} ({repository})"
     reopen_discussion: "Re: [D] {title} ({repository})"
     new_comment_discussion: "Re: [D] {title} ({repository})"
+    edit_comment_discussion: "Re: [D] {title} ({repository})"
+    delete_comment_discussion: "Re: [D] {title} ({repository})"
 
   #remove ~ when enabling the protection
   protected_branches: ~


### PR DESCRIPTION
This reverts commit 54dce3734cac7851d960c5dbc64bf8b773e4272a.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [ ] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [ ] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
