### PR TITLE
Fix the 0012-fuzzymatch.hpl unit test failure

### DIFF
--- a/integration-tests/transforms/metadata/unit-test/0012-fuzzymatch UNIT.json
+++ b/integration-tests/transforms/metadata/unit-test/0012-fuzzymatch UNIT.json
@@ -35,7 +35,7 @@
           "data_set_field": "measure value"
         },
         {
-          "transform_field": "name",
+          "transform_field": "lookupName",
           "data_set_field": "name"
         },
         {


### PR DESCRIPTION
Fix `0012-fuzzymatch.hpl`  "Unable to find output field 'name' while testing output of transform 'Output'"

fix: https://github.com/apache/hop/issues/6130