### PR TITLE
Remove redundant public modifiers from interface method return types

### DIFF
--- a/core/src/main/java/org/apache/hop/core/plugins/IPlugin.java
+++ b/core/src/main/java/org/apache/hop/core/plugins/IPlugin.java
@@ -118,7 +118,7 @@ public interface IPlugin {
   /**
    * @param keywords keywords describing this plugin
    */
-  public void setKeywords(String[] keywords);
+  void setKeywords(String[] keywords);
 
   URL getPluginDirectory();
 

--- a/core/src/main/java/org/apache/hop/core/row/IValueMetaConverter.java
+++ b/core/src/main/java/org/apache/hop/core/row/IValueMetaConverter.java
@@ -27,9 +27,9 @@ public interface IValueMetaConverter {
    * @return An object representing the value converted to targetMetaType. This value is suitable to
    *     use for
    */
-  public Object convertFromSourceToTargetDataType(
+  Object convertFromSourceToTargetDataType(
       int sourceValueMetaType, int targetValueMetaType, Object value)
       throws ValueMetaConversionException;
 
-  public void setDatePattern(SimpleDateFormat datePattern);
+  void setDatePattern(SimpleDateFormat datePattern);
 }

--- a/core/src/main/java/org/apache/hop/core/search/ISearchableCallback.java
+++ b/core/src/main/java/org/apache/hop/core/search/ISearchableCallback.java
@@ -28,5 +28,5 @@ public interface ISearchableCallback {
    * @param searchResult
    * @throws HopException
    */
-  public void callback(ISearchable searchable, ISearchResult searchResult) throws HopException;
+  void callback(ISearchable searchable, ISearchResult searchResult) throws HopException;
 }

--- a/core/src/main/java/org/apache/hop/i18n/IMessageHandler.java
+++ b/core/src/main/java/org/apache/hop/i18n/IMessageHandler.java
@@ -32,7 +32,7 @@ public interface IMessageHandler extends IHandler {
    * @param key
    * @return
    */
-  public String getString(String key);
+  String getString(String key);
 
   /**
    * get a key from the defined package bundle, by key
@@ -41,7 +41,7 @@ public interface IMessageHandler extends IHandler {
    * @param key
    * @return
    */
-  public String getString(String packageName, String key);
+  String getString(String packageName, String key);
 
   /**
    * get a key from the defined package bundle, by key
@@ -51,7 +51,7 @@ public interface IMessageHandler extends IHandler {
    * @param parameters
    * @return
    */
-  public String getString(String packageName, String key, String... parameters);
+  String getString(String packageName, String key, String... parameters);
 
   /**
    * Get a string from the defined package bundle, by key and by a resource class
@@ -62,6 +62,5 @@ public interface IMessageHandler extends IHandler {
    * @param parameters
    * @return
    */
-  public String getString(
-      String packageName, String key, Class<?> resourceClass, String... parameters);
+  String getString(String packageName, String key, Class<?> resourceClass, String... parameters);
 }

--- a/plugins/actions/ftp/src/main/java/org/apache/hop/workflow/actions/util/IFtpConnection.java
+++ b/plugins/actions/ftp/src/main/java/org/apache/hop/workflow/actions/util/IFtpConnection.java
@@ -129,5 +129,5 @@ public interface IFtpConnection {
    *
    * @return value of activeConnection
    */
-  public boolean isActiveConnection();
+  boolean isActiveConnection();
 }

--- a/plugins/misc/git/src/main/java/org/apache/hop/git/model/revision/ObjectRevision.java
+++ b/plugins/misc/git/src/main/java/org/apache/hop/git/model/revision/ObjectRevision.java
@@ -25,17 +25,17 @@ public interface ObjectRevision {
   /**
    * @return The internal name or number of the revision
    */
-  public String getRevisionId();
+  String getRevisionId();
 
   /**
    * @return The creation date of the revision
    */
-  public Date getCreationDate();
+  Date getCreationDate();
 
   /**
    * @return The user that caused the revision
    */
-  public String getLogin();
+  String getLogin();
 
   /**
    * The commit message


### PR DESCRIPTION
This PR removes the redundant `public` keywords to improve code clarity
and align with standard Java interface conventions.

No functional or behavioral changes are introduced.