### PR TITLE
Fix corrected column name by DatabaseMetaData.getColumns api

### DIFF
--- a/core/src/main/java/org/apache/hop/core/row/value/ValueMetaTimestamp.java
+++ b/core/src/main/java/org/apache/hop/core/row/value/ValueMetaTimestamp.java
@@ -452,7 +452,7 @@ public class ValueMetaTimestamp extends ValueMetaDate {
       IVariables variables, DatabaseMeta databaseMeta, ResultSet rs) throws HopDatabaseException {
 
     try {
-      if (java.sql.Types.TIMESTAMP == rs.getInt("COLUMN_TYPE")) {
+      if (java.sql.Types.TIMESTAMP == rs.getInt("DATA_TYPE")) {
         IValueMeta vmi = super.getMetadataPreview(variables, databaseMeta, rs);
         IValueMeta valueMeta;
         if (databaseMeta.supportsTimestampDataType()) {


### PR DESCRIPTION
Change the column name to DATA_TYPE

JDK api DatabaseMetaData.getColumns:

1. TABLE_CAT String => table catalog (may be null)
2. TABLE_SCHEM String => table schema (may be null)
3. TABLE_NAME String => table name
4. COLUMN_NAME String => column name
5. DATA_TYPE int => SQL type from java.sql.Types
6. TYPE_NAME String => Data source dependent type name, for a UDT the type name is fully qualified
...