### PR TITLE
Fix top margin for Set Fields button in SSTable Output component

### DIFF
--- a/plugins/tech/cassandra/src/main/java/org/apache/hop/pipeline/transforms/cassandrasstableoutput/SSTableOutputDialog.java
+++ b/plugins/tech/cassandra/src/main/java/org/apache/hop/pipeline/transforms/cassandrasstableoutput/SSTableOutputDialog.java
@@ -24,6 +24,7 @@ import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.i18n.BaseMessages;
 import org.apache.hop.pipeline.PipelineMeta;
 import org.apache.hop.pipeline.transform.TransformMeta;
+import org.apache.hop.ui.core.FormDataBuilder;
 import org.apache.hop.ui.core.PropsUi;
 import org.apache.hop.ui.core.dialog.BaseDialog;
 import org.apache.hop.ui.core.dialog.EnterSelectionDialog;
@@ -241,11 +242,7 @@ public class SSTableOutputDialog extends BaseTransformDialog {
     wbGetFields = new Button(shell, SWT.PUSH | SWT.CENTER);
     PropsUi.setLook(wbGetFields);
     wbGetFields.setText(BaseMessages.getString(PKG, "SSTableOutputDialog.GetFields.Button"));
-
-    fd = new FormData();
-    fd.right = new FormAttachment(100, 0);
-    fd.top = new FormAttachment(wTable, 0);
-    wbGetFields.setLayoutData(fd);
+    wbGetFields.setLayoutData(FormDataBuilder.builder().top(wTable, margin).right(100, 0).build());
 
     wbGetFields.addSelectionListener(
         new SelectionAdapter() {


### PR DESCRIPTION
This PR improves the UI layout of the `SSTable Output` transform in Apache Hop.

The `Set Fields` button was positioned too close to the component above it, resulting in a crowded appearance and reduced visual clarity. This change adjusts the top margin of the button to provide proper spacing and improve overall UI consistency.

No functional or behavioral changes are introduced.