### PR TITLE
Fix#6693 translation loading for ProgressMonitorDialog.InitialSubTaskLabel

### DIFF
--- a/ui/src/main/resources/org/apache/hop/ui/core/dialog/messages/messages_en_US.properties
+++ b/ui/src/main/resources/org/apache/hop/ui/core/dialog/messages/messages_en_US.properties
@@ -265,6 +265,7 @@ PreviewRowsDialog.ShowLogging.Title=Logging text
 PreviewRowsDialog.Title=Examine preview data
 ProgressMonitorDialog.InitialTaskLabel=Apache Hop is handling a long running task
 ProgressMonitorDialog.Shell.Title=Progress...
+ProgressMonitorDialog.InitialSubTaskLabel=\ 
 SelectRowDialog.Title=Select an entry
 SQLStatementDialog.Button.EditTransform=&Edit origin transform
 SQLStatementDialog.Button.ExecSQL=E&xecute SQL


### PR DESCRIPTION
Fix https://github.com/apache/hop/issues/6693 -- ProgressMonitorDialog.InitialSubTaskLabel translation not pulled

