### PR TITLE
Fix layout spacing issue for "Trusted Hosts" field in Mail Server Connection dialog

### DIFF
--- a/plugins/misc/mail/src/main/java/org/apache/hop/mail/metadata/MailServerConnectionEditor.java
+++ b/plugins/misc/mail/src/main/java/org/apache/hop/mail/metadata/MailServerConnectionEditor.java
@@ -313,7 +313,7 @@ public class MailServerConnectionEditor extends MetadataEditor<MailServerConnect
             BaseMessages.getString(PKG, "MailServerConnectionDialog.TrustedHosts.Tooltip"));
     FormData fdTrustedHosts = new FormData();
     fdTrustedHosts.left = new FormAttachment(0, 0);
-    fdTrustedHosts.top = new FormAttachment(wlCheckServerIdentity, 0);
+    fdTrustedHosts.top = new FormAttachment(wlCheckServerIdentity, margin + 5);
     fdTrustedHosts.right = new FormAttachment(100, 0);
     wTrustedHosts.setLayoutData(fdTrustedHosts);
     lastControl = wTrustedHosts;
@@ -475,7 +475,6 @@ public class MailServerConnectionEditor extends MetadataEditor<MailServerConnect
         mb.setText(BaseMessages.getString(PKG, "ActionGetPOP.Connected.Title.Ok"));
         mb.open();
       }
-      ;
     } catch (Exception e) {
       new ErrorDialog(hopGui.getShell(), "Error", "Error connecting mail server:", e);
     }


### PR DESCRIPTION
This PR fixes a UI layout issue in the `Mail Server Connection` dialog.

Previously, the `Trusted Hosts` text field was positioned too close to the `Check Server Identity` label, causing the top border of the `Trusted Hosts` input to be partially overlapped and not fully visible.

<img width="2269" height="739" alt="7c7d929b8702fafcbe02179cdc8503e" src="https://github.com/user-attachments/assets/b08f3222-8242-471a-bc84-c4249bfff7f5" />

No functional or behavioral changes are introduced.