### PR TITLE
Fix #4876 Always pass field downstream when prev-field isn't a json source(JsonInput)

### DIFF
--- a/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsoninput/JsonInput.java
+++ b/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsoninput/JsonInput.java
@@ -95,10 +95,11 @@ public class JsonInput extends BaseFileInputTransform<JsonInputMeta, JsonInputDa
     if (first) {
       first = false;
       prepareToRowProcessing();
-    } else if (data.indexSourceField == -1 && !data.inputRowMeta.isEmpty()) {
+    } else if (data.indexSourceField == -1 && data.inputRowMeta != null) {
       data.readrow = getRow();
       if (data.readrow != null) {
-        throw new HopValueException(BaseMessages.getString(PKG, "JsonInput.Log.ReceivingMultiRows"));
+        throw new HopValueException(
+            BaseMessages.getString(PKG, "JsonInput.Log.ReceivingMultiRows"));
       }
     }
 

--- a/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsoninput/JsonInput.java
+++ b/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsoninput/JsonInput.java
@@ -95,6 +95,11 @@ public class JsonInput extends BaseFileInputTransform<JsonInputMeta, JsonInputDa
     if (first) {
       first = false;
       prepareToRowProcessing();
+    } else if (data.indexSourceField == -1 && !data.inputRowMeta.isEmpty()) {
+      data.readrow = getRow();
+      if (data.readrow != null) {
+        throw new HopValueException(BaseMessages.getString(PKG, "JsonInput.Log.ReceivingMultiRows"));
+      }
     }
 
     Object[] outRow;

--- a/plugins/transforms/json/src/main/resources/org/apache/hop/pipeline/transforms/jsoninput/messages/messages_en_US.properties
+++ b/plugins/transforms/json/src/main/resources/org/apache/hop/pipeline/transforms/jsoninput/messages/messages_en_US.properties
@@ -66,7 +66,6 @@ JsonInput.Log.ErrorFindingField=Field ''{0}'' does not exist
 JsonInput.Log.FileAddedResult=File was read by a Json Input transform
 JsonInput.Log.FinishedProcessing=Finished processing files.
 JsonInput.Log.IsNotAFile=[{0}] is not a file \!
-JsonInput.Log.NoField=No field specified\! Stop processing.
 JsonInput.Log.NoFiles=No file(s) specified\! Stop processing.
 JsonInput.Log.NrRecords=We found [{0}] records
 JsonInput.Log.OpeningFile=Opening file\: {0}

--- a/plugins/transforms/json/src/main/resources/org/apache/hop/pipeline/transforms/jsoninput/messages/messages_en_US.properties
+++ b/plugins/transforms/json/src/main/resources/org/apache/hop/pipeline/transforms/jsoninput/messages/messages_en_US.properties
@@ -70,6 +70,7 @@ JsonInput.Log.NoFiles=No file(s) specified\! Stop processing.
 JsonInput.Log.NrRecords=We found [{0}] records
 JsonInput.Log.OpeningFile=Opening file\: {0}
 JsonInput.Log.ReadRow=Read row\: {0}
+JsonInput.Log.ReceivingMultiRows=In the case of using non-field json source, only a single input row is supported
 JsonInput.Log.UnableToOpenFile=Could not open file \#{0} \: {1} --> {2}
 JsonInput.Log.UnexpectedError=Unexpected Error \: {0}
 JsonInput.name=JSON input

--- a/plugins/transforms/json/src/main/resources/org/apache/hop/pipeline/transforms/jsoninput/messages/messages_zh_CN.properties
+++ b/plugins/transforms/json/src/main/resources/org/apache/hop/pipeline/transforms/jsoninput/messages/messages_zh_CN.properties
@@ -27,7 +27,6 @@ JsonInput.Log.ErrorFindingField=\u65E0\u6CD5\u5728\u8F93\u5165\u6D41\u4E2D\u627E
 JsonInput.Log.FileAddedResult=Json \u8F93\u5165 Transform \u8BFB\u5230\u7684\u6587\u4EF6
 JsonInput.Log.FinishedProcessing=\u5904\u7406\u7ED3\u675F
 JsonInput.Log.IsNotAFile={0} \u4E0D\u662F\u6587\u4EF6
-JsonInput.Log.NoField=\u8BF7\u6307\u5B9A\u4FDD\u5B58\u6709\u6587\u4EF6\u540D\u7684\u5B57\u6BB5
 JsonInput.Log.NoFiles=\u6CA1\u6709\u6307\u5B9A\u6587\u4EF6\!\u505C\u6B62\u5904\u7406.
 JsonInput.Log.NrRecords=\u627E\u5230 {0} \u6761\u8BB0\u5F55
 JsonInput.Log.OpeningFile=\u6253\u5F00\u6587\u4EF6\: {0}

--- a/plugins/transforms/json/src/main/resources/org/apache/hop/pipeline/transforms/jsoninput/messages/messages_zh_CN.properties
+++ b/plugins/transforms/json/src/main/resources/org/apache/hop/pipeline/transforms/jsoninput/messages/messages_zh_CN.properties
@@ -31,6 +31,7 @@ JsonInput.Log.NoFiles=\u6CA1\u6709\u6307\u5B9A\u6587\u4EF6\!\u505C\u6B62\u5904\u
 JsonInput.Log.NrRecords=\u627E\u5230 {0} \u6761\u8BB0\u5F55
 JsonInput.Log.OpeningFile=\u6253\u5F00\u6587\u4EF6\: {0}
 JsonInput.Log.ReadRow=\u8BFB\u884C\: {0}
+JsonInput.Log.ReceivingMultiRows=\u5728\u4F7F\u7528\u975E\u5B57\u6BB5 json \u6E90\u65F6, \u4EC5\u652F\u6301\u5355\u6761\u8F93\u5165\u8BB0\u5F55
 JsonInput.Log.UnableToOpenFile=\u65E0\u6CD5\u6253\u5F00\u6587\u4EF6 \#{0} \: {1} --> {2}
 JsonInput.Log.UnexpectedError=\u672A\u77E5\u5F02\u5E38\: {0}
 JsonInput.name=JSON \u8F93\u5165


### PR DESCRIPTION
If prev-field is not a json source: 
Receiving multiple rows is not allowed (otherwise: the same json file is loaded repeatedly)