### PR TITLE
Issue #2369  - DimensionLookup: Option to not create unknown row 

### DIFF
--- a/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/dimensionlookup.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/dimensionlookup.adoc
@@ -99,6 +99,11 @@ For example, if you need to lookup different types of products like ORIGINAL_PRO
 Note that the new maximum is always cached, so that the maximum does not need to be calculated for each new row.
 * Use sequence: Specify the sequence name if you want to use a database sequence on the table connection to generate the technical key (typical for Oracle e.g.).
 * Use auto increment field: Use an auto increment field in the database table to generate the technical key (supported e.g. by DB2).
+
+|Do not check or insert the 'unknown' row
+|By default, Hop checks whether there is an 'unknown' record available at ID 0 or 1.
+If no such record is present in the dimension table, this transform adds it.
+If you check this option you indicate that you take responsibility for adding this record yourself.
 |===
 
 === Versioning tab

--- a/plugins/transforms/dimensionlookup/src/main/java/org/apache/hop/pipeline/transforms/dimensionlookup/DimensionLookup.java
+++ b/plugins/transforms/dimensionlookup/src/main/java/org/apache/hop/pipeline/transforms/dimensionlookup/DimensionLookup.java
@@ -1741,6 +1741,10 @@ public class DimensionLookup extends BaseTransform<DimensionLookupMeta, Dimensio
   }
 
   public void checkDimZero() throws HopException {
+    // Manually disabled
+    if (meta.isUnknownRowCheckDisabled()) {
+      return;
+    }
     // Don't insert anything when running in lookup mode.
     //
     if (!meta.isUpdate()) {

--- a/plugins/transforms/dimensionlookup/src/main/java/org/apache/hop/pipeline/transforms/dimensionlookup/DimensionLookupDialog.java
+++ b/plugins/transforms/dimensionlookup/src/main/java/org/apache/hop/pipeline/transforms/dimensionlookup/DimensionLookupDialog.java
@@ -113,6 +113,8 @@ public class DimensionLookupDialog extends BaseTransformDialog {
   private Button wSeqButton;
   private Text wSeq;
 
+  private Button wDisableUnknownUpdate;
+
   private Label wlVersion;
   private Combo wVersion;
 
@@ -611,6 +613,18 @@ public class DimensionLookupDialog extends BaseTransformDialog {
     wAutoIncrement.setText(
         BaseMessages.getString(PKG, "DimensionLookupDialog.AutoIncrement.Label"));
 
+    // Disable the unknown row check when updating a dimension?
+    //
+    wDisableUnknownUpdate = new Button(wTechnicalKeyComp, SWT.CHECK);
+    wDisableUnknownUpdate.setText(
+        BaseMessages.getString(PKG, "DimensionLookupDialog.DisableUnknownUpdate.Label"));
+    PropsUi.setLook(wDisableUnknownUpdate);
+    FormData fdDisableUnknownUpdate = new FormData();
+    fdDisableUnknownUpdate.left = new FormAttachment(0, 0);
+    fdDisableUnknownUpdate.top = new FormAttachment(gTechGroup, 2 * margin);
+    fdDisableUnknownUpdate.right = new FormAttachment(100, 0);
+    wDisableUnknownUpdate.setLayoutData(fdDisableUnknownUpdate);
+
     FormData fdTechnicalKeyComp = new FormData();
     fdTechnicalKeyComp.left = new FormAttachment(0, 0);
     fdTechnicalKeyComp.top = new FormAttachment(0, 0);
@@ -1049,6 +1063,10 @@ public class DimensionLookupDialog extends BaseTransformDialog {
 
     wlCacheSize.setEnabled(wUseCache.getSelection() && !wPreloadCache.getSelection());
     wCacheSize.setEnabled(wUseCache.getSelection() && !wPreloadCache.getSelection());
+
+    // The unknown record
+    //
+    wDisableUnknownUpdate.setEnabled(update);
   }
 
   protected void setComboBoxes() {
@@ -1125,6 +1143,7 @@ public class DimensionLookupDialog extends BaseTransformDialog {
     if (input.getConnection() != null) {
       wConnection.setText(input.getConnection());
     }
+    wDisableUnknownUpdate.setSelection(input.isUnknownRowCheckDisabled());
     wDateField.setText(Const.NVL(f.getDate().getName(), ""));
     wFromDate.setText(Const.NVL(f.getDate().getFrom(), ""));
     wToDate.setText(Const.NVL(f.getDate().getTo(), ""));
@@ -1255,6 +1274,7 @@ public class DimensionLookupDialog extends BaseTransformDialog {
     } else { // all the rest
       f.getReturns().setCreationMethod(TABLE_MAXIMUM);
     }
+    in.setUnknownRowCheckDisabled(wDisableUnknownUpdate.getSelection());
 
     f.getReturns().setVersionField(wVersion.getText());
     in.setConnection(wConnection.getText());

--- a/plugins/transforms/dimensionlookup/src/main/java/org/apache/hop/pipeline/transforms/dimensionlookup/DimensionLookupMeta.java
+++ b/plugins/transforms/dimensionlookup/src/main/java/org/apache/hop/pipeline/transforms/dimensionlookup/DimensionLookupMeta.java
@@ -21,6 +21,8 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hop.core.CheckResult;
 import org.apache.hop.core.Const;
@@ -169,6 +171,14 @@ public class DimensionLookupMeta extends BaseTransformMeta<DimensionLookup, Dime
       injectionKeyDescription = "DimensionLookup.Injection.PRELOAD_CACHE")
   private boolean preloadingCache;
 
+  @HopMetadataProperty(
+      key = "unknown_row_check_disabled",
+      injectionKey = "UNKNOWN_ROW_CHECK_DISABLED",
+      injectionKeyDescription = "DimensionLookup.Injection.UNKNOWN_ROW_CHECK_DISABLED")
+  @Getter
+  @Setter
+  private boolean unknownRowCheckDisabled;
+
   public DimensionLookupMeta() {
     super();
     this.fields = new DLFields();
@@ -201,6 +211,7 @@ public class DimensionLookupMeta extends BaseTransformMeta<DimensionLookup, Dime
     this.startDateAlternative = m.startDateAlternative;
     this.startDateFieldName = m.startDateFieldName;
     this.preloadingCache = m.preloadingCache;
+    this.unknownRowCheckDisabled = m.unknownRowCheckDisabled;
   }
 
   @Override
@@ -226,6 +237,7 @@ public class DimensionLookupMeta extends BaseTransformMeta<DimensionLookup, Dime
 
     cacheSize = 5000;
     preloadingCache = false;
+    unknownRowCheckDisabled = false;
   }
 
   @Override

--- a/plugins/transforms/dimensionlookup/src/main/resources/org/apache/hop/pipeline/transforms/dimensionlookup/messages/messages_en_US.properties
+++ b/plugins/transforms/dimensionlookup/src/main/resources/org/apache/hop/pipeline/transforms/dimensionlookup/messages/messages_en_US.properties
@@ -219,3 +219,4 @@ DimensionLookupMeta.TypeDesc.PunchThrough=Punch through
 DimensionLookupMeta.TypeDesc.Update=Update
 DimensionUpdate.Description=Update a slowly changing dimension in a data warehouse.\nAlternatively, look up information in this dimension.
 DimensionUpdate.Name=Dimension lookup/update
+DimensionLookupDialog.DisableUnknownUpdate.Label=Do not check or insert the 'unknown' record.


### PR DESCRIPTION
Couldn't possibly be more simple as a patch.

Issue #2369