### PR TITLE
Update messages_en_US.properties

### DIFF
--- a/plugins/tech/cassandra/src/main/resources/org/apache/hop/databases/cassandra/metadata/messages/messages_en_US.properties
+++ b/plugins/tech/cassandra/src/main/resources/org/apache/hop/databases/cassandra/metadata/messages/messages_en_US.properties
@@ -42,4 +42,4 @@ CassandraMetadata.UseCompression.ToolTip=Check this option if you want to use co
 CassandraMetadata.Username.Label=Username
 CassandraMetadata.Username.ToolTip=The user to log in with
 CassandraConnection.name=Cassandra Connection
-CassandraConnection.desciption=Describes a connection to a Cassandra cluster
+CassandraConnection.description=Describes a connection to a Cassandra cluster


### PR DESCRIPTION
Fix typo on property key "CassandraConnection.desciption" (missing an 'r') that is referenced with the correct spelling "CassandraConnection.description" in this source file:

https://github.com/apache/hop/blob/bc34e15626767935bf4822d4bdf508fff054aad7/plugins/tech/cassandra/src/main/java/org/apache/hop/databases/cassandra/metadata/CassandraConnection.java#L43



------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [ ] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [ ] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ X  ] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
