### PR TITLE
Enhance calculator documentation with division warning

### DIFF
--- a/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/calculator.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/calculator.adoc
@@ -77,7 +77,9 @@ The table below lists the supported calculations in the `Calculator` transform:
 |A + B|ADD|A plus B.
 |A - B|SUBTRACT|A minus B.
 |A * B|MULTIPLY|A multiplied by B.
-|A / B|DIVIDE|A divided by B.
+|A / B|DIVIDE|A divided by B. +
+ +
+Beware: If A is an Integer and B a Number, it will automatically convert B to an Integer as well. This can lead to division by zero errors if B is less than 1.0 as it will be converted to 0
 |A * A|SQUARE|The square of A.
 |SQRT( A )|SQUARE_ROOT|The square root of A.
 |100 * A / B|PERCENT_1|Percentage of A in B.


### PR DESCRIPTION
Addresses #6110, added a warning about division by zero when using Integer and Number types.
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [ ] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [ ] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
