### PR TITLE
Support TLS ingress for Hop Web in Helm chart Fix #6503

### DIFF
--- a/helm/hop/templates/hop-web/web-ingress.yaml
+++ b/helm/hop/templates/hop-web/web-ingress.yaml
@@ -34,6 +34,19 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
+{{- if .Values.web.ingress.className }}
+  ingressClassName: {{ .Values.web.ingress.className }}
+{{- end }}
+{{- if .Values.web.ingress.tls }}
+  tls:
+  {{- range .Values.web.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
   rules:
   {{- if .Values.web.ingress.hosts  }}
   {{- range .Values.web.ingress.hosts }}


### PR DESCRIPTION
This PR implements the proposed feature described in issue #6503 to support Hop Web TLS in the Helm chart.