### PR TITLE
Fix #5754, propagate style in `ShowMessageDialog` 

### DIFF
--- a/core/src/main/java/org/apache/hop/core/Const.java
+++ b/core/src/main/java/org/apache/hop/core/Const.java
@@ -416,10 +416,6 @@ public class Const {
   /** UI-agnostic flag for warnings */
   public static final int INFO = 3;
 
-  public static final int SHOW_MESSAGE_DIALOG_DB_TEST_DEFAULT = 0;
-
-  public static final int SHOW_MESSAGE_DIALOG_DB_TEST_SUCCESS = 1;
-
   /** The margin between the text of a note and its border. */
   public static final int NOTE_MARGIN = 5;
 

--- a/ui/src/main/java/org/apache/hop/ui/core/database/DatabaseMetaEditor.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/database/DatabaseMetaEditor.java
@@ -964,8 +964,7 @@ public class DatabaseMetaEditor extends MetadataEditor<DatabaseMeta> {
   }
 
   /** Test the database connection */
-  public static final void testConnection(
-      Shell shell, IVariables variables, DatabaseMeta databaseMeta) {
+  public static void testConnection(Shell shell, IVariables variables, DatabaseMeta databaseMeta) {
     testConnection(shell, variables, databaseMeta, false);
   }
 
@@ -977,7 +976,7 @@ public class DatabaseMetaEditor extends MetadataEditor<DatabaseMeta> {
    * @param databaseMeta The database metadata
    * @param hideUrl Whether to hide URL information from the test results
    */
-  public static final void testConnection(
+  public static void testConnection(
       Shell shell, IVariables variables, DatabaseMeta databaseMeta, boolean hideUrl) {
     if (databaseMeta.isTestable()) {
       String[] remarks = databaseMeta.checkParameters();
@@ -1004,19 +1003,19 @@ public class DatabaseMetaEditor extends MetadataEditor<DatabaseMeta> {
         }
         ShowMessageDialog msgDialog =
             new ShowMessageDialog(
-                shell, SWT.ICON_INFORMATION | SWT.OK, title, message, message.length() > 300);
-        msgDialog.setType(
-            success
-                ? Const.SHOW_MESSAGE_DIALOG_DB_TEST_SUCCESS
-                : Const.SHOW_MESSAGE_DIALOG_DB_TEST_DEFAULT);
+                shell,
+                (success ? SWT.ICON_INFORMATION : SWT.ICON_ERROR) | SWT.OK | SWT.APPLICATION_MODAL,
+                title,
+                message,
+                message.length() > 300);
         msgDialog.open();
       } else {
         String message = "";
-        for (int i = 0; i < remarks.length; i++) {
-          message += "    * " + remarks[i] + Const.CR;
+        for (String remark : remarks) {
+          message += "    * " + remark + Const.CR;
         }
 
-        MessageBox mb = new MessageBox(shell, SWT.OK | SWT.ICON_ERROR);
+        MessageBox mb = new MessageBox(shell, SWT.OK | SWT.ICON_ERROR | SWT.APPLICATION_MODAL);
         mb.setText(BaseMessages.getString(PKG, "DatabaseDialog.ErrorParameters2.title"));
         mb.setMessage(
             BaseMessages.getString(PKG, "DatabaseDialog.ErrorParameters2.description", message));
@@ -1024,7 +1023,7 @@ public class DatabaseMetaEditor extends MetadataEditor<DatabaseMeta> {
       }
     } else {
       String message = databaseMeta.getPluginName();
-      MessageBox mb = new MessageBox(shell, SWT.OK | SWT.ICON_ERROR);
+      MessageBox mb = new MessageBox(shell, SWT.OK | SWT.ICON_ERROR | SWT.APPLICATION_MODAL);
       mb.setText(BaseMessages.getString(PKG, "DatabaseDialog.Testing.Disabled.title"));
       mb.setMessage(
           BaseMessages.getString(PKG, "DatabaseDialog.Testing.Disabled.description", message));

--- a/ui/src/main/java/org/apache/hop/ui/core/dialog/MessageBox.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/dialog/MessageBox.java
@@ -64,7 +64,7 @@ public class MessageBox extends Dialog {
 
   public int open() {
     Shell parent = getParent();
-    shell = new Shell(parent, SWT.DIALOG_TRIM | SWT.RESIZE | SWT.MAX | SWT.MIN);
+    shell = new Shell(parent, SWT.DIALOG_TRIM | SWT.RESIZE | SWT.MAX | SWT.MIN | style);
     PropsUi.setLook(shell);
     shell.setImage(GuiResource.getInstance().getImageHop());
     shell.setText(Const.NVL(text, ""));

--- a/ui/src/main/java/org/apache/hop/ui/core/dialog/ShowMessageDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/dialog/ShowMessageDialog.java
@@ -22,7 +22,6 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.hop.core.Const;
 import org.apache.hop.i18n.BaseMessages;
 import org.apache.hop.ui.core.PropsUi;
 import org.apache.hop.ui.core.gui.GuiResource;
@@ -63,18 +62,17 @@ public class ShowMessageDialog extends Dialog {
   private Shell shell;
   private PropsUi props;
 
-  private int flags;
+  private int style;
   private final Map<Integer, String> buttonTextByFlag;
 
   private int returnValue;
-  private int type;
 
   private Shell parent;
 
   private boolean scroll;
   private boolean hasIcon;
 
-  /** Timeout of dialog in seconds */
+  /** Timeout of the dialog in seconds */
   private int timeOut;
 
   private List<Button> buttons;
@@ -90,35 +88,35 @@ public class ShowMessageDialog extends Dialog {
    * Dialog to allow someone to show a text with an icon in front
    *
    * @param parent The parent shell to use
-   * @param flags the icon to show using SWT flags: SWT.ICON_WARNING, SWT.ICON_ERROR, ... Also
-   *     SWT.OK, SWT.CANCEL is allowed.
+   * @param style the icon to show using SWT flags: SWT.ICON_WARNING, SWT.ICON_ERROR, ... Also
+   *     SWT.OK, SWT.CANCEL, SWT.APPLICATION_MODAL, SWT.PRIMARY_MODAL, SWT.SYSTEM_MODAL is allowed.
    * @param title The dialog title
    * @param message The message to display
    */
-  public ShowMessageDialog(Shell parent, int flags, String title, String message) {
-    this(parent, flags, title, message, false);
+  public ShowMessageDialog(Shell parent, int style, String title, String message) {
+    this(parent, style, title, message, false);
   }
 
   /**
    * Dialog to allow someone to show a text with an icon in front
    *
    * @param parent The parent shell to use
-   * @param flags the icon to show using SWT flags: SWT.ICON_WARNING, SWT.ICON_ERROR, ... Also
-   *     SWT.OK, SWT.CANCEL is allowed.
+   * @param style the icon to show using SWT flags: SWT.ICON_WARNING, SWT.ICON_ERROR, ... Also
+   *     SWT.OK, SWT.CANCEL, SWT.APPLICATION_MODAL, SWT.PRIMARY_MODAL, SWT.SYSTEM_MODAL is allowed.
    * @param title The dialog title
    * @param message The message to display
    * @param scroll Set the dialog to a default size and enable scrolling
    */
-  public ShowMessageDialog(Shell parent, int flags, String title, String message, boolean scroll) {
-    this(parent, flags, buttonTextByFlagDefaults, title, message, scroll);
+  public ShowMessageDialog(Shell parent, int style, String title, String message, boolean scroll) {
+    this(parent, style, buttonTextByFlagDefaults, title, message, scroll);
   }
 
   /**
    * Dialog to allow someone to show a text with an icon in front
    *
    * @param parent The parent shell to use
-   * @param flags the icon to show using SWT flags: SWT.ICON_WARNING, SWT.ICON_ERROR, ... Also
-   *     SWT.OK, SWT.CANCEL is allowed.
+   * @param style the icon to show using SWT flags: SWT.ICON_WARNING, SWT.ICON_ERROR, ... Also
+   *     SWT.OK, SWT.CANCEL, SWT.APPLICATION_MODAL, SWT.PRIMARY_MODAL, SWT.SYSTEM_MODAL is allowed.
    * @param buttonTextByFlag Custom text to display for each button by flag i.e. key: SWT.OK, value:
    *     "Custom OK" Note - controls button order, use an ordered map to maintain button order.
    * @param title The dialog title
@@ -127,7 +125,7 @@ public class ShowMessageDialog extends Dialog {
    */
   public ShowMessageDialog(
       Shell parent,
-      int flags,
+      int style,
       Map<Integer, String> buttonTextByFlag,
       String title,
       String message,
@@ -135,7 +133,7 @@ public class ShowMessageDialog extends Dialog {
     super(parent, SWT.NONE);
     this.buttonTextByFlag = buttonTextByFlag;
     this.parent = parent;
-    this.flags = flags;
+    this.style = style;
     this.title = title;
     this.message = message;
     this.scroll = scroll;
@@ -146,37 +144,36 @@ public class ShowMessageDialog extends Dialog {
   public int open() {
     Display display = parent.getDisplay();
 
-    shell = new Shell(parent, SWT.DIALOG_TRIM | SWT.RESIZE);
+    shell = new Shell(parent, SWT.DIALOG_TRIM | SWT.RESIZE | style);
 
     PropsUi.setLook(shell);
     shell.setImage(GuiResource.getInstance().getImageHopUi());
-
     formLayout = new FormLayout();
     shell.setLayout(formLayout);
-
+    shell.setMinimumSize(600, 300);
     shell.setText(title);
 
     hasIcon =
-        (flags & SWT.ICON_WARNING) != 0
-            || (flags & SWT.ICON_INFORMATION) != 0
-            || (flags & SWT.ICON_QUESTION) != 0
-            || (flags & SWT.ICON_ERROR) != 0
-            || (flags & SWT.ICON_WORKING) != 0;
+        (style & SWT.ICON_WARNING) != 0
+            || (style & SWT.ICON_INFORMATION) != 0
+            || (style & SWT.ICON_QUESTION) != 0
+            || (style & SWT.ICON_ERROR) != 0
+            || (style & SWT.ICON_WORKING) != 0;
 
     Image image = null;
-    if ((flags & SWT.ICON_WARNING) != 0) {
+    if ((style & SWT.ICON_WARNING) != 0) {
       image = display.getSystemImage(SWT.ICON_WARNING);
     }
-    if ((flags & SWT.ICON_INFORMATION) != 0) {
+    if ((style & SWT.ICON_INFORMATION) != 0) {
       image = display.getSystemImage(SWT.ICON_INFORMATION);
     }
-    if ((flags & SWT.ICON_QUESTION) != 0) {
+    if ((style & SWT.ICON_QUESTION) != 0) {
       image = display.getSystemImage(SWT.ICON_QUESTION);
     }
-    if ((flags & SWT.ICON_ERROR) != 0) {
+    if ((style & SWT.ICON_ERROR) != 0) {
       image = display.getSystemImage(SWT.ICON_ERROR);
     }
-    if ((flags & SWT.ICON_WORKING) != 0) {
+    if ((style & SWT.ICON_WORKING) != 0) {
       image = display.getSystemImage(SWT.ICON_WORKING);
     }
 
@@ -218,7 +215,7 @@ public class ShowMessageDialog extends Dialog {
 
     for (Map.Entry<Integer, String> entry : buttonTextByFlag.entrySet()) {
       Integer buttonFlag = entry.getKey();
-      if ((flags & buttonFlag) != 0) {
+      if ((style & buttonFlag) != 0) {
         Button button = new Button(shell, SWT.PUSH);
         button.setText(entry.getValue());
         SelectionAdapter selectionAdapter =
@@ -234,7 +231,11 @@ public class ShowMessageDialog extends Dialog {
       }
     }
 
-    setLayoutAccordingToType();
+    int margin = PropsUi.getMargin();
+    formLayout.marginWidth = PropsUi.getFormMargin();
+    formLayout.marginHeight = PropsUi.getFormMargin();
+    setFdlDesc(margin * 2, margin, 0, margin);
+    BaseTransformDialog.positionBottomButtons(shell, buttons.toArray(new Button[0]), margin, null);
 
     // Detect [X] or ALT-F4 or something that kills this window...
     shell.addShellListener(
@@ -279,7 +280,7 @@ public class ShowMessageDialog extends Dialog {
   }
 
   private void cancel() {
-    if ((flags & SWT.NO) > 0) {
+    if ((style & SWT.NO) > 0) {
       quit(SWT.NO);
     } else {
       quit(SWT.CANCEL);
@@ -289,31 +290,6 @@ public class ShowMessageDialog extends Dialog {
   private void quit(int returnValue) {
     this.returnValue = returnValue;
     dispose();
-  }
-
-  /** Handles any variances in the UI from the default. */
-  private void setLayoutAccordingToType() {
-    int margin = PropsUi.getMargin();
-    switch (type) {
-      case Const.SHOW_MESSAGE_DIALOG_DB_TEST_SUCCESS:
-        formLayout.marginWidth = 15;
-        formLayout.marginHeight = 15;
-        setFdlDesc(margin * 3, 0, 0, margin);
-        BaseTransformDialog.positionBottomButtons(
-            shell,
-            buttons.toArray(new Button[buttons.size()]),
-            0,
-            BaseTransformDialog.BUTTON_ALIGNMENT_RIGHT,
-            wlDesc);
-        break;
-      default:
-        formLayout.marginWidth = PropsUi.getFormMargin();
-        formLayout.marginHeight = PropsUi.getFormMargin();
-        setFdlDesc(margin * 2, margin, 0, margin);
-        BaseTransformDialog.positionBottomButtons(
-            shell, buttons.toArray(new Button[buttons.size()]), margin, wlDesc);
-        break;
-    }
   }
 
   private void setFdlDesc(
@@ -339,9 +315,5 @@ public class ShowMessageDialog extends Dialog {
    */
   public void setTimeOut(int timeOut) {
     this.timeOut = timeOut;
-  }
-
-  public void setType(int type) {
-    this.type = type;
   }
 }

--- a/ui/src/main/java/org/apache/hop/ui/core/metadata/MetadataEditorDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/metadata/MetadataEditorDialog.java
@@ -52,8 +52,7 @@ public class MetadataEditorDialog extends Dialog implements IMetadataDialog {
   public String open() {
 
     Shell parent = getParent();
-    shell =
-        new Shell(parent, SWT.DIALOG_TRIM | SWT.RESIZE | SWT.MAX | SWT.MIN | SWT.APPLICATION_MODAL);
+    shell = new Shell(parent, SWT.DIALOG_TRIM | SWT.RESIZE | SWT.MAX | SWT.MIN | SWT.PRIMARY_MODAL);
     shell.setText(editor.getTitle());
     shell.setImage(editor.getTitleImage());
     FormLayout formLayout = new FormLayout();


### PR DESCRIPTION
- Simply displays the result of the database connection check with a different icon, rather than use a specific style.
- Remove core constants SHOW_MESSAGE_DIALOG_DB_TEST_DEFAULT, SHOW_MESSAGE_DIALOG_DB_TEST_SUCCESS.
