### PR TITLE
Fix missing body parameters when uploading files via HTTP Post

### DIFF
--- a/plugins/transforms/httppost/src/main/java/org/apache/hop/pipeline/transforms/httppost/HttpPostArgumentField.java
+++ b/plugins/transforms/httppost/src/main/java/org/apache/hop/pipeline/transforms/httppost/HttpPostArgumentField.java
@@ -18,8 +18,12 @@
 package org.apache.hop.pipeline.transforms.httppost;
 
 import java.util.Objects;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.hop.metadata.api.HopMetadataProperty;
 
+@Getter
+@Setter
 public class HttpPostArgumentField {
 
   @HopMetadataProperty(injectionKeyDescription = "HTTPPOST.Injection.ArgumentFieldName")
@@ -30,30 +34,6 @@ public class HttpPostArgumentField {
 
   @HopMetadataProperty(injectionKeyDescription = "HTTPPOST.Injection.ArgumentFieldHeader")
   private boolean header;
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public String getParameter() {
-    return parameter;
-  }
-
-  public void setParameter(String parameter) {
-    this.parameter = parameter;
-  }
-
-  public boolean isHeader() {
-    return header;
-  }
-
-  public void setHeader(boolean header) {
-    this.header = header;
-  }
 
   public HttpPostArgumentField(String name, String parameter, boolean header) {
     this.name = name;
@@ -71,8 +51,12 @@ public class HttpPostArgumentField {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     HttpPostArgumentField that = (HttpPostArgumentField) o;
     return header == that.header
         && Objects.equals(name, that.name)

--- a/plugins/transforms/httppost/src/main/java/org/apache/hop/pipeline/transforms/httppost/HttpPostDialog.java
+++ b/plugins/transforms/httppost/src/main/java/org/apache/hop/pipeline/transforms/httppost/HttpPostDialog.java
@@ -456,7 +456,7 @@ public class HttpPostDialog extends BaseTransformDialog {
     fdFields.left = new FormAttachment(0, 0);
     fdFields.top = new FormAttachment(wlFields, margin);
     fdFields.right = new FormAttachment(wGetBodyParam, -margin);
-    fdFields.bottom = new FormAttachment(wlFields, 200);
+    fdFields.bottom = new FormAttachment(wlFields, 300);
     wFields.setLayoutData(fdFields);
     return wGetBodyParam;
   }

--- a/plugins/transforms/httppost/src/main/java/org/apache/hop/pipeline/transforms/httppost/HttpPostLookupField.java
+++ b/plugins/transforms/httppost/src/main/java/org/apache/hop/pipeline/transforms/httppost/HttpPostLookupField.java
@@ -19,8 +19,12 @@ package org.apache.hop.pipeline.transforms.httppost;
 
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.hop.metadata.api.HopMetadataProperty;
 
+@Setter
+@Getter
 public class HttpPostLookupField {
 
   @HopMetadataProperty(
@@ -32,22 +36,6 @@ public class HttpPostLookupField {
       key = "arg",
       injectionGroupDescription = "HTTPPOST.Injection.LookupArgumentField")
   private List<HttpPostArgumentField> argumentField = new ArrayList<>();
-
-  public List<HttpPostQuery> getQueryField() {
-    return queryField;
-  }
-
-  public void setQueryField(List<HttpPostQuery> queryField) {
-    this.queryField = queryField;
-  }
-
-  public List<HttpPostArgumentField> getArgumentField() {
-    return argumentField;
-  }
-
-  public void setArgumentField(List<HttpPostArgumentField> argumentField) {
-    this.argumentField = argumentField;
-  }
 
   public HttpPostLookupField(
       List<HttpPostQuery> postQuery, List<HttpPostArgumentField> argumentField) {

--- a/plugins/transforms/httppost/src/main/java/org/apache/hop/pipeline/transforms/httppost/HttpPostMeta.java
+++ b/plugins/transforms/httppost/src/main/java/org/apache/hop/pipeline/transforms/httppost/HttpPostMeta.java
@@ -19,6 +19,8 @@ package org.apache.hop.pipeline.transforms.httppost;
 
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.hop.core.CheckResult;
 import org.apache.hop.core.ICheckResult;
 import org.apache.hop.core.annotations.Transform;
@@ -36,6 +38,8 @@ import org.apache.hop.pipeline.PipelineMeta;
 import org.apache.hop.pipeline.transform.BaseTransformMeta;
 import org.apache.hop.pipeline.transform.TransformMeta;
 
+@Setter
+@Getter
 @Transform(
     id = "HttpPost",
     image = "httppost.svg",
@@ -116,144 +120,6 @@ public class HttpPostMeta extends BaseTransformMeta<HttpPost, HttpPostData> {
 
   public HttpPostMeta() {
     super(); // allocate BaseTransformMeta
-  }
-
-  public String getEncoding() {
-    return encoding;
-  }
-
-  public void setEncoding(String encoding) {
-    this.encoding = encoding;
-  }
-
-  /**
-   * @return Returns the connectionTimeout.
-   */
-  public String getConnectionTimeout() {
-    return connectionTimeout;
-  }
-
-  /**
-   * @param connectionTimeout The connectionTimeout to set.
-   */
-  public void setConnectionTimeout(String connectionTimeout) {
-    this.connectionTimeout = connectionTimeout;
-  }
-
-  /**
-   * @return Returns the closeIdleConnectionsTime.
-   */
-  public String getCloseIdleConnectionsTime() {
-    return closeIdleConnectionsTime;
-  }
-
-  /**
-   * @param closeIdleConnectionsTime The connectionTimeout to set.
-   */
-  public void setCloseIdleConnectionsTime(String closeIdleConnectionsTime) {
-    this.closeIdleConnectionsTime = closeIdleConnectionsTime;
-  }
-
-  /**
-   * @return Returns the socketTimeout.
-   */
-  public String getSocketTimeout() {
-    return socketTimeout;
-  }
-
-  /**
-   * @param socketTimeout The socketTimeout to set.
-   */
-  public void setSocketTimeout(String socketTimeout) {
-    this.socketTimeout = socketTimeout;
-  }
-
-  /**
-   * @return Returns the procedure.
-   */
-  public String getUrl() {
-    return url;
-  }
-
-  /**
-   * @param procedure The procedure to set.
-   */
-  public void setUrl(String procedure) {
-    this.url = procedure;
-  }
-
-  /**
-   * @return Is the url coded in a field?
-   */
-  public boolean isUrlInField() {
-    return urlInField;
-  }
-
-  public boolean isPostAFile() {
-    return postAFile;
-  }
-
-  public void setPostAFile(boolean postafile) {
-    this.postAFile = postafile;
-  }
-
-  public boolean isMultipartupload() {
-    return multipartupload;
-  }
-
-  public void setMultipartupload(boolean multipartupload) {
-    this.multipartupload = multipartupload;
-  }
-
-  /**
-   * @param urlInField Is the url coded in a field?
-   */
-  public void setUrlInField(boolean urlInField) {
-    this.urlInField = urlInField;
-  }
-
-  /**
-   * @return The field name that contains the url.
-   */
-  public String getUrlField() {
-    return urlField;
-  }
-
-  /**
-   * @param urlField name of the field that contains the url
-   */
-  public void setUrlField(String urlField) {
-    this.urlField = urlField;
-  }
-
-  /**
-   * @param requestEntity the requestEntity to set
-   */
-  public void setRequestEntity(String requestEntity) {
-    this.requestEntity = requestEntity;
-  }
-
-  /**
-   * @return requestEntity
-   */
-  public String getRequestEntity() {
-    return requestEntity;
-  }
-
-  public List<HttpPostLookupField> getLookupFields() {
-    return lookupFields;
-  }
-
-  public void setLookupFields(List<HttpPostLookupField> lookupFields) {
-    this.lookupFields = lookupFields;
-  }
-
-  public List<HttpPostResultField> getResultFields() {
-    return resultFields;
-  }
-
-  public void setResultFields(List<HttpPostResultField> resultFields) {
-    this.resultFields = resultFields;
   }
 
   @Override
@@ -374,83 +240,5 @@ public class HttpPostMeta extends BaseTransformMeta<HttpPost, HttpPostData> {
   @Override
   public boolean supportsErrorHandling() {
     return true;
-  }
-
-  /**
-   * ISetter
-   *
-   * @param proxyHost
-   */
-  public void setProxyHost(String proxyHost) {
-    this.proxyHost = proxyHost;
-  }
-
-  /**
-   * IGetter
-   *
-   * @return
-   */
-  public String getProxyHost() {
-    return proxyHost;
-  }
-
-  /**
-   * ISetter
-   *
-   * @param proxyPort
-   */
-  public void setProxyPort(String proxyPort) {
-    this.proxyPort = proxyPort;
-  }
-
-  /**
-   * IGetter
-   *
-   * @return
-   */
-  public String getProxyPort() {
-    return this.proxyPort;
-  }
-
-  /**
-   * ISetter
-   *
-   * @param httpLogin
-   */
-  public void setHttpLogin(String httpLogin) {
-    this.httpLogin = httpLogin;
-  }
-
-  /**
-   * IGetter
-   *
-   * @return
-   */
-  public String getHttpLogin() {
-    return httpLogin;
-  }
-
-  /**
-   * ISetter
-   *
-   * @param httpPassword
-   */
-  public void setHttpPassword(String httpPassword) {
-    this.httpPassword = httpPassword;
-  }
-
-  /**
-   * @return
-   */
-  public String getHttpPassword() {
-    return httpPassword;
-  }
-
-  public boolean isIgnoreSsl() {
-    return ignoreSsl;
-  }
-
-  public void setIgnoreSsl(boolean ignoreSsl) {
-    this.ignoreSsl = ignoreSsl;
   }
 }

--- a/plugins/transforms/httppost/src/main/java/org/apache/hop/pipeline/transforms/httppost/HttpPostQuery.java
+++ b/plugins/transforms/httppost/src/main/java/org/apache/hop/pipeline/transforms/httppost/HttpPostQuery.java
@@ -18,8 +18,12 @@
 package org.apache.hop.pipeline.transforms.httppost;
 
 import java.util.Objects;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.hop.metadata.api.HopMetadataProperty;
 
+@Setter
+@Getter
 public class HttpPostQuery {
 
   @HopMetadataProperty(injectionKeyDescription = "HTTPPOST.Injection.QueryFieldName")
@@ -27,22 +31,6 @@ public class HttpPostQuery {
 
   @HopMetadataProperty(injectionKeyDescription = "HTTPPOST.Injection.QueryFieldParameter")
   private String parameter;
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public String getParameter() {
-    return parameter;
-  }
-
-  public void setParameter(String parameter) {
-    this.parameter = parameter;
-  }
 
   public HttpPostQuery(String name, String parameter) {
     this.name = name;
@@ -58,8 +46,12 @@ public class HttpPostQuery {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     HttpPostQuery that = (HttpPostQuery) o;
     return Objects.equals(name, that.name) && Objects.equals(parameter, that.parameter);
   }

--- a/plugins/transforms/httppost/src/main/java/org/apache/hop/pipeline/transforms/httppost/HttpPostResultField.java
+++ b/plugins/transforms/httppost/src/main/java/org/apache/hop/pipeline/transforms/httppost/HttpPostResultField.java
@@ -18,8 +18,12 @@
 package org.apache.hop.pipeline.transforms.httppost;
 
 import java.util.Objects;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.hop.metadata.api.HopMetadataProperty;
 
+@Setter
+@Getter
 public class HttpPostResultField {
 
   @HopMetadataProperty(injectionKeyDescription = "HTTPPOST.Injection.ResultFieldCode")
@@ -37,38 +41,6 @@ public class HttpPostResultField {
       key = "response_header",
       injectionKeyDescription = "HTTPPOST.Injection.ResultFieldResponseHeader")
   private String responseHeaderFieldName;
-
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public String getResponseTimeFieldName() {
-    return responseTimeFieldName;
-  }
-
-  public void setResponseTimeFieldName(String responseTimeFieldName) {
-    this.responseTimeFieldName = responseTimeFieldName;
-  }
-
-  public String getResponseHeaderFieldName() {
-    return responseHeaderFieldName;
-  }
-
-  public void setResponseHeaderFieldName(String responseHeaderFieldName) {
-    this.responseHeaderFieldName = responseHeaderFieldName;
-  }
 
   public HttpPostResultField(
       String code, String name, String responseTimeFieldName, String responseHeaderFieldName) {
@@ -91,8 +63,12 @@ public class HttpPostResultField {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     HttpPostResultField that = (HttpPostResultField) o;
     return Objects.equals(code, that.code)
         && Objects.equals(name, that.name)


### PR DESCRIPTION
Fixed: https://github.com/apache/hop/issues/6480

This PR fixes an issue where body parameters were lost when sending multipart `HTTP POST` requests with file uploads.

### Fix
- Use a single `MultipartEntityBuilder` to collect **both**:
  - text body parameters
  - binary file parts
- Defer building and setting the request entity until all parts have been added
- Ensure body parameters are preserved when file upload is enabled