### PR TITLE
Initialize variables to prevent the use of null values

### DIFF
--- a/plugins/tech/neo4j/src/main/java/org/apache/hop/neo4j/model/GraphModel.java
+++ b/plugins/tech/neo4j/src/main/java/org/apache/hop/neo4j/model/GraphModel.java
@@ -53,6 +53,7 @@ public class GraphModel extends HopMetadataBase implements IHopMetadata {
   @HopMetadataProperty protected List<GraphRelationship> relationships;
 
   public GraphModel() {
+    name = "";
     nodes = new ArrayList<>();
     relationships = new ArrayList<>();
   }

--- a/plugins/tech/neo4j/src/main/java/org/apache/hop/neo4j/transforms/output/fields/NodeField.java
+++ b/plugins/tech/neo4j/src/main/java/org/apache/hop/neo4j/transforms/output/fields/NodeField.java
@@ -17,6 +17,7 @@
 
 package org.apache.hop.neo4j.transforms.output.fields;
 
+import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
@@ -38,4 +39,9 @@ public class NodeField {
       injectionKey = "",
       inlineListTags = {"label", "value"})
   private List<LabelField> labels;
+
+  public NodeField() {
+    properties = new ArrayList<>();
+    labels = new ArrayList<>();
+  }
 }


### PR DESCRIPTION
**Please** add a meaningful description for your change here
1. When the name variable is null, calling the equals() function may attempt to compare null values, resulting in a runtime exception.
  @Override
   public boolean equals(Object object) {
     if (object == null) {
       return false;
     }
     if (!(object instanceof GraphModel)) {
       return false;
     }
     if (object == this) {
       return true;
     }
     return name.equalsIgnoreCase(((GraphModel) object).getName());
   }
3. If labels is null, calling getLabels().isEmpty() will throw a NullPointerException because we're attempting to access methods on a null object in Neo4JOutputDialog.java.
final int fromLabelRows =
        (!input.getNodeFromField().getLabels().isEmpty()
            ? input.getNodeFromField().getLabels().size()
            : 10);
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [ ] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [ ] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
