### PR TITLE
Fix alignment issue of "Apply formatting" checkbox in Set Variables transform

### DIFF
--- a/plugins/transforms/setvariable/src/main/java/org/apache/hop/pipeline/transforms/setvariable/SetVariableDialog.java
+++ b/plugins/transforms/setvariable/src/main/java/org/apache/hop/pipeline/transforms/setvariable/SetVariableDialog.java
@@ -28,6 +28,7 @@ import org.apache.hop.i18n.BaseMessages;
 import org.apache.hop.pipeline.PipelineMeta;
 import org.apache.hop.pipeline.transform.TransformMeta;
 import org.apache.hop.ui.core.ConstUi;
+import org.apache.hop.ui.core.FormDataBuilder;
 import org.apache.hop.ui.core.PropsUi;
 import org.apache.hop.ui.core.dialog.BaseDialog;
 import org.apache.hop.ui.core.dialog.ErrorDialog;
@@ -128,18 +129,18 @@ public class SetVariableDialog extends BaseTransformDialog {
     wlFormat.setText(BaseMessages.getString(PKG, "SetVariableDialog.Format.Label"));
     wlFormat.setToolTipText(BaseMessages.getString(PKG, "SetVariableDialog.Format.Tooltip"));
     PropsUi.setLook(wlFormat);
-    FormData fdlFormat = new FormData();
-    fdlFormat.left = new FormAttachment(0, 0);
-    fdlFormat.right = new FormAttachment(middle, -margin);
-    fdlFormat.top = new FormAttachment(wTransformName, margin);
-    wlFormat.setLayoutData(fdlFormat);
+    wlFormat.setLayoutData(
+        FormDataBuilder.builder()
+            .top(wlTransformName, margin)
+            .left()
+            .right(middle, -margin)
+            .build());
+
     wFormat = new Button(shell, SWT.CHECK);
     wFormat.setToolTipText(BaseMessages.getString(PKG, "SetVariableDialog.Format.Tooltip"));
     PropsUi.setLook(wFormat);
-    FormData fdFormat = new FormData();
-    fdFormat.left = new FormAttachment(middle, 0);
-    fdFormat.top = new FormAttachment(wlFormat, 0, SWT.CENTER);
-    wFormat.setLayoutData(fdFormat);
+    wFormat.setLayoutData(
+        FormDataBuilder.builder().top(wTransformName, margin).left(middle, 0).build());
     wFormat.addSelectionListener(new ComponentSelectionListener(input));
 
     Label wlFields = new Label(shell, SWT.NONE);
@@ -150,7 +151,7 @@ public class SetVariableDialog extends BaseTransformDialog {
     fdlFields.top = new FormAttachment(wFormat, margin);
     wlFields.setLayoutData(fdlFields);
 
-    final int FieldsRows = input.getVariables().size();
+    final int fieldsRows = input.getVariables().size();
     colinf = new ColumnInfo[4];
     colinf[0] =
         new ColumnInfo(
@@ -184,7 +185,7 @@ public class SetVariableDialog extends BaseTransformDialog {
             shell,
             SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI,
             colinf,
-            FieldsRows,
+            fieldsRows,
             lsMod,
             props);
 
@@ -277,8 +278,8 @@ public class SetVariableDialog extends BaseTransformDialog {
     if (Utils.isEmpty(wTransformName.getText())) {
       return;
     }
-
-    transformName = wTransformName.getText(); // return value
+    // return value
+    transformName = wTransformName.getText();
 
     int count = wFields.nrNonEmpty();
 

--- a/plugins/transforms/setvariable/src/main/java/org/apache/hop/pipeline/transforms/setvariable/SetVariableMeta.java
+++ b/plugins/transforms/setvariable/src/main/java/org/apache/hop/pipeline/transforms/setvariable/SetVariableMeta.java
@@ -19,6 +19,8 @@ package org.apache.hop.pipeline.transforms.setvariable;
 
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.hop.core.CheckResult;
 import org.apache.hop.core.ICheckResult;
 import org.apache.hop.core.annotations.Transform;
@@ -32,6 +34,8 @@ import org.apache.hop.pipeline.transform.BaseTransformMeta;
 import org.apache.hop.pipeline.transform.TransformMeta;
 
 /** Sets environment variables based on content in certain fields of a single input row. */
+@Setter
+@Getter
 @Transform(
     id = "SetVariable",
     image = "setvariable.svg",
@@ -52,14 +56,6 @@ public class SetVariableMeta extends BaseTransformMeta<SetVariable, SetVariableD
   public SetVariableMeta() {
     super(); // allocate BaseTransformMeta
     variables = new ArrayList<>();
-  }
-
-  public List<VariableItem> getVariables() {
-    return variables;
-  }
-
-  public void setVariables(List<VariableItem> variables) {
-    this.variables = variables;
   }
 
   @Override
@@ -118,19 +114,5 @@ public class SetVariableMeta extends BaseTransformMeta<SetVariable, SetVariableD
               transformMeta);
       remarks.add(cr);
     }
-  }
-
-  /**
-   * @return the usingFormatting
-   */
-  public boolean isUsingFormatting() {
-    return usingFormatting;
-  }
-
-  /**
-   * @param usingFormatting the usingFormatting to set
-   */
-  public void setUsingFormatting(boolean usingFormatting) {
-    this.usingFormatting = usingFormatting;
   }
 }


### PR DESCRIPTION
Adjusted the top spacing/size of the “Apply formatting” checkbox

No functional or behavioral changes are introduced.