### PR TITLE
Refactor DelayMeta#setScaleTimeCode using JDK 17 switch expression

### DIFF
--- a/plugins/transforms/delay/src/main/java/org/apache/hop/pipeline/transforms/delay/DelayMeta.java
+++ b/plugins/transforms/delay/src/main/java/org/apache/hop/pipeline/transforms/delay/DelayMeta.java
@@ -88,40 +88,33 @@ public class DelayMeta extends BaseTransformMeta<Delay, DelayData> {
   }
 
   public void setScaleTimeCode(int scaleTimeIndex) {
-    switch (scaleTimeIndex) {
-      case 0:
-        scaletime = SCALE_TIME_CODE[0]; // milliseconds
-        break;
-      case 1:
-        scaletime = SCALE_TIME_CODE[1]; // second
-        break;
-      case 2:
-        scaletime = SCALE_TIME_CODE[2]; // minutes
-        break;
-      case 3:
-        scaletime = SCALE_TIME_CODE[3]; // hours
-        break;
-      default:
-        scaletime = SCALE_TIME_CODE[1]; // seconds
-        break;
-    }
+    scaletime =
+        switch (scaleTimeIndex) {
+            // milliseconds
+          case 0 -> SCALE_TIME_CODE[0];
+            // minutes
+          case 2 -> SCALE_TIME_CODE[2];
+            // hours
+          case 3 -> SCALE_TIME_CODE[3];
+            // seconds
+          default -> SCALE_TIME_CODE[1];
+        };
   }
 
   public int getScaleTimeCode() {
-    int retval = 1; // DEFAULT: seconds
+    // DEFAULT: seconds
+    int retval = 1;
     if (scaletime == null) {
       return retval;
     }
+
     if (scaletime.equals(SCALE_TIME_CODE[0])) {
       retval = 0;
-    } else if (scaletime.equals(SCALE_TIME_CODE[1])) {
-      retval = 1;
     } else if (scaletime.equals(SCALE_TIME_CODE[2])) {
       retval = 2;
     } else if (scaletime.equals(SCALE_TIME_CODE[3])) {
       retval = 3;
     }
-
     return retval;
   }
 
@@ -131,8 +124,10 @@ public class DelayMeta extends BaseTransformMeta<Delay, DelayData> {
 
   @Override
   public void setDefault() {
-    timeout = "1"; // default one second
-    scaletime = DEFAULT_SCALE_TIME; // defaults to "seconds"
+    // default one second
+    timeout = "1";
+    // defaults to "seconds"
+    scaletime = DEFAULT_SCALE_TIME;
     timeoutField = null;
     scaleTimeFromField = false;
     scaleTimeField = null;

--- a/plugins/transforms/delay/src/test/java/org/apache/hop/pipeline/transforms/delay/DelayMetaTest.java
+++ b/plugins/transforms/delay/src/test/java/org/apache/hop/pipeline/transforms/delay/DelayMetaTest.java
@@ -17,6 +17,11 @@
 
 package org.apache.hop.pipeline.transforms.delay;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -24,12 +29,23 @@ import java.util.Map;
 import org.apache.hop.core.exception.HopException;
 import org.apache.hop.junit.rules.RestoreHopEngineEnvironmentExtension;
 import org.apache.hop.pipeline.transforms.loadsave.LoadSaveTester;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
+/** Unit test for {@link DelayMeta} */
 class DelayMetaTest {
   @RegisterExtension
   static RestoreHopEngineEnvironmentExtension env = new RestoreHopEngineEnvironmentExtension();
+
+  private DelayMeta meta;
+
+  @BeforeEach
+  void setUp() {
+    meta = new DelayMeta();
+  }
 
   @Test
   void testTransformMeta() throws HopException {
@@ -54,5 +70,55 @@ class DelayMetaTest {
     LoadSaveTester<DelayMeta> loadSaveTester =
         new LoadSaveTester<>(DelayMeta.class, attributes, getterMap, setterMap);
     loadSaveTester.testSerialization();
+  }
+
+  @Test
+  void testSetDefault() {
+    meta.setDefault();
+
+    assertEquals("1", meta.getTimeout());
+    assertEquals("seconds", meta.getScaletime());
+    assertNull(meta.getTimeoutField());
+    assertFalse(meta.isScaleTimeFromField());
+    assertNull(meta.getScaleTimeField());
+  }
+
+  @ParameterizedTest(name = "index={0} <-> scaleTime={1}")
+  @CsvSource({"0, milliseconds", "1, seconds", "2, minutes", "3, hours"})
+  void testSetAndGetScaleTimeCode_Normal(int index, String expected) {
+    meta.setScaleTimeCode(index);
+
+    assertEquals(expected, meta.getScaletime());
+    assertEquals(index, meta.getScaleTimeCode());
+  }
+
+  @Test
+  void testGetScaleTimeCodeWhenNull() {
+    meta.setScaletime(null);
+    assertEquals(1, meta.getScaleTimeCode());
+  }
+
+  @Test
+  void testSetTimeoutFieldEmpty() {
+    meta.setTimeoutField("");
+    assertNull(meta.getTimeoutField());
+  }
+
+  @Test
+  void testSetTimeoutFieldValue() {
+    meta.setTimeoutField("timeout_col");
+    assertEquals("timeout_col", meta.getTimeoutField());
+  }
+
+  @Test
+  void testSetScaleTimeFieldEmpty() {
+    meta.setScaleTimeField("  ");
+    assertNotNull(meta.getScaleTimeField());
+  }
+
+  @Test
+  void testSetScaleTimeFieldValue() {
+    meta.setScaleTimeField("scale_col");
+    assertEquals("scale_col", meta.getScaleTimeField());
   }
 }


### PR DESCRIPTION
This PR refactors the setScaleTimeCode method in DelayMeta to use the JDK 17 switch expression.