### PR TITLE
Fix #6404 Do not add Pipeline Unit Test when dialog is cancelled or closed

### DIFF
--- a/plugins/misc/testing/src/main/java/org/apache/hop/testing/gui/TestingGuiPlugin.java
+++ b/plugins/misc/testing/src/main/java/org/apache/hop/testing/gui/TestingGuiPlugin.java
@@ -928,6 +928,12 @@ public class TestingGuiPlugin {
             hopGui.getShell());
     PipelineUnitTest test = manager.newMetadata();
     if (test != null) {
+      // If the user clicks Cancel or closes the window,
+      // the current unit test will not be added to the list.
+      if (Utils.isEmpty(test.getMetadataProviderName())) {
+        return;
+      }
+
       // Activate the test
       refreshUnitTestsList();
       selectUnitTest(pipelineMeta, test);


### PR DESCRIPTION
Fix https://github.com/apache/hop/issues/6404  

This PR fixes an issue in the `Hop GUI` where a `Pipeline Unit Test` is incorrectly added to the unit test list when the user clicks `Cancel` or `closes` the creation dialog.