### PR TITLE
apply URL encoding in RestClient

### DIFF
--- a/plugins/transforms/rest/src/main/java/org/apache/hop/pipeline/transforms/rest/Rest.java
+++ b/plugins/transforms/rest/src/main/java/org/apache/hop/pipeline/transforms/rest/Rest.java
@@ -97,9 +97,9 @@ public class Rest extends BaseTransform<RestMeta, RestData> {
     // get dynamic url ?
     if (meta.isUrlInField()) {
       if (!Utils.isEmpty(data.connectionName)) {
-        data.realUrl = baseUrl + data.inputRowMeta.getString(rowData, data.indexOfUrlField);
+        data.realUrl = java.net.URLEncoder.encode(baseUrl + data.inputRowMeta.getString(rowData, data.indexOfUrlField), "UTF-8");
       } else {
-        data.realUrl = data.inputRowMeta.getString(rowData, data.indexOfUrlField);
+        data.realUrl = java.net.URLEncoder.encode(data.inputRowMeta.getString(rowData, data.indexOfUrlField), "UTF-8");
       }
     }
 
@@ -444,9 +444,9 @@ public class Rest extends BaseTransform<RestMeta, RestData> {
       } else {
         // Static URL
         if (!Utils.isEmpty(data.connectionName)) {
-          data.realUrl = baseUrl + NVL(resolve(meta.getUrl()), "");
+          data.realUrl = java.net.URLEncoder.encode(baseUrl + NVL(resolve(meta.getUrl()), ""), "UTF-8");
         } else {
-          data.realUrl = resolve(meta.getUrl());
+          data.realUrl = java.net.URLEncoder.encode(resolve(meta.getUrl()), "UTF-8");
         }
       }
       // Check Method


### PR DESCRIPTION
Since the current method of URL encoding is to use a User defined Java Expression (see #5201), I would propose to apply URL encoding in the RestCLient component.

This avoids the need to add an extra step just to do URL encoding, that currently forces a java expression to be written, and run on the janino run-time compiler.

It also prevents users from having to find out they need to do this themselves by running into an "Illegal character in path" error, see https://pentaho.home.blog/2019/05/18/create-url-for-rest-query/ .