### PR TITLE
Fix base directory assembly.xml of Database Procedure transformation

### DIFF
--- a/plugins/transforms/dbproc/src/assembly/assembly.xml
+++ b/plugins/transforms/dbproc/src/assembly/assembly.xml
@@ -23,7 +23,7 @@
     <formats>
         <format>zip</format>
     </formats>
-    <baseDirectory>plugins/transforms/dbproc</baseDirectory>
+    <baseDirectory>.</baseDirectory>
     <files>
         <file>
             <source>${project.basedir}/src/main/resources/version.xml</source>


### PR DESCRIPTION
The path is set in the ouput directory

```
    <baseDirectory>.</baseDirectory>
    <files>
        <file>
            <source>${project.basedir}/src/main/resources/version.xml</source>
            <outputDirectory>plugins/transforms/dbproc</outputDirectory>
            <filtered>true</filtered>
        </file>
    </files>
```