### PR TITLE
Fix last modified time for azure files

### DIFF
--- a/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/AzureFileObject.java
+++ b/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/AzureFileObject.java
@@ -171,12 +171,13 @@ public class AzureFileObject extends AbstractFileObject<AzureFileSystem> {
               });
           size = children.size();
           type = FileType.FOLDER;
-          lastModified = directoryClient.getProperties().getLastModified().toEpochSecond();
+          lastModified = directoryClient.getProperties().getLastModified().toEpochSecond() * 1000L;
         } else if (exists && isFile) {
           dataLakeFileClient = fileSystemClient.getFileClient(currentFilePath);
           size = dataLakeFileClient.getProperties().getFileSize();
           type = FileType.FILE;
-          lastModified = dataLakeFileClient.getProperties().getLastModified().toEpochSecond();
+          lastModified =
+              dataLakeFileClient.getProperties().getLastModified().toEpochSecond() * 1000L;
         } else {
           lastModified = 0;
           type = FileType.IMAGINARY;


### PR DESCRIPTION
The last modified time for Azure files were being set using seconds. new Date(lastModifiedTime) expects an epoch time in milliseconds. Google storage / local / dropbox  are properly using a last modified time in milliseconds, therefore they don't have any issue displaying it in the file browser / in transforms 

Fixes  #5451 (See before photos in linked issue)

Azure files after fix
![image](https://github.com/user-attachments/assets/3be60ba8-1498-472b-bc0c-aa81b25c4ff1)


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
