### PR TITLE
Upgrade to Apache POM 35 and set compiler timestamp for reproducible build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>33</version>
+        <version>35</version>
     </parent>
 
     <groupId>org.apache.hop</groupId>
@@ -146,6 +146,7 @@
         <mockito-core.version>5.12.0</mockito-core.version>
         <objenesis.version>3.4</objenesis.version>
         <org.eclipse.platform.version>3.129.0</org.eclipse.platform.version>
+        <project.build.outputTimestamp>1695310533</project.build.outputTimestamp>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <set-highest-basedir-phase>initialize</set-highest-basedir-phase>


### PR DESCRIPTION
This PR updates to Apache POM 35 and set the compiler timestamp for have a clean reproducible build.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [X] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [X] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [X] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
