### PR TITLE
Update info streams correctly across multiple transforms, fixes #4877

### DIFF
--- a/assemblies/debug/pom.xml
+++ b/assemblies/debug/pom.xml
@@ -429,6 +429,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.hop</groupId>
+            <artifactId>hop-transform-append</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hop</groupId>
             <artifactId>hop-transform-blockuntiltransformsfinish</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
@@ -471,6 +477,24 @@
         </dependency>
         <dependency>
             <groupId>org.apache.hop</groupId>
+            <artifactId>hop-transform-joinrows</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hop</groupId>
+            <artifactId>hop-transform-mergejoin</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hop</groupId>
+            <artifactId>hop-transform-multimerge</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hop</groupId>
             <artifactId>hop-transform-pipelineexecutor</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
@@ -496,6 +520,12 @@
         <dependency>
             <groupId>org.apache.hop</groupId>
             <artifactId>hop-transform-selectvalues</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hop</groupId>
+            <artifactId>hop-transform-streamlookup</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/plugins/transforms/append/src/main/java/org/apache/hop/pipeline/transforms/append/AppendMeta.java
+++ b/plugins/transforms/append/src/main/java/org/apache/hop/pipeline/transforms/append/AppendMeta.java
@@ -91,7 +91,8 @@ public class AppendMeta extends BaseTransformMeta<Append, AppendData> {
       PipelineMeta pipelineMeta = parentTransformMeta.getParentPipelineMeta();
       if (pipelineMeta != null) {
         String[] prev = pipelineMeta.getPrevTransformNames(parentTransformMeta);
-        // Only auto-fill when both are empty (initial connect). Do not re-fill when user cleared one.
+        // Only auto-fill when both are empty (initial connect). Do not re-fill when user cleared
+        // one.
         if (prev != null && prev.length == 2) {
           if (Utils.isEmpty(headTransformName) && Utils.isEmpty(tailTransformName)) {
             if (headStream.getTransformMeta() != null && tailStream.getTransformMeta() != null) {

--- a/plugins/transforms/append/src/main/java/org/apache/hop/pipeline/transforms/append/AppendMeta.java
+++ b/plugins/transforms/append/src/main/java/org/apache/hop/pipeline/transforms/append/AppendMeta.java
@@ -18,11 +18,13 @@
 package org.apache.hop.pipeline.transforms.append;
 
 import java.util.List;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hop.core.CheckResult;
 import org.apache.hop.core.ICheckResult;
 import org.apache.hop.core.annotations.Transform;
 import org.apache.hop.core.exception.HopTransformException;
 import org.apache.hop.core.row.IRowMeta;
+import org.apache.hop.core.util.Utils;
 import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.i18n.BaseMessages;
 import org.apache.hop.metadata.api.HopMetadataProperty;
@@ -75,9 +77,114 @@ public class AppendMeta extends BaseTransformMeta<Append, AppendData> {
 
   @Override
   public void searchInfoAndTargetTransforms(List<TransformMeta> transforms) {
-    List<IStream> streams = getTransformIOMeta().getInfoStreams();
-    streams.get(0).setTransformMeta(TransformMeta.findTransform(transforms, headTransformName));
-    streams.get(1).setTransformMeta(TransformMeta.findTransform(transforms, tailTransformName));
+    List<IStream> infoStreams = getTransformIOMeta().getInfoStreams();
+    if (infoStreams.size() < 2) {
+      return;
+    }
+    IStream headStream = infoStreams.get(0);
+    IStream tailStream = infoStreams.get(1);
+    // Respect user choice: only re-fill from stream/prev when they had set a value (e.g. rename).
+    boolean hadHeadFilledIn = !Utils.isEmpty(headTransformName);
+    boolean hadTailFilledIn = !Utils.isEmpty(tailTransformName);
+
+    if (parentTransformMeta != null) {
+      PipelineMeta pipelineMeta = parentTransformMeta.getParentPipelineMeta();
+      if (pipelineMeta != null) {
+        String[] prev = pipelineMeta.getPrevTransformNames(parentTransformMeta);
+        // Only auto-fill when both are empty (initial connect). Do not re-fill when user cleared one.
+        if (prev != null && prev.length == 2) {
+          if (Utils.isEmpty(headTransformName) && Utils.isEmpty(tailTransformName)) {
+            if (headStream.getTransformMeta() != null && tailStream.getTransformMeta() != null) {
+              headTransformName = headStream.getTransformName();
+              tailTransformName = tailStream.getTransformName();
+            } else {
+              headTransformName = prev[0];
+              tailTransformName = prev[1];
+              setChanged();
+            }
+          }
+        }
+        // Clear names that no longer exist in prev (e.g. transform was removed)
+        if (headTransformName != null && !ArrayUtils.contains(prev, headTransformName)) {
+          headTransformName = null;
+          setChanged();
+        }
+        if (tailTransformName != null && !ArrayUtils.contains(prev, tailTransformName)) {
+          tailTransformName = null;
+          setChanged();
+        }
+      }
+    }
+
+    // Resolve by name. Prefer stream only when the stored name is "stale": empty (auto-fill),
+    // not in prev (insert-in-the-middle), or transform not found (rename).
+    String[] prev = null;
+    if (parentTransformMeta != null && parentTransformMeta.getParentPipelineMeta() != null) {
+      prev = parentTransformMeta.getParentPipelineMeta().getPrevTransformNames(parentTransformMeta);
+    }
+    TransformMeta tmHead = null;
+    boolean headNameStale =
+        Utils.isEmpty(headTransformName)
+            || (prev != null && !ArrayUtils.contains(prev, headTransformName))
+            || TransformMeta.findTransform(transforms, headTransformName) == null;
+    boolean preferHeadStream =
+        headStream.getTransformMeta() != null
+            && prev != null
+            && ArrayUtils.contains(prev, headStream.getTransformName())
+            && headNameStale
+            && hadHeadFilledIn;
+    if (preferHeadStream) {
+      headTransformName = headStream.getTransformName();
+      tmHead = headStream.getTransformMeta();
+      setChanged();
+    }
+    if (tmHead == null) {
+      tmHead = TransformMeta.findTransform(transforms, headTransformName);
+      if (tmHead == null
+          && headStream.getTransformMeta() != null
+          && prev != null
+          && ArrayUtils.contains(prev, headStream.getTransformName())
+          && hadHeadFilledIn) {
+        headTransformName = headStream.getTransformName();
+        tmHead = TransformMeta.findTransform(transforms, headTransformName);
+      }
+    }
+    headStream.setTransformMeta(tmHead);
+    if (tmHead != null) {
+      headStream.setSubject(tmHead.getName());
+    }
+
+    TransformMeta tmTail = null;
+    boolean tailNameStale =
+        Utils.isEmpty(tailTransformName)
+            || (prev != null && !ArrayUtils.contains(prev, tailTransformName))
+            || TransformMeta.findTransform(transforms, tailTransformName) == null;
+    boolean preferTailStream =
+        tailStream.getTransformMeta() != null
+            && prev != null
+            && ArrayUtils.contains(prev, tailStream.getTransformName())
+            && tailNameStale
+            && hadTailFilledIn;
+    if (preferTailStream) {
+      tailTransformName = tailStream.getTransformName();
+      tmTail = tailStream.getTransformMeta();
+      setChanged();
+    }
+    if (tmTail == null) {
+      tmTail = TransformMeta.findTransform(transforms, tailTransformName);
+      if (tmTail == null
+          && tailStream.getTransformMeta() != null
+          && prev != null
+          && ArrayUtils.contains(prev, tailStream.getTransformName())
+          && hadTailFilledIn) {
+        tailTransformName = tailStream.getTransformName();
+        tmTail = TransformMeta.findTransform(transforms, tailTransformName);
+      }
+    }
+    tailStream.setTransformMeta(tmTail);
+    if (tmTail != null) {
+      tailStream.setSubject(tmTail.getName());
+    }
   }
 
   @Override

--- a/plugins/transforms/joinrows/src/main/java/org/apache/hop/pipeline/transforms/joinrows/JoinRowsDialog.java
+++ b/plugins/transforms/joinrows/src/main/java/org/apache/hop/pipeline/transforms/joinrows/JoinRowsDialog.java
@@ -259,6 +259,9 @@ public class JoinRowsDialog extends BaseTransformDialog {
 
   /** Copy information from the meta-data input to the dialog fields. */
   public void getData() {
+    // Sync from hops (rename, insert-in-the-middle) so main transform is up to date
+    input.searchInfoAndTargetTransforms(pipelineMeta.getTransforms());
+
     if (input.getPrefix() != null) {
       wPrefix.setText(input.getPrefix());
     }

--- a/plugins/transforms/joinrows/src/main/resources/org/apache/hop/pipeline/transforms/joinrows/messages/messages_en_US.properties
+++ b/plugins/transforms/joinrows/src/main/resources/org/apache/hop/pipeline/transforms/joinrows/messages/messages_en_US.properties
@@ -45,6 +45,7 @@ JoinRowsDialog.Temp.Label=temp
 JoinRowsDialog.TempDir.Label=Temp directory
 JoinRowsDialog.TempFilePrefix.Label=TMP-file prefix
 JoinRowsDialog.TransformName.Label=Transform name
+JoinRowsMeta.InfoStream.Description=Main transform to read from
 JoinRowsMeta.CheckResult.CouldNotFindFieldsFromPreviousTransforms=Couldn''t find fields from previous transforms, check the hops...\!
 JoinRowsMeta.CheckResult.DirectoryDoesNotExist=Directory [{0}] doesn''t exist!
 JoinRowsMeta.CheckResult.DirectoryExists=] exists and is a directory

--- a/plugins/transforms/mergejoin/src/main/java/org/apache/hop/pipeline/transforms/mergejoin/MergeJoinDialog.java
+++ b/plugins/transforms/mergejoin/src/main/java/org/apache/hop/pipeline/transforms/mergejoin/MergeJoinDialog.java
@@ -297,6 +297,18 @@ public class MergeJoinDialog extends BaseTransformDialog {
 
   /** Copy information from the meta-data input to the dialog fields. */
   public void getData() {
+    // If both fields are empty and exactly 2 transforms are attached, auto-fill first and second
+    if (Utils.isEmpty(input.getLeftTransformName())
+        && Utils.isEmpty(input.getRightTransformName())) {
+      String[] prev = pipelineMeta.getPrevTransformNames(transformName);
+      if (prev != null && prev.length == 2) {
+        input.setLeftTransformName(prev[0]);
+        input.setRightTransformName(prev[1]);
+      }
+    }
+    // Sync from hops (rename, insert-in-the-middle) and resolve streams
+    input.searchInfoAndTargetTransforms(pipelineMeta.getTransforms());
+
     List<IStream> infoStreams = input.getTransformIOMeta().getInfoStreams();
 
     wTransform1.setText(Const.NVL(infoStreams.get(0).getTransformName(), ""));

--- a/plugins/transforms/mergejoin/src/main/java/org/apache/hop/pipeline/transforms/mergejoin/MergeJoinMeta.java
+++ b/plugins/transforms/mergejoin/src/main/java/org/apache/hop/pipeline/transforms/mergejoin/MergeJoinMeta.java
@@ -134,7 +134,8 @@ public class MergeJoinMeta extends BaseTransformMeta<MergeJoin, MergeJoinData> {
       PipelineMeta pipelineMeta = parentTransformMeta.getParentPipelineMeta();
       if (pipelineMeta != null) {
         String[] prev = pipelineMeta.getPrevTransformNames(parentTransformMeta);
-        // Only auto-fill when both are empty (initial connect). Do not re-fill when user cleared one.
+        // Only auto-fill when both are empty (initial connect). Do not re-fill when user cleared
+        // one.
         if (prev != null && prev.length == 2) {
           if (Utils.isEmpty(leftTransformName) && Utils.isEmpty(rightTransformName)) {
             if (stream0.getTransformMeta() != null && stream1.getTransformMeta() != null) {

--- a/plugins/transforms/multimerge/src/main/java/org/apache/hop/pipeline/transforms/multimerge/MultiMergeJoinDialog.java
+++ b/plugins/transforms/multimerge/src/main/java/org/apache/hop/pipeline/transforms/multimerge/MultiMergeJoinDialog.java
@@ -412,6 +412,20 @@ public class MultiMergeJoinDialog extends BaseTransformDialog {
 
   /** Copy information from the meta-data input to the dialog fields. */
   public void getData() {
+    // If no inputs configured and at least 2 transforms are attached, auto-fill from prev
+    if (joinMeta.getInputTransforms() == null || joinMeta.getInputTransforms().isEmpty()) {
+      String[] prev = pipelineMeta.getPrevTransformNames(transformName);
+      if (prev != null && prev.length >= 2) {
+        List<String> list = new ArrayList<>();
+        for (String p : prev) {
+          list.add(p);
+        }
+        joinMeta.setInputTransforms(list);
+      }
+    }
+    // Sync from hops (rename, insert-in-the-middle) and resolve streams
+    joinMeta.searchInfoAndTargetTransforms(pipelineMeta.getTransforms());
+
     List<String> inputTransformNames = joinMeta.getInputTransforms();
     if (inputTransformNames != null) {
       String inputTransformName;


### PR DESCRIPTION
- When 2 streams are attached to merge join and you open the transform automatically fill them in
- Update InfoStreams when transform names change for following transforms
  - Merge join
  - Append Streams
  - Multiway merge
  - Stream lookup
  - Join Rows

Automatically update the links when renaming a transform, splitting (dropping a transform on a hop) or using the detach this transform option


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [ ] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [ ] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
