### PR TITLE
Fix #5492

### DIFF
--- a/docs/hop-user-manual/modules/ROOT/pages/hop-tools/hop-encrypt.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/hop-tools/hop-encrypt.adoc
@@ -156,3 +156,23 @@ OBF:1s3g1s3i1s3k1s3m
 --
 ====
 
+== Notes about using hop-encrypt on Windows
+
+When using the `hop-encrypt` tool on Windows, you may need to be aware about some characters that for Windows command line are considered as reserved characters and must be managed appropriately becuase otherwise the tool fails in encrypting your password.
+
+As documented at https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/cmd[this  page], on Windows, _the ampersand &, pipe |, and parentheses ( ) are special characters that must be preceded by the escape character ^ or quotation marks when you pass them as arguments_. Fort this reason when you run your hop-encrypt.bat command you should use the escape character ^ before the any of the special characters and the password's string must be passed between double quotes as shown in the following examples:
+
+
+--
+[source,shell]
+----
+./hop-encrypt.bat -hop "hello^&world"
+----
+
+--
+[source,shell]
+----
+./hop-encrypt.bat -server "hello^&world"
+----
+
+If you don't use the escape character ^ before the special characters and you don't put the clear text string between double quotes, the command is candidate to fail always.


### PR DESCRIPTION
Fix #5492 - hop-encrypt do not accept & characters in password to encrypt

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
