### PR TITLE
Ignore some dispose error of the dynamic ui widgets #3497

### DIFF
--- a/ui/src/main/java/org/apache/hop/ui/core/metadata/MetadataManager.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/metadata/MetadataManager.java
@@ -44,6 +44,7 @@ import org.apache.hop.ui.hopgui.HopGui;
 import org.apache.hop.ui.hopgui.context.GuiContextHandler;
 import org.apache.hop.ui.hopgui.context.GuiContextUtil;
 import org.apache.hop.ui.hopgui.perspective.metadata.MetadataPerspective;
+import org.apache.hop.ui.util.SwtErrorHandler;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Shell;
 
@@ -211,7 +212,9 @@ public class MetadataManager<T extends IHopMetadata> {
       }
 
     } catch (Exception e) {
-      new ErrorDialog(hopGui.getActiveShell(), CONST_ERROR, CONST_ERROR_EDITING_METADATA, e);
+      if (!SwtErrorHandler.handleException(e)) {
+        new ErrorDialog(hopGui.getActiveShell(), CONST_ERROR, CONST_ERROR_EDITING_METADATA, e);
+      }
       return false;
     }
   }
@@ -248,7 +251,9 @@ public class MetadataManager<T extends IHopMetadata> {
         perspective.setActiveEditor(editor);
       }
     } catch (Exception e) {
-      new ErrorDialog(hopGui.getActiveShell(), CONST_ERROR, CONST_ERROR_EDITING_METADATA, e);
+      if (!SwtErrorHandler.handleException(e)) {
+        new ErrorDialog(hopGui.getActiveShell(), CONST_ERROR, CONST_ERROR_EDITING_METADATA, e);
+      }
     }
   }
 
@@ -475,8 +480,10 @@ public class MetadataManager<T extends IHopMetadata> {
 
       return element;
     } catch (Exception e) {
-      new ErrorDialog(
-          hopGui.getActiveShell(), CONST_ERROR, "Error creating new metadata element", e);
+      if (SwtErrorHandler.handleException(e)) {
+        new ErrorDialog(
+            hopGui.getActiveShell(), CONST_ERROR, "Error creating new metadata element", e);
+      }
       return null;
     }
   }

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/delegates/HopGuiAuditDelegate.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/delegates/HopGuiAuditDelegate.java
@@ -38,6 +38,7 @@ import org.apache.hop.ui.hopgui.file.IHopFileTypeHandler;
 import org.apache.hop.ui.hopgui.perspective.IHopPerspective;
 import org.apache.hop.ui.hopgui.perspective.TabItemHandler;
 import org.apache.hop.ui.hopgui.perspective.metadata.MetadataPerspective;
+import org.apache.hop.ui.util.SwtErrorHandler;
 
 public class HopGuiAuditDelegate {
 
@@ -172,8 +173,10 @@ public class HopGuiAuditDelegate {
       }
 
     } catch (Exception e) {
-      throw new HopException(
-          "Error opening metadata object '" + name + "' of class " + className, e);
+      if (!SwtErrorHandler.handleException(e)) {
+        throw new HopException(
+            "Error opening metadata object '" + name + "' of class " + className, e);
+      }
     }
   }
 

--- a/ui/src/main/java/org/apache/hop/ui/util/SwtErrorHandler.java
+++ b/ui/src/main/java/org/apache/hop/ui/util/SwtErrorHandler.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.ui.util;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.SWTException;
+
+public final class SwtErrorHandler {
+
+  public static boolean handleException(Exception exception) {
+    return exception instanceof SWTException
+        && ((SWTException) exception).code == SWT.ERROR_WIDGET_DISPOSED;
+  }
+}


### PR DESCRIPTION
TabClosable.closeTab method is calling: disposed some dynamic ui widgets by MetadataPerspective.addEditor method, so should ignore dispose error of swt widgets