### PR TITLE
Re-add setter for TableViewModifyListener

### DIFF
--- a/ui/src/main/java/org/apache/hop/ui/core/widget/TableView.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/widget/TableView.java
@@ -3702,6 +3702,7 @@ public class TableView extends Composite {
     void delete(int[] items);
   }
 
+  @Setter
   private ITableViewModifyListener tableViewModifyListener =
       new ITableViewModifyListener() {
         @Override


### PR DESCRIPTION
2.13 switched to using lombok getter and setter annotations in the TableView class. The setter method for the TableViewModifyListener was deleted but the annotation was not added. Causes issues when upgrading from Hop 2.12 with custom plugins which override the default listener behaviour by setting their own.

addresses #5503

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
