### PR TITLE
Properly Register TransformMetaChangeListeners

### DIFF
--- a/engine/src/main/java/org/apache/hop/pipeline/PipelineMeta.java
+++ b/engine/src/main/java/org/apache/hop/pipeline/PipelineMeta.java
@@ -378,14 +378,16 @@ public class PipelineMeta extends AbstractMeta
   public void addOrReplaceTransform(TransformMeta transformMeta) {
     int index = transforms.indexOf(transformMeta);
     if (index < 0) {
-      index = transforms.add(transformMeta) ? 0 : index;
+      transforms.add(transformMeta);
+      index = transforms.size() - 1;
     } else {
       TransformMeta previous = getTransform(index);
       previous.replaceMeta(transformMeta);
     }
     transformMeta.setParentPipelineMeta(this);
     ITransformMeta iface = transformMeta.getTransform();
-    if (index != -1 && iface instanceof ITransformMetaChangeListener iTransformMetaChangeListener) {
+
+    if (iface instanceof ITransformMetaChangeListener iTransformMetaChangeListener) {
       addTransformChangeListener(index, iTransformMetaChangeListener);
     }
     changedTransforms = true;
@@ -3656,37 +3658,20 @@ public class PipelineMeta extends AbstractMeta
   }
 
   public void addTransformChangeListener(int p, ITransformMetaChangeListener list) {
-    int indexListener = -1;
-    int indexListenerRemove = -1;
     TransformMeta rewriteTransform = transforms.get(p);
     ITransformMeta iface = rewriteTransform.getTransform();
     if (iface instanceof ITransformMetaChangeListener) {
-      for (ITransformMetaChangeListener listener : transformChangeListeners) {
-        indexListener++;
-        if (listener.equals(iface)) {
-          indexListenerRemove = indexListener;
-        }
-      }
-      if (indexListenerRemove >= 0) {
-        transformChangeListeners.add(indexListenerRemove, list);
-      } else if (transformChangeListeners.isEmpty() && p == 0) {
+      int index = transformChangeListeners.indexOf(iface);
+      if (index >= 0) {
+        transformChangeListeners.set(index, list);
+      } else {
         transformChangeListeners.add(list);
       }
     }
   }
 
   public void removeTransformChangeListener(ITransformMetaChangeListener list) {
-    int indexListener = -1;
-    int indexListenerRemove = -1;
-    for (ITransformMetaChangeListener listener : transformChangeListeners) {
-      indexListener++;
-      if (listener.equals(list)) {
-        indexListenerRemove = indexListener;
-      }
-    }
-    if (indexListenerRemove >= 0) {
-      transformChangeListeners.remove(indexListenerRemove);
-    }
+    transformChangeListeners.remove(list);
   }
 
   public void notifyAllListeners(TransformMeta oldMeta, TransformMeta newMeta) {

--- a/engine/src/test/java/org/apache/hop/pipeline/PipelineMetaTest.java
+++ b/engine/src/test/java/org/apache/hop/pipeline/PipelineMetaTest.java
@@ -247,7 +247,7 @@ class PipelineMetaTest {
 
     pipelineMeta.addTransform(0, transformMeta);
     assertEquals(2, pipelineMeta.transforms.size());
-    assertEquals(2, pipelineMeta.transformChangeListeners.size());
+    assertEquals(1, pipelineMeta.transformChangeListeners.size());
   }
 
   @Test


### PR DESCRIPTION
Fixes #6855

Changes: 
in addOrReplaceTransform: properly set the index to the end of the list instead of 0 after the list.add.

in addTransformChangeListener: remove convoluted removal logic, use list.set to replace instead of list.add, properly register the listener in an else block.

in removeTransformChangeListener: remove convoluted removal logic.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
