### PR TITLE
Upgrade XMLUnit from 1.6 to xmlunit-core 2.11.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -382,8 +382,8 @@
         </dependency>
 
         <dependency>
-            <groupId>xmlunit</groupId>
-            <artifactId>xmlunit</artifactId>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/core/src/test/java/org/apache/hop/core/xml/XmlFormatterTest.java
+++ b/core/src/test/java/org/apache/hop/core/xml/XmlFormatterTest.java
@@ -16,24 +16,18 @@
  */
 package org.apache.hop.core.xml;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
-import org.custommonkey.xmlunit.Diff;
-import org.custommonkey.xmlunit.XMLUnit;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.diff.Diff;
 
 /** Unit test for {@link XmlFormatter} */
 class XmlFormatterTest {
-
-  @BeforeAll
-  static void setupClass() {
-    XMLUnit.setIgnoreWhitespace(true);
-  }
 
   @Test
   void test1() throws Exception {
@@ -48,8 +42,14 @@ class XmlFormatterTest {
     }
 
     String result = XmlFormatter.format(inXml);
-    Diff diff = XMLUnit.compareXML(expectedXml, result);
-    assertTrue(diff.similar(), "XML documents are not equal: " + diff.toString());
+    Diff diff =
+        DiffBuilder.compare(expectedXml)
+            .withTest(result)
+            .ignoreWhitespace()
+            .checkForSimilar()
+            .build();
+
+    assertFalse(diff.hasDifferences(), "XML documents are not equal: " + diff);
   }
 
   @Test
@@ -66,8 +66,14 @@ class XmlFormatterTest {
     }
 
     String result = XmlFormatter.format(inXml);
-    Diff diff = XMLUnit.compareXML(expectedXml, result);
-    assertTrue(diff.similar(), "XML documents are not equal: " + diff.toString());
+    Diff diff =
+        DiffBuilder.compare(expectedXml)
+            .withTest(result)
+            .ignoreWhitespace()
+            .checkForSimilar()
+            .build();
+
+    assertFalse(diff.hasDifferences(), "XML documents are not equal: " + diff);
   }
 
   @Test
@@ -85,8 +91,14 @@ class XmlFormatterTest {
     }
 
     String result = XmlFormatter.format(inXml);
-    Diff diff = XMLUnit.compareXML(expectedXml, result);
-    assertTrue(diff.similar(), "XML documents are not equal: " + diff.toString());
+    Diff diff =
+        DiffBuilder.compare(expectedXml)
+            .withTest(result)
+            .ignoreWhitespace()
+            .checkForSimilar()
+            .build();
+
+    assertFalse(diff.hasDifferences(), "XML documents are not equal: " + diff);
   }
 
   @Test
@@ -104,7 +116,14 @@ class XmlFormatterTest {
     }
 
     String result = XmlFormatter.format(inXml);
-    Diff diff = XMLUnit.compareXML(expectedXml, result);
-    assertTrue(diff.similar(), "XML documents are not equal: " + diff.toString());
+    Diff diff =
+        DiffBuilder.compare(expectedXml)
+            .withTest(result)
+            .ignoreWhitespace()
+            .ignoreComments()
+            .checkForSimilar()
+            .build();
+
+    assertFalse(diff.hasDifferences(), "XML documents are not equal: " + diff);
   }
 }

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -143,7 +143,7 @@
         <woodstox.version>7.1.1</woodstox.version>
         <xerces.version>2.12.2</xerces.version>
         <xml-apis-ext.version>1.3.04</xml-apis-ext.version>
-        <xmlunit.version>1.6</xmlunit.version>
+        <xmlunit.version>2.11.0</xmlunit.version>
         <xstream.version>1.4.21</xstream.version>
         <zstd-jni.version>1.5.7-7</zstd-jni.version>
     </properties>
@@ -817,9 +817,10 @@
                 <version>${xml-apis-ext.version}</version>
             </dependency>
             <dependency>
-                <groupId>xmlunit</groupId>
-                <artifactId>xmlunit</artifactId>
+                <groupId>org.xmlunit</groupId>
+                <artifactId>xmlunit-core</artifactId>
                 <version>${xmlunit.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
This PR upgrades the XML comparison library from:

- XMLUnit 1.6 (org.custommonkey.xmlunit)
to:
- XMLUnit 2.11.0 (org.xmlunit)

The old XMLUnit 1.x version is deprecated and no longer maintained.