### PR TITLE
[#5602] updated substituteVariableResolvers when no secretValue

### DIFF
--- a/core/src/main/java/org/apache/hop/core/variables/Variables.java
+++ b/core/src/main/java/org/apache/hop/core/variables/Variables.java
@@ -242,9 +242,7 @@ public class Variables implements IVariables {
 
         // If we have a value to retrieve from the JSON we got back, we can do that:
         //
-        if (StringUtils.isEmpty(secretValue)) {
-          return resolvedArgument;
-        } else {
+        if (!StringUtils.isEmpty(secretValue)) {
           try {
             JSONObject js = (JSONObject) new JSONParser().parse(resolvedArgument);
             Object value = js.get(secretValue);


### PR DESCRIPTION
updated substituteVariableResolvers to ensure before + resolvedArguments + after is returned when there is no secretValue.

This pull request address #5602 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [ X ] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [ X ] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [ X ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ X ] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ X ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
