### PR TITLE
Fix NoSuchMethodError in Hop Web when changing GUI options

### DIFF
--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/configuration/tabs/ConfigGuiOptionsTab.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/configuration/tabs/ConfigGuiOptionsTab.java
@@ -32,6 +32,7 @@ import org.apache.hop.ui.core.dialog.ErrorDialog;
 import org.apache.hop.ui.core.gui.GuiResource;
 import org.apache.hop.ui.hopgui.HopGui;
 import org.apache.hop.ui.hopgui.perspective.configuration.ConfigurationPerspective;
+import org.apache.hop.ui.util.EnvironmentUtils;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
@@ -165,9 +166,12 @@ public class ConfigGuiOptionsTab {
       wHideMenuBar.setSelection(props.isHidingMenuBar());
       wShowTableViewToolbar.setSelection(props.isShowTableViewToolbar());
       // On macOS (and other non-Windows), dark mode follows system; sync from system so UI and
-      // props match
-      boolean darkMode = Const.isWindows() ? props.isDarkMode() : Display.isSystemDarkTheme();
-      if (!Const.isWindows()) {
+      // props match. In Web environment, isSystemDarkTheme() is not available.
+      boolean darkMode;
+      if (EnvironmentUtils.getInstance().isWeb() || Const.isWindows()) {
+        darkMode = props.isDarkMode();
+      } else {
+        darkMode = Display.isSystemDarkTheme();
         props.setDarkMode(darkMode);
       }
       wDarkMode.setSelection(darkMode);
@@ -941,8 +945,13 @@ public class ConfigGuiOptionsTab {
     props.setInfiniteCanvasMoveEnabled(wEnableInfiniteMove.getSelection());
     props.setZoomScrollingDisabled(wDisableZoomScrolling.getSelection());
     // On macOS (and other non-Windows), dark mode follows system; persist system theme, not
-    // checkbox
-    boolean darkMode = Const.isWindows() ? wDarkMode.getSelection() : Display.isSystemDarkTheme();
+    // checkbox. In Web environment, isSystemDarkTheme() is not available.
+    boolean darkMode;
+    if (EnvironmentUtils.getInstance().isWeb() || Const.isWindows()) {
+      darkMode = wDarkMode.getSelection();
+    } else {
+      darkMode = Display.isSystemDarkTheme();
+    }
     props.setDarkMode(darkMode);
     props.setHidingMenuBar(wHideMenuBar.getSelection());
     props.setShowTableViewToolbar(wShowTableViewToolbar.getSelection());


### PR DESCRIPTION
## Problem
  When using Hop Web (RAP-based web interface) and changing locale or other GUI options, the application crashes with HTTP 500 error:

  java.lang.NoSuchMethodError: 'boolean org.eclipse.swt.widgets.Display.isSystemDarkTheme()'
      at org.apache.hop.ui.hopgui.perspective.configuration.tabs.ConfigGuiOptionsTab.saveValues(ConfigGuiOptionsTab.java:945)

  ## Root Cause
  `Display.isSystemDarkTheme()` is a desktop SWT API that is not available in Eclipse RAP (Web environment). The `ConfigGuiOptionsTab` class calls this method without checking if running in
   web mode.

  ## Solution
  Added `EnvironmentUtils.getInstance().isWeb()` check before calling `Display.isSystemDarkTheme()`:
  - In web environment or Windows: use the stored/selected dark mode preference
  - In desktop non-Windows (macOS/Linux): detect system theme as before

  ## Changes
  - `ui/src/main/java/.../ConfigGuiOptionsTab.java`
    - `reloadValues()` method
    - `saveValues()` method

  ## Testing
  - Tested on Hop Web 2.18.0-SNAPSHOT (Docker container with Tomcat 10)
  - Verified locale can be changed to Chinese without errors
  - Dark mode toggle works correctly in both Web and Desktop environments