### PR TITLE
#5602 fix variable resolver substitution failing to preserve string

### DIFF
--- a/core/src/main/java/org/apache/hop/core/variables/Variables.java
+++ b/core/src/main/java/org/apache/hop/core/variables/Variables.java
@@ -168,9 +168,8 @@ public class Variables implements IVariables {
     while (startIndex < resolved.length()) {
       int resolverIndex = resolved.indexOf(StringUtil.RESOLVER_OPEN);
       if (resolverIndex < 0) {
-        // There's nothing more to do here.
-        //
-        return null;
+
+        return resolved;
       }
 
       // Is there a close token?
@@ -242,9 +241,7 @@ public class Variables implements IVariables {
 
         // If we have a value to retrieve from the JSON we got back, we can do that:
         //
-        if (StringUtils.isEmpty(secretValue)) {
-          return resolvedArgument;
-        } else {
+        if (!StringUtils.isEmpty(secretValue)) {
           try {
             JSONObject js = (JSONObject) new JSONParser().parse(resolvedArgument);
             Object value = js.get(secretValue);

--- a/integration-tests/resolver/0002-pipeline-resolver-test.hpl
+++ b/integration-tests/resolver/0002-pipeline-resolver-test.hpl
@@ -39,21 +39,6 @@ limitations under the License.
   </notepads>
   <order>
     <hop>
-      <from>get db1 configuration</from>
-      <to>db1</to>
-      <enabled>Y</enabled>
-    </hop>
-    <hop>
-      <from>get db2 configuration</from>
-      <to>db2</to>
-      <enabled>Y</enabled>
-    </hop>
-    <hop>
-      <from>get db3 configuration</from>
-      <to>db3</to>
-      <enabled>Y</enabled>
-    </hop>
-    <hop>
       <from>db1</from>
       <to>Union</to>
       <enabled>Y</enabled>
@@ -73,6 +58,36 @@ limitations under the License.
       <to>Validate</to>
       <enabled>Y</enabled>
     </hop>
+    <hop>
+      <from>get db1 configuration</from>
+      <to>db1 string substitution test</to>
+      <enabled>Y</enabled>
+    </hop>
+    <hop>
+      <from>db1 string substitution test</from>
+      <to>db1</to>
+      <enabled>Y</enabled>
+    </hop>
+    <hop>
+      <from>get db2 configuration</from>
+      <to>db2 string substitution test</to>
+      <enabled>Y</enabled>
+    </hop>
+    <hop>
+      <from>db2 string substitution test</from>
+      <to>db2</to>
+      <enabled>Y</enabled>
+    </hop>
+    <hop>
+      <from>get db3 configuration</from>
+      <to>db3 string substitution test</to>
+      <enabled>Y</enabled>
+    </hop>
+    <hop>
+      <from>db3 string substitution test</from>
+      <to>db3</to>
+      <enabled>Y</enabled>
+    </hop>
   </order>
   <transform>
     <name>Union</name>
@@ -87,7 +102,7 @@ limitations under the License.
     </partitioning>
     <attributes/>
     <GUI>
-      <xloc>432</xloc>
+      <xloc>816</xloc>
       <yloc>128</yloc>
     </GUI>
   </transform>
@@ -104,7 +119,7 @@ limitations under the License.
     </partitioning>
     <attributes/>
     <GUI>
-      <xloc>544</xloc>
+      <xloc>928</xloc>
       <yloc>128</yloc>
     </GUI>
   </transform>
@@ -121,7 +136,115 @@ limitations under the License.
     </partitioning>
     <attributes/>
     <GUI>
-      <xloc>304</xloc>
+      <xloc>688</xloc>
+      <yloc>64</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>db1 string substitution test</name>
+    <type>Calculator</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <calculation>
+      <calc_type>CONSTANT</calc_type>
+      <conversion_mask/>
+      <currency_symbol/>
+      <decimal_symbol/>
+      <field_a>Hostname: #{conf:db1:hostname}; Port: #{conf:db1:port}</field_a>
+      <field_b/>
+      <field_c/>
+      <field_name>hostname_constant</field_name>
+      <grouping_symbol/>
+      <remove>Y</remove>
+      <value_length>-1</value_length>
+      <value_precision>-1</value_precision>
+      <value_type>String</value_type>
+    </calculation>
+    <calculation>
+      <calc_type>SUBSTITUTE_VARIABLE</calc_type>
+      <conversion_mask/>
+      <currency_symbol/>
+      <decimal_symbol/>
+      <field_a>hostname_constant</field_a>
+      <field_b/>
+      <field_c/>
+      <field_name>hostname_str</field_name>
+      <grouping_symbol/>
+      <remove>N</remove>
+      <value_length>-1</value_length>
+      <value_precision>-1</value_precision>
+      <value_type>String</value_type>
+    </calculation>
+    <calculation>
+      <calc_type>CONSTANT</calc_type>
+      <conversion_mask/>
+      <currency_symbol/>
+      <decimal_symbol/>
+      <field_a>{ "json": [ #{conf:db1} ] }</field_a>
+      <field_b/>
+      <field_c/>
+      <field_name>json_constant</field_name>
+      <grouping_symbol/>
+      <remove>Y</remove>
+      <value_length>-1</value_length>
+      <value_precision>-1</value_precision>
+      <value_type>String</value_type>
+    </calculation>
+    <calculation>
+      <calc_type>SUBSTITUTE_VARIABLE</calc_type>
+      <conversion_mask/>
+      <currency_symbol/>
+      <decimal_symbol/>
+      <field_a>json_constant</field_a>
+      <field_b/>
+      <field_c/>
+      <field_name>json_str</field_name>
+      <grouping_symbol/>
+      <remove>N</remove>
+      <value_length>-1</value_length>
+      <value_precision>-1</value_precision>
+      <value_type>String</value_type>
+    </calculation>
+    <calculation>
+      <calc_type>CONSTANT</calc_type>
+      <conversion_mask/>
+      <currency_symbol/>
+      <decimal_symbol/>
+      <field_a>#{conf:db1:hostname}</field_a>
+      <field_b/>
+      <field_c/>
+      <field_name>hostname_2_constant</field_name>
+      <grouping_symbol/>
+      <remove>Y</remove>
+      <value_length>-1</value_length>
+      <value_precision>-1</value_precision>
+      <value_type>String</value_type>
+    </calculation>
+    <calculation>
+      <calc_type>SUBSTITUTE_VARIABLE</calc_type>
+      <conversion_mask/>
+      <currency_symbol/>
+      <decimal_symbol/>
+      <field_a>hostname_2_constant</field_a>
+      <field_b/>
+      <field_c/>
+      <field_name>hostname_2</field_name>
+      <grouping_symbol/>
+      <remove>N</remove>
+      <value_length>-1</value_length>
+      <value_precision>-1</value_precision>
+      <value_type>String</value_type>
+    </calculation>
+    <failIfNoFile>Y</failIfNoFile>
+    <attributes/>
+    <GUI>
+      <xloc>400</xloc>
       <yloc>64</yloc>
     </GUI>
   </transform>
@@ -138,7 +261,115 @@ limitations under the License.
     </partitioning>
     <attributes/>
     <GUI>
-      <xloc>304</xloc>
+      <xloc>688</xloc>
+      <yloc>128</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>db2 string substitution test</name>
+    <type>Calculator</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <calculation>
+      <calc_type>CONSTANT</calc_type>
+      <conversion_mask/>
+      <currency_symbol/>
+      <decimal_symbol/>
+      <field_a>Hostname: #{conf:db2:hostname}; Port: #{conf:db2:port}</field_a>
+      <field_b/>
+      <field_c/>
+      <field_name>hostname_constant</field_name>
+      <grouping_symbol/>
+      <remove>Y</remove>
+      <value_length>-1</value_length>
+      <value_precision>-1</value_precision>
+      <value_type>String</value_type>
+    </calculation>
+    <calculation>
+      <calc_type>SUBSTITUTE_VARIABLE</calc_type>
+      <conversion_mask/>
+      <currency_symbol/>
+      <decimal_symbol/>
+      <field_a>hostname_constant</field_a>
+      <field_b/>
+      <field_c/>
+      <field_name>hostname_str</field_name>
+      <grouping_symbol/>
+      <remove>N</remove>
+      <value_length>-1</value_length>
+      <value_precision>-1</value_precision>
+      <value_type>String</value_type>
+    </calculation>
+    <calculation>
+      <calc_type>CONSTANT</calc_type>
+      <conversion_mask/>
+      <currency_symbol/>
+      <decimal_symbol/>
+      <field_a>{ "json": [ #{conf:db2} ] }</field_a>
+      <field_b/>
+      <field_c/>
+      <field_name>json_constant</field_name>
+      <grouping_symbol/>
+      <remove>Y</remove>
+      <value_length>-1</value_length>
+      <value_precision>-1</value_precision>
+      <value_type>String</value_type>
+    </calculation>
+    <calculation>
+      <calc_type>SUBSTITUTE_VARIABLE</calc_type>
+      <conversion_mask/>
+      <currency_symbol/>
+      <decimal_symbol/>
+      <field_a>json_constant</field_a>
+      <field_b/>
+      <field_c/>
+      <field_name>json_str</field_name>
+      <grouping_symbol/>
+      <remove>N</remove>
+      <value_length>-1</value_length>
+      <value_precision>-1</value_precision>
+      <value_type>String</value_type>
+    </calculation>
+    <calculation>
+      <calc_type>CONSTANT</calc_type>
+      <conversion_mask/>
+      <currency_symbol/>
+      <decimal_symbol/>
+      <field_a>#{conf:db2:hostname}</field_a>
+      <field_b/>
+      <field_c/>
+      <field_name>hostname_2_constant</field_name>
+      <grouping_symbol/>
+      <remove>Y</remove>
+      <value_length>-1</value_length>
+      <value_precision>-1</value_precision>
+      <value_type>String</value_type>
+    </calculation>
+    <calculation>
+      <calc_type>SUBSTITUTE_VARIABLE</calc_type>
+      <conversion_mask/>
+      <currency_symbol/>
+      <decimal_symbol/>
+      <field_a>hostname_2_constant</field_a>
+      <field_b/>
+      <field_c/>
+      <field_name>hostname_2</field_name>
+      <grouping_symbol/>
+      <remove>N</remove>
+      <value_length>-1</value_length>
+      <value_precision>-1</value_precision>
+      <value_type>String</value_type>
+    </calculation>
+    <failIfNoFile>Y</failIfNoFile>
+    <attributes/>
+    <GUI>
+      <xloc>400</xloc>
       <yloc>128</yloc>
     </GUI>
   </transform>
@@ -155,7 +386,115 @@ limitations under the License.
     </partitioning>
     <attributes/>
     <GUI>
-      <xloc>304</xloc>
+      <xloc>688</xloc>
+      <yloc>192</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>db3 string substitution test</name>
+    <type>Calculator</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <calculation>
+      <calc_type>CONSTANT</calc_type>
+      <conversion_mask/>
+      <currency_symbol/>
+      <decimal_symbol/>
+      <field_a>Hostname: #{conf:db3:hostname}; Port: #{conf:db3:port}</field_a>
+      <field_b/>
+      <field_c/>
+      <field_name>hostname_constant</field_name>
+      <grouping_symbol/>
+      <remove>Y</remove>
+      <value_length>-1</value_length>
+      <value_precision>-1</value_precision>
+      <value_type>String</value_type>
+    </calculation>
+    <calculation>
+      <calc_type>SUBSTITUTE_VARIABLE</calc_type>
+      <conversion_mask/>
+      <currency_symbol/>
+      <decimal_symbol/>
+      <field_a>hostname_constant</field_a>
+      <field_b/>
+      <field_c/>
+      <field_name>hostname_str</field_name>
+      <grouping_symbol/>
+      <remove>N</remove>
+      <value_length>-1</value_length>
+      <value_precision>-1</value_precision>
+      <value_type>String</value_type>
+    </calculation>
+    <calculation>
+      <calc_type>CONSTANT</calc_type>
+      <conversion_mask/>
+      <currency_symbol/>
+      <decimal_symbol/>
+      <field_a>{ "json": [ #{conf:db3} ] }</field_a>
+      <field_b/>
+      <field_c/>
+      <field_name>json_constant</field_name>
+      <grouping_symbol/>
+      <remove>Y</remove>
+      <value_length>-1</value_length>
+      <value_precision>-1</value_precision>
+      <value_type>String</value_type>
+    </calculation>
+    <calculation>
+      <calc_type>SUBSTITUTE_VARIABLE</calc_type>
+      <conversion_mask/>
+      <currency_symbol/>
+      <decimal_symbol/>
+      <field_a>json_constant</field_a>
+      <field_b/>
+      <field_c/>
+      <field_name>json_str</field_name>
+      <grouping_symbol/>
+      <remove>N</remove>
+      <value_length>-1</value_length>
+      <value_precision>-1</value_precision>
+      <value_type>String</value_type>
+    </calculation>
+    <calculation>
+      <calc_type>CONSTANT</calc_type>
+      <conversion_mask/>
+      <currency_symbol/>
+      <decimal_symbol/>
+      <field_a>#{conf:db3:hostname}</field_a>
+      <field_b/>
+      <field_c/>
+      <field_name>hostname_2_constant</field_name>
+      <grouping_symbol/>
+      <remove>Y</remove>
+      <value_length>-1</value_length>
+      <value_precision>-1</value_precision>
+      <value_type>String</value_type>
+    </calculation>
+    <calculation>
+      <calc_type>SUBSTITUTE_VARIABLE</calc_type>
+      <conversion_mask/>
+      <currency_symbol/>
+      <decimal_symbol/>
+      <field_a>hostname_2_constant</field_a>
+      <field_b/>
+      <field_c/>
+      <field_name>hostname_2</field_name>
+      <grouping_symbol/>
+      <remove>N</remove>
+      <value_length>-1</value_length>
+      <value_precision>-1</value_precision>
+      <value_type>String</value_type>
+    </calculation>
+    <failIfNoFile>Y</failIfNoFile>
+    <attributes/>
+    <GUI>
+      <xloc>400</xloc>
       <yloc>192</yloc>
     </GUI>
   </transform>

--- a/integration-tests/resolver/datasets/0002-golden-pipeline-resolver.csv
+++ b/integration-tests/resolver/datasets/0002-golden-pipeline-resolver.csv
@@ -1,4 +1,4 @@
-hostname,port,db,username,password,variable
-hostname1,port1,db1,user1,port1,value1
-hostname2,port2,db2,user2,port2,value2
-hostname3,port3,db3,user3,port3,value3
+hostname,port,db,username,password,variable,hostname_str,json,hostname_2
+hostname1,port1,db1,user1,port1,value1,Hostname: hostname1; Port: port1,"{ ""json"": [ {""hostname"":""hostname1"",""password"":""pwd1"",""port"":""port1"",""variable"":""value1"",""db"":""db1"",""username"":""user1""} ] }",hostname1
+hostname2,port2,db2,user2,port2,value2,Hostname: hostname2; Port: port2,"{ ""json"": [ {""hostname"":""hostname2"",""password"":""pwd2"",""port"":""port2"",""variable"":""value2"",""db"":""db2"",""username"":""user2""} ] }",hostname2
+hostname3,port3,db3,user3,port3,value3,Hostname: hostname3; Port: port3,"{ ""json"": [ {""hostname"":""hostname3"",""password"":""pwd3"",""port"":""port3"",""variable"":""value3"",""db"":""db3"",""username"":""user3""} ] }",hostname3

--- a/integration-tests/resolver/metadata/dataset/0002-golden-pipeline-resolver.json
+++ b/integration-tests/resolver/metadata/dataset/0002-golden-pipeline-resolver.json
@@ -50,6 +50,30 @@
       "field_precision": -1,
       "field_name": "variable",
       "field_format": ""
+    },
+    {
+      "field_comment": "",
+      "field_length": -1,
+      "field_type": 2,
+      "field_precision": -1,
+      "field_name": "hostname_str",
+      "field_format": ""
+    },
+    {
+      "field_comment": "",
+      "field_length": -1,
+      "field_type": 2,
+      "field_precision": -1,
+      "field_name": "json",
+      "field_format": ""
+    },
+    {
+      "field_comment": "",
+      "field_length": -1,
+      "field_type": 2,
+      "field_precision": -1,
+      "field_name": "hostname_2",
+      "field_format": ""
     }
   ],
   "folder_name": ""

--- a/integration-tests/resolver/metadata/unit-test/0002-pipeline-resolver-test UNIT.json
+++ b/integration-tests/resolver/metadata/unit-test/0002-pipeline-resolver-test UNIT.json
@@ -32,6 +32,18 @@
         {
           "transform_field": "variable",
           "data_set_field": "variable"
+        },
+        {
+          "transform_field": "hostname_str",
+          "data_set_field": "hostname_str"
+        },
+        {
+          "transform_field": "json_str",
+          "data_set_field": "json"
+        },
+        {
+          "transform_field": "hostname_2",
+          "data_set_field": "hostname_2"
         }
       ],
       "field_order": [
@@ -40,7 +52,10 @@
         "db",
         "username",
         "password",
-        "variable"
+        "variable",
+        "hostname_str",
+        "json",
+        "hostname_2"
       ],
       "data_set_name": "0002-golden-pipeline-resolver",
       "transform_name": "Validate"


### PR DESCRIPTION
#5602 fix variable resolver substitution failing to preserve other components in string.  Added test to validate in future releases as well.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [ X ] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [ X ] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [ X ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ X ] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ X ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
