### PR TITLE
Fix & speed up ByteArrayHashIndex #5972

### DIFF
--- a/core/src/test/java/org/apache/hop/core/hash/ByteArrayHashIndexTest.java
+++ b/core/src/test/java/org/apache/hop/core/hash/ByteArrayHashIndexTest.java
@@ -44,6 +44,9 @@ public class ByteArrayHashIndexTest {
 
     obj = new ByteArrayHashIndex(new RowMeta(), 99);
     assertEquals(128, obj.getSize());
+
+    obj = new ByteArrayHashIndex(new RowMeta(), 9);
+    assertEquals(0, obj.getCount());
   }
 
   @Test


### PR DESCRIPTION
Fix the resize upon first insertion of the ByteArrayHashIndex and speed it up a bit (#5972).

Microbenchmark [here](https://github.com/apache/hop/issues/5972)

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
