### PR TITLE
convert binary data when copying field, fixes #2140

### DIFF
--- a/plugins/transforms/calculator/src/main/java/org/apache/hop/pipeline/transforms/calculator/calculations/CopyField.java
+++ b/plugins/transforms/calculator/src/main/java/org/apache/hop/pipeline/transforms/calculator/calculations/CopyField.java
@@ -17,6 +17,7 @@
 
 package org.apache.hop.pipeline.transforms.calculator.calculations;
 
+import org.apache.hop.core.exception.HopValueException;
 import org.apache.hop.core.row.IValueMeta;
 import org.apache.hop.i18n.BaseMessages;
 import org.apache.hop.pipeline.transforms.calculator.CalculationInput;
@@ -43,7 +44,12 @@ public class CopyField implements ICalculation {
   }
 
   @Override
-  public CalculationOutput calculate(CalculationInput in) {
+  public CalculationOutput calculate(CalculationInput in) throws HopValueException {
+    if (in.dataA instanceof byte[] && in.metaA != null) {
+      Object convertedData = in.metaA.convertBinaryStringToNativeType((byte[]) in.dataA);
+      return new CalculationOutput(in.metaA.getType(), convertedData);
+    }
+
     return new CalculationOutput(ICalculation.getResultType(in.metaA), in.dataA);
   }
 }

--- a/plugins/transforms/calculator/src/test/java/org/apache/hop/pipeline/transforms/calculator/CalculatorMetaTest.java
+++ b/plugins/transforms/calculator/src/test/java/org/apache/hop/pipeline/transforms/calculator/CalculatorMetaTest.java
@@ -18,6 +18,7 @@ package org.apache.hop.pipeline.transforms.calculator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Random;
 import java.util.UUID;
@@ -53,7 +54,7 @@ class CalculatorMetaTest {
     for (int i = 0; i < meta.getFunctions().size(); i++) {
       CalculatorMetaFunction function = meta.getFunctions().get(i);
       CalculatorMetaFunction function2 = meta2.getFunctions().get(i);
-      assertEquals(function, function2);
+      assertTrue(function.equals(function2));
     }
   }
 


### PR DESCRIPTION
Altered the COPY_FIELD calculation to convert data from binary to native type in case lazy input is provided.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
