### PR TITLE
Add left margin to "Do not show at startup" checkbox in welcome dialog

### DIFF
--- a/ui/src/main/java/org/apache/hop/ui/hopgui/welcome/WelcomeDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/welcome/WelcomeDialog.java
@@ -119,7 +119,7 @@ public class WelcomeDialog {
       PropsUi.setLook(doNotShow);
       FormData fdDoNotShow = new FormData();
       fdDoNotShow.bottom = new FormAttachment(100, 0);
-      fdDoNotShow.left = new FormAttachment(0, 0);
+      fdDoNotShow.left = new FormAttachment(0, margin);
       fdDoNotShow.right = new FormAttachment(100, 0);
       doNotShow.setLayoutData(fdDoNotShow);
 


### PR DESCRIPTION
This change adds a small left margin to the “Don’t show this at startup” checkbox on the welcome dialog.

No functional or behavioral changes are introduced.