### PR TITLE
Fix #3775 Clean invalid info streams when don't found from previous transforms

### DIFF
--- a/engine/src/main/java/org/apache/hop/pipeline/PipelineMeta.java
+++ b/engine/src/main/java/org/apache/hop/pipeline/PipelineMeta.java
@@ -1811,16 +1811,6 @@ public class PipelineMeta extends AbstractMeta
           }
         }
 
-        // Have all StreamValueLookups, etc. reference the correct source transforms...
-        //
-        for (int i = 0; i < nrTransforms(); i++) {
-          TransformMeta transformMeta = getTransform(i);
-          ITransformMeta sii = transformMeta.getTransform();
-          if (sii != null) {
-            sii.searchInfoAndTargetTransforms(transforms);
-          }
-        }
-
         // Handle Hops
         //
         Node orderNode = XmlHandler.getSubNode(pipelineNode, XML_TAG_ORDER);
@@ -1837,6 +1827,16 @@ public class PipelineMeta extends AbstractMeta
           PipelineHopMeta hopinf = new PipelineHopMeta(hopNode, transforms);
           hopinf.setErrorHop(isErrorNode(errorHandlingNode, hopNode));
           addPipelineHop(hopinf);
+        }
+
+        // Have all StreamValueLookups, etc. reference the correct source transforms...
+        //
+        for (int i = 0; i < nrTransforms(); i++) {
+          TransformMeta transformMeta = getTransform(i);
+          ITransformMeta sii = transformMeta.getTransform();
+          if (sii != null) {
+            sii.searchInfoAndTargetTransforms(transforms);
+          }
         }
 
         //

--- a/plugins/transforms/mergejoin/src/main/java/org/apache/hop/pipeline/transforms/mergejoin/MergeJoinMeta.java
+++ b/plugins/transforms/mergejoin/src/main/java/org/apache/hop/pipeline/transforms/mergejoin/MergeJoinMeta.java
@@ -121,28 +121,22 @@ public class MergeJoinMeta extends BaseTransformMeta<MergeJoin, MergeJoinData> {
   @Override
   public void searchInfoAndTargetTransforms(List<TransformMeta> transforms) {
     List<IStream> infoStreams = getTransformIOMeta().getInfoStreams();
-    String[] prev =
-        parentTransformMeta.getParentPipelineMeta().getPrevTransformNames(parentTransformMeta);
-    if (leftTransformName != null) {
-      if (ArrayUtils.contains(prev, leftTransformName)) {
-        infoStreams
-            .get(0)
-            .setTransformMeta(TransformMeta.findTransform(transforms, leftTransformName));
-      } else {
+    if (parentTransformMeta != null) {
+      String[] prev =
+          parentTransformMeta.getParentPipelineMeta().getPrevTransformNames(parentTransformMeta);
+      if (leftTransformName != null && !ArrayUtils.contains(prev, leftTransformName)) {
         leftTransformName = null;
         setChanged();
       }
-    }
-    if (rightTransformName != null) {
-      if (ArrayUtils.contains(prev, rightTransformName)) {
-        infoStreams
-            .get(1)
-            .setTransformMeta(TransformMeta.findTransform(transforms, rightTransformName));
-      } else {
+      if (rightTransformName != null && !ArrayUtils.contains(prev, rightTransformName)) {
         rightTransformName = null;
         setChanged();
       }
     }
+    infoStreams.get(0).setTransformMeta(TransformMeta.findTransform(transforms, leftTransformName));
+    infoStreams
+        .get(1)
+        .setTransformMeta(TransformMeta.findTransform(transforms, rightTransformName));
   }
 
   @Override

--- a/plugins/transforms/mergejoin/src/main/java/org/apache/hop/pipeline/transforms/mergejoin/MergeJoinMeta.java
+++ b/plugins/transforms/mergejoin/src/main/java/org/apache/hop/pipeline/transforms/mergejoin/MergeJoinMeta.java
@@ -19,6 +19,7 @@ package org.apache.hop.pipeline.transforms.mergejoin;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hop.core.CheckResult;
 import org.apache.hop.core.ICheckResult;
 import org.apache.hop.core.annotations.Transform;
@@ -120,10 +121,28 @@ public class MergeJoinMeta extends BaseTransformMeta<MergeJoin, MergeJoinData> {
   @Override
   public void searchInfoAndTargetTransforms(List<TransformMeta> transforms) {
     List<IStream> infoStreams = getTransformIOMeta().getInfoStreams();
-    infoStreams.get(0).setTransformMeta(TransformMeta.findTransform(transforms, leftTransformName));
-    infoStreams
-        .get(1)
-        .setTransformMeta(TransformMeta.findTransform(transforms, rightTransformName));
+    String[] prev =
+        parentTransformMeta.getParentPipelineMeta().getPrevTransformNames(parentTransformMeta);
+    if (leftTransformName != null) {
+      if (ArrayUtils.contains(prev, leftTransformName)) {
+        infoStreams
+            .get(0)
+            .setTransformMeta(TransformMeta.findTransform(transforms, leftTransformName));
+      } else {
+        leftTransformName = null;
+        setChanged();
+      }
+    }
+    if (rightTransformName != null) {
+      if (ArrayUtils.contains(prev, rightTransformName)) {
+        infoStreams
+            .get(1)
+            .setTransformMeta(TransformMeta.findTransform(transforms, rightTransformName));
+      } else {
+        rightTransformName = null;
+        setChanged();
+      }
+    }
   }
 
   @Override

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/delegates/HopGuiPipelineHopDelegate.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/delegates/HopGuiPipelineHopDelegate.java
@@ -226,6 +226,9 @@ public class HopGuiPipelineHopDelegate {
     TransformMeta toTransformMeta = pipelineHopMeta.getToTransform();
     TransformMeta beforeTo = (TransformMeta) toTransformMeta.clone();
     int indexTo = pipelineMeta.indexOfTransform(toTransformMeta);
+    if (toTransformMeta.getTransform() != null) {
+      toTransformMeta.getTransform().searchInfoAndTargetTransforms(pipelineMeta.getTransforms());
+    }
 
     boolean transformFromNeedAddUndoChange =
         fromTransformMeta.getTransform().cleanAfterHopFromRemove(pipelineHopMeta.getToTransform());

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/delegates/HopGuiPipelineTransformDelegate.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/delegates/HopGuiPipelineTransformDelegate.java
@@ -507,6 +507,7 @@ public class HopGuiPipelineTransformDelegate {
     newHop2.setEnabled(hop.isEnabled());
     if (pipelineMeta.findPipelineHop(newHop2) == null) {
       pipelineMeta.addPipelineHop(newHop2);
+      toTransform.getTransform().searchInfoAndTargetTransforms(pipelineMeta.getTransforms());
       hopGui.undoDelegate.addUndoNew(
           pipelineMeta,
           new PipelineHopMeta[] {newHop2},


### PR DESCRIPTION
Search info&target streams: All hop mets were loaded