### PR TITLE
Fix Add filenames to result action and File exists transform not finding cloud storage files when using azure/google authentication metadata

### DIFF
--- a/plugins/actions/addresultfilenames/src/main/java/org/apache/hop/workflow/actions/addresultfilenames/ActionAddResultFilenames.java
+++ b/plugins/actions/addresultfilenames/src/main/java/org/apache/hop/workflow/actions/addresultfilenames/ActionAddResultFilenames.java
@@ -190,7 +190,7 @@ public class ActionAddResultFilenames extends ActionBase implements Cloneable, I
     String realwildcard = resolve(wildcard);
 
     try {
-      filefolder = HopVfs.getFileObject(realFilefoldername);
+      filefolder = HopVfs.getFileObject(realFilefoldername, getVariables());
       if (filefolder.exists()) {
         // the file or folder exists
 
@@ -204,7 +204,7 @@ public class ActionAddResultFilenames extends ActionBase implements Cloneable, I
           ResultFile resultFile =
               new ResultFile(
                   ResultFile.FILE_TYPE_GENERAL,
-                  HopVfs.getFileObject(filefolder.toString()),
+                  HopVfs.getFileObject(filefolder.toString(), getVariables()),
                   parentWorkflow.getWorkflowName(),
                   toString());
           result.getResultFiles().put(resultFile.getFile().toString(), resultFile);
@@ -222,7 +222,7 @@ public class ActionAddResultFilenames extends ActionBase implements Cloneable, I
             ResultFile resultFile =
                 new ResultFile(
                     ResultFile.FILE_TYPE_GENERAL,
-                    HopVfs.getFileObject(list[i].toString()),
+                    HopVfs.getFileObject(list[i].toString(), getVariables()),
                     parentWorkflow.getWorkflowName(),
                     toString());
             result.getResultFiles().put(resultFile.getFile().toString(), resultFile);

--- a/plugins/transforms/fileexists/src/main/java/org/apache/hop/pipeline/transforms/fileexists/FileExists.java
+++ b/plugins/transforms/fileexists/src/main/java/org/apache/hop/pipeline/transforms/fileexists/FileExists.java
@@ -100,7 +100,7 @@ public class FileExists extends BaseTransform<FileExistsMeta, FileExistsData> {
       // get filename
       String filename = data.previousRowMeta.getString(r, data.indexOfFileename);
       if (!Utils.isEmpty(filename)) {
-        data.file = HopVfs.getFileObject(filename);
+        data.file = HopVfs.getFileObject(filename, variables);
 
         // Check if file
         fileexists = data.file.exists();


### PR DESCRIPTION
Switching these plugins to use the correct HopVfs getFileObject method so that the azure/google authentication metadata elements are properly added to the fsm providers map

See before in #5506 

Now these plugins are able to successfully locate the files
<img width="1412" height="551" alt="image" src="https://github.com/user-attachments/assets/aae7f108-0f94-4fd9-a087-437e885c6d46" />


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
