### PR TITLE
Issue #5730 (parquet file input improvements)

### DIFF
--- a/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/parquet-file-input.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/parquet-file-input.adoc
@@ -63,6 +63,11 @@ Make sure to allocate enough memory to allow this.
 Use a transform like Get File Names to obtain file names.
 Any supported file location is fine.
 
+|Metadata filename
+|If you specify a filename here, you can leave the fields section empty and Hop will automatically determine
+the output fields.  It prevents you from having to define all the fields when this metadata is already in
+a parquet file schema.
+
 |Fields
 |In this table you can specify all the fields you want to obtain from the parquet files as well as their desired Hop output type.
 

--- a/plugins/tech/parquet/src/main/java/org/apache/hop/parquet/transforms/input/ParquetReadSupport.java
+++ b/plugins/tech/parquet/src/main/java/org/apache/hop/parquet/transforms/input/ParquetReadSupport.java
@@ -20,6 +20,7 @@ package org.apache.hop.parquet.transforms.input;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import lombok.Getter;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hop.core.RowMetaAndData;
 import org.apache.parquet.hadoop.api.InitContext;
@@ -35,7 +36,7 @@ public class ParquetReadSupport extends ReadSupport<RowMetaAndData> {
     this.fields = fields;
   }
 
-  private MessageType messageType;
+  @Getter private MessageType messageType;
 
   @Override
   public ReadContext init(InitContext context) {
@@ -50,14 +51,5 @@ public class ParquetReadSupport extends ReadSupport<RowMetaAndData> {
       MessageType messageType,
       ReadContext readContext) {
     return new ParquetRecordMaterializer(messageType, fields);
-  }
-
-  /**
-   * Gets messageType
-   *
-   * @return value of messageType
-   */
-  public MessageType getMessageType() {
-    return messageType;
   }
 }

--- a/plugins/tech/parquet/src/main/resources/org/apache/hop/parquet/transforms/input/messages/messages_en_US.properties
+++ b/plugins/tech/parquet/src/main/resources/org/apache/hop/parquet/transforms/input/messages/messages_en_US.properties
@@ -28,3 +28,4 @@ ParquetInputDialog.FieldsColumn.TargetType.Label=Type
 ParquetInputDialog.FilenameField.Label=Filename field
 ParquetInputDialog.TransformName.Label=Transform name
 ParquetInputMeta.keyword=Parquet,input
+ParquetInputDialog.MetaFilename.Label = Metadata filename


### PR DESCRIPTION
The main challenge was figuring out how the int96 field translates to a Timestamp, something deprecated from Impala/Spark/Iceberg, in plugins/tech/parquet/src/main/java/org/apache/hop/parquet/transforms/input/ParquetValueConverter.java
