### PR TITLE
Issue #5685

### DIFF
--- a/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsonoutputenhanced/JsonOutput.java
+++ b/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsonoutputenhanced/JsonOutput.java
@@ -104,23 +104,30 @@ public class JsonOutput extends BaseTransform<JsonOutputMeta, JsonOutputData> {
 
     Object[] r = getRow(); // This also waits for a row to be finished.
     if (r == null) {
-      // no more input to be expected...
-      // Let's output the remaining unsafe data
-      outputRow(prevRow);
       // only attempt writing to file when the first row is not empty
       if (data.isWriteToFile && !first && meta.getSplitOutputAfter() == 0) {
+        // no more input to be expected...
+        // Let's output the remaining unsafe data
+        outputRow(prevRow);
+        writeJsonFile();
+      }
+
+      // Process the leftover data only when a split file size is defined
+      // and there are still items pending.
+      if (meta.getSplitOutputAfter() > 0 && !data.jsonItems.isEmpty()) {
+        serializeJson(data.jsonItems);
         writeJsonFile();
       }
       setOutputDone();
       return false;
     }
 
-    if (first && onFirstRecord(r)) return false;
+    if (first && onFirstRecord(r)) {
+      return false;
+    }
 
     data.rowsAreSafe = false;
-
     manageRowItems(r);
-
     return true;
   }
 


### PR DESCRIPTION
Fix https://github.com/apache/hop/issues/5685 - JSON output does not generate last file when split-after-n-records is activated

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
