### PR TITLE
Update mysql.adoc

### DIFF
--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/mysql.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/mysql.adoc
@@ -24,11 +24,11 @@ under the License.
 |===
 | Option | Info
 |Type | Relational
-|Driver | https://dev.mysql.com/downloads/connector/j/[Drivere Link] (Use Platform Independent)
+|Driver | https://dev.mysql.com/downloads/connector/j/[Driver Link] (Use Platform Independent)
 |Version Included | None
 |Hop Dependencies | None
 |Documentation | https://dev.mysql.com/doc/connector-j/8.0/en/[Documentation Link]
-|JDBC Url | jdbc:mysql://hostname:33060/databaseName
+|JDBC Url | jdbc:mysql://hostname:3306/databaseName
 |Driver folder | <Hop Installation>/lib/jdbc
 |===
 


### PR DESCRIPTION
Fixed a couple typos

A couple of typos fixed: the most important one is the default MySQL port number that should be 3306

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [ ] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [ ] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
