### PR TITLE
Fix Google Sheets Proxy Configuration

### DIFF
--- a/plugins/tech/google/src/main/java/org/apache/hop/pipeline/transforms/googlesheets/GoogleSheetsConnectionFactory.java
+++ b/plugins/tech/google/src/main/java/org/apache/hop/pipeline/transforms/googlesheets/GoogleSheetsConnectionFactory.java
@@ -35,7 +35,7 @@ public class GoogleSheetsConnectionFactory {
 
   public static NetHttpTransport newTransport(String proxyHost, String proxyPort)
       throws GeneralSecurityException, IOException {
-    if (proxyHost != null && proxyPort != null) {
+    if (proxyHost != null && !proxyHost.isEmpty() && proxyPort != null && !proxyPort.isEmpty()) {
       int port = Integer.parseInt(proxyPort);
       return newProxyTransport(proxyHost, port);
     } else {

--- a/plugins/tech/google/src/main/java/org/apache/hop/pipeline/transforms/googlesheets/GoogleSheetsInput.java
+++ b/plugins/tech/google/src/main/java/org/apache/hop/pipeline/transforms/googlesheets/GoogleSheetsInput.java
@@ -70,8 +70,10 @@ public class GoogleSheetsInput extends BaseTransform<GoogleSheetsInputMeta, Goog
 
     try {
       jsonFactory = JacksonFactory.getDefaultInstance();
-      httpTransport =
-          GoogleSheetsConnectionFactory.newTransport(meta.getProxyHost(), meta.getProxyPort());
+
+      String host = resolve(meta.getProxyHost());
+      String port = resolve(meta.getProxyPort());
+      httpTransport = GoogleSheetsConnectionFactory.newTransport(host, port);
     } catch (Exception e) {
       logError("cannot initiate HTTP transport" + e.getMessage());
       return false;
@@ -84,7 +86,8 @@ public class GoogleSheetsInput extends BaseTransform<GoogleSheetsInputMeta, Goog
                 scope,
                 resolve(meta.getJsonCredentialPath()),
                 resolve(meta.getImpersonation()),
-                variables);
+                variables,
+                httpTransport);
         Sheets service =
             new Sheets.Builder(
                     httpTransport,

--- a/plugins/tech/google/src/main/java/org/apache/hop/pipeline/transforms/googlesheets/GoogleSheetsInputDialog.java
+++ b/plugins/tech/google/src/main/java/org/apache/hop/pipeline/transforms/googlesheets/GoogleSheetsInputDialog.java
@@ -561,7 +561,8 @@ public class GoogleSheetsInputDialog extends BaseTransformDialog {
   private void testServiceAccount() {
     try {
       NetHttpTransport netHttpTransport =
-          GoogleSheetsConnectionFactory.newTransport(meta.getProxyHost(), meta.getProxyPort());
+          GoogleSheetsConnectionFactory.newTransport(
+              variables.resolve(meta.getProxyHost()), variables.resolve(meta.getProxyPort()));
       JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
       String scope = SheetsScopes.SPREADSHEETS_READONLY;
 
@@ -571,7 +572,8 @@ public class GoogleSheetsInputDialog extends BaseTransformDialog {
               scope,
               variables.resolve(meta.getJsonCredentialPath()),
               variables.resolve(meta.getImpersonation()),
-              variables);
+              variables,
+              netHttpTransport);
       //
       new Drive.Builder(
               netHttpTransport,
@@ -589,7 +591,8 @@ public class GoogleSheetsInputDialog extends BaseTransformDialog {
   private void selectSpreadSheet() {
     try {
       NetHttpTransport netHttpTransport =
-          GoogleSheetsConnectionFactory.newTransport(meta.getProxyHost(), meta.getProxyPort());
+          GoogleSheetsConnectionFactory.newTransport(
+              variables.resolve(meta.getProxyHost()), variables.resolve(meta.getProxyPort()));
       JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
       String scope = "https://www.googleapis.com/auth/drive.readonly";
       HttpRequestInitializer credential =
@@ -597,7 +600,8 @@ public class GoogleSheetsInputDialog extends BaseTransformDialog {
               scope,
               variables.resolve(meta.getJsonCredentialPath()),
               variables.resolve(meta.getImpersonation()),
-              variables);
+              variables,
+              netHttpTransport);
       //
       Drive service =
           new Drive.Builder(
@@ -656,7 +660,8 @@ public class GoogleSheetsInputDialog extends BaseTransformDialog {
     try {
 
       NetHttpTransport netHttpTransport =
-          GoogleSheetsConnectionFactory.newTransport(meta.getProxyHost(), meta.getProxyPort());
+          GoogleSheetsConnectionFactory.newTransport(
+              variables.resolve(meta.getProxyHost()), variables.resolve(meta.getProxyPort()));
       JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
       String scope = SheetsScopes.SPREADSHEETS_READONLY;
 
@@ -665,7 +670,8 @@ public class GoogleSheetsInputDialog extends BaseTransformDialog {
               scope,
               variables.resolve(meta.getJsonCredentialPath()),
               variables.resolve(meta.getImpersonation()),
-              variables);
+              variables,
+              netHttpTransport);
       //
       Sheets service =
           new Sheets.Builder(
@@ -874,7 +880,8 @@ public class GoogleSheetsInputDialog extends BaseTransformDialog {
       GoogleSheetsInputMeta meta = new GoogleSheetsInputMeta();
       setData(meta);
       NetHttpTransport netHttpTransport =
-          GoogleSheetsConnectionFactory.newTransport(meta.getProxyHost(), meta.getProxyPort());
+          GoogleSheetsConnectionFactory.newTransport(
+              variables.resolve(meta.getProxyHost()), variables.resolve(meta.getProxyPort()));
       JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
       String scope = SheetsScopes.SPREADSHEETS_READONLY;
       wFields.table.removeAll();
@@ -884,7 +891,8 @@ public class GoogleSheetsInputDialog extends BaseTransformDialog {
               scope,
               variables.resolve(meta.getJsonCredentialPath()),
               variables.resolve(meta.getImpersonation()),
-              variables);
+              variables,
+              netHttpTransport);
       Sheets service =
           new Sheets.Builder(
                   netHttpTransport,

--- a/plugins/tech/google/src/main/java/org/apache/hop/pipeline/transforms/googlesheets/GoogleSheetsOutput.java
+++ b/plugins/tech/google/src/main/java/org/apache/hop/pipeline/transforms/googlesheets/GoogleSheetsOutput.java
@@ -86,7 +86,8 @@ public class GoogleSheetsOutput
       // Check if file exists
       try {
         httpTransport =
-            GoogleSheetsConnectionFactory.newTransport(meta.getProxyHost(), meta.getProxyPort());
+            GoogleSheetsConnectionFactory.newTransport(
+                resolve(meta.getProxyHost()), resolve(meta.getProxyPort()));
         jsonFactory = JacksonFactory.getDefaultInstance();
         scope = "https://www.googleapis.com/auth/drive";
 
@@ -95,7 +96,8 @@ public class GoogleSheetsOutput
                 scope,
                 resolve(meta.getJsonCredentialPath()),
                 resolve(meta.getImpersonation()),
-                variables);
+                variables,
+                httpTransport);
         Drive service =
             new Drive.Builder(
                     httpTransport,
@@ -362,7 +364,8 @@ public class GoogleSheetsOutput
                   scope,
                   resolve(meta.getJsonCredentialPath()),
                   resolve(meta.getImpersonation()),
-                  variables);
+                  variables,
+                  httpTransport);
           data.service =
               new Sheets.Builder(
                       httpTransport,

--- a/plugins/tech/google/src/main/java/org/apache/hop/pipeline/transforms/googlesheets/GoogleSheetsOutputDialog.java
+++ b/plugins/tech/google/src/main/java/org/apache/hop/pipeline/transforms/googlesheets/GoogleSheetsOutputDialog.java
@@ -539,7 +539,8 @@ public class GoogleSheetsOutputDialog extends BaseTransformDialog {
   private void selectWorksheet() {
     try {
       NetHttpTransport netHttpTransport =
-          GoogleSheetsConnectionFactory.newTransport(meta.getProxyHost(), meta.getProxyPort());
+          GoogleSheetsConnectionFactory.newTransport(
+              variables.resolve(meta.getProxyHost()), variables.resolve(meta.getProxyPort()));
       JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
       String scope = SheetsScopes.SPREADSHEETS_READONLY;
 
@@ -548,7 +549,8 @@ public class GoogleSheetsOutputDialog extends BaseTransformDialog {
               scope,
               variables.resolve(meta.getJsonCredentialPath()),
               variables.resolve(meta.getImpersonation()),
-              variables);
+              variables,
+              netHttpTransport);
       Sheets service =
           new Sheets.Builder(
                   netHttpTransport,
@@ -597,7 +599,8 @@ public class GoogleSheetsOutputDialog extends BaseTransformDialog {
   private void selectSpreadSheetKey() {
     try {
       NetHttpTransport netHttpTransport =
-          GoogleSheetsConnectionFactory.newTransport(meta.getProxyHost(), meta.getProxyPort());
+          GoogleSheetsConnectionFactory.newTransport(
+              variables.resolve(meta.getProxyHost()), variables.resolve(meta.getProxyPort()));
       JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
       String scope = "https://www.googleapis.com/auth/drive";
       HttpRequestInitializer credential =
@@ -605,7 +608,8 @@ public class GoogleSheetsOutputDialog extends BaseTransformDialog {
               scope,
               variables.resolve(meta.getJsonCredentialPath()),
               variables.resolve(meta.getImpersonation()),
-              variables);
+              variables,
+              netHttpTransport);
       Drive service =
           new Drive.Builder(
                   netHttpTransport,
@@ -661,7 +665,8 @@ public class GoogleSheetsOutputDialog extends BaseTransformDialog {
   private void testServiceAccount() {
     try {
       NetHttpTransport netHttpTransport =
-          GoogleSheetsConnectionFactory.newTransport(meta.getProxyHost(), meta.getProxyPort());
+          GoogleSheetsConnectionFactory.newTransport(
+              variables.resolve(meta.getProxyHost()), variables.resolve(meta.getProxyPort()));
       JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
       String scope = SheetsScopes.SPREADSHEETS_READONLY;
 
@@ -670,7 +675,8 @@ public class GoogleSheetsOutputDialog extends BaseTransformDialog {
               scope,
               variables.resolve(wPrivateKeyStore.getText()),
               variables.resolve(wImpersonation.getText()),
-              variables);
+              variables,
+              netHttpTransport);
       // Build a Drive connection to test it
       //
       new Drive.Builder(


### PR DESCRIPTION
Inject httpTransport into credentials and handle empty proxy config. 

Behind our corporate proxy, we found that the Google Sheets Proxy settings were not working. After investigation, we found that the cause was that the credentials were not being passed through correctly. This PR resolves this issue and has been tested both behind our corporate proxy and in a no proxy environment.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [ ] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [ ] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
