### PR TITLE
fix context menu action "copy to clipboard" actually copying field va…

### DIFF
--- a/ui/src/main/java/org/apache/hop/ui/core/widget/TableView.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/widget/TableView.java
@@ -1397,7 +1397,7 @@ public class TableView extends Composite {
           OsHelper.customizeMenuitemText(
               BaseMessages.getString(PKG, "TableView.menu.CopyToClipboard")));
       miCopy.setImage(GuiResource.getInstance().getImageCopy());
-      miCopy.addListener(SWT.Selection, e -> copyToAll());
+      miCopy.addListener(SWT.Selection, e -> clipSelected());
       miCopy.setEnabled(!readonly);
     }
 
@@ -2282,7 +2282,7 @@ public class TableView extends Composite {
 
         for (int i = 1; i < lines.length; i++) {
           grid[i - 1] = lines[i].split("\t");
-          idx[i - 1] = rowNr + i;
+          idx[i - 1] = rowNr + i - 1;
           addItem(idx[i - 1], grid[i - 1]);
         }
 


### PR DESCRIPTION
adresses #5416  
- fixes: TableView undo after paste causing an Exception
- fixes: TableView context menu action "copy to clipboard" actually performing "copy field value to all rows"

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
