### PR TITLE
#5322: Fix OracleBulkLoader

### DIFF
--- a/plugins/transforms/orabulkloader/src/main/java/org/apache/hop/pipeline/transforms/orabulkloader/OraBulkLoader.java
+++ b/plugins/transforms/orabulkloader/src/main/java/org/apache/hop/pipeline/transforms/orabulkloader/OraBulkLoader.java
@@ -420,25 +420,19 @@ public class OraBulkLoader extends BaseTransform<OraBulkLoaderMeta, OraBulkLoade
       if (!password) {
         pass = "******";
       }
-
-      sb.append(" userid=").append(resolve(user)).append("/").append(resolve(pass)).append("@");
-
-      // If host name is specified, use form host:port/dbName else use TNS_NAME
-      if (!Utils.isEmpty(db.getHostname())) {
-        sb.append(resolve(db.getHostname()));
-        sb.append(':');
-        sb.append(resolve(db.getPort()));
+      String connectURL = Const.NVL(db.getURL(variables), "");
+      if (connectURL.indexOf('@') >= 0) {
+        connectURL = connectURL.substring(connectURL.indexOf('@') + 1);
       }
 
-      String databaseName = resolve(db.getDatabaseName());
+      sb.append(" userid=\'")
+          .append(resolve(user))
+          .append("/")
+          .append(resolve(pass))
+          .append("@")
+          .append(resolve(connectURL))
+          .append("\'");
 
-      // Quote
-      if (databaseName.indexOf('(') >= 0) {
-        databaseName = databaseName.replace("=", "\\=");
-        databaseName = '"' + databaseName + '"';
-      }
-
-      sb.append("/" + databaseName);
     } else {
       throw new HopException("No connection specified");
     }


### PR DESCRIPTION
Fixes #5322
Now using getURL() to retrieve the correct connection string to use in sqlldr command for OracleBulkLoader component.
Previously connection string was empty when using manual connection URL.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
