### PR TITLE
DELETE key is not working in the input fields of metadata #5293

### DIFF
--- a/ui/src/main/java/org/apache/hop/ui/hopgui/HopGuiKeyHandler.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/HopGuiKeyHandler.java
@@ -91,7 +91,8 @@ public class HopGuiKeyHandler extends KeyAdapter {
           || shortcut.toString().equals("Cmd+A")
           || shortcut.toString().equals("Ctrl+A")
           || shortcut.toString().equals("Cmd+X")
-          || shortcut.toString().equals("Ctrl+X")) {
+          || shortcut.toString().equals("Ctrl+X")
+          || shortcut.toString().equals("Delete")) {
         return false;
       }
     }


### PR DESCRIPTION
This is just a fix to get it working, but we need to review the key manager