### PR TITLE
Fix i18n key case mismatch for jdbc-metadata transform description

### DIFF
--- a/plugins/transforms/jdbc-metadata/src/main/java/org/apache/pipeline/transform/jdbcmetadata/JdbcMetadataMeta.java
+++ b/plugins/transforms/jdbc-metadata/src/main/java/org/apache/pipeline/transform/jdbcmetadata/JdbcMetadataMeta.java
@@ -42,7 +42,7 @@ import org.apache.hop.pipeline.transform.TransformMeta;
     id = "JdbcMetadata",
     image = "jdbcmetadata.svg",
     name = "i18n::JdbcMetadata.Name",
-    description = "i18n::JdbcMetaData.Description",
+    description = "i18n::JdbcMetadata.Description",
     categoryDescription = "i18n:org.apache.hop.pipeline.transform:BaseTransform.Category.Utility",
     keywords = "i18n::JdbcMetaData.keyword",
     documentationUrl = "/pipeline/transforms/jdbcmetadata.html")


### PR DESCRIPTION
This PR fixes an internationalization (i18n) issue in the Get JDBC Metadata transform.

The transform description was defined as:
```
description = "i18n::JdbcMetadata.Description"
```
However, the corresponding key in messages.properties was:
```
JdbcMetaData.Description=Get JDBC Metadata
```
Due to the case mismatch between JdbcMetadata and JdbcMetaData, the description was not resolved correctly at runtime and could result in missing or incorrect UI text.

<img width="1201" height="1227" alt="bb05ff4318155907d0c5f7c313e10ea" src="https://github.com/user-attachments/assets/599fbddf-29a9-4957-8886-0d5ceec45fdb" />
