### PR TITLE
Issue #6918 (Only show action when there's a test active)

### DIFF
--- a/plugins/misc/testing/src/main/java/org/apache/hop/testing/gui/TestingGuiPlugin.java
+++ b/plugins/misc/testing/src/main/java/org/apache/hop/testing/gui/TestingGuiPlugin.java
@@ -1727,4 +1727,24 @@ public class TestingGuiPlugin {
       new ErrorDialog(shell, "Error", "Error saving the view into a dataset", e);
     }
   }
+
+  /**
+   * We only want to show the copy
+   *
+   * @param contextActionId
+   * @param context
+   * @return
+   */
+  @GuiContextActionFilter(parentId = HopGuiPipelineContext.CONTEXT_ID)
+  public boolean filterTestingPipeline(String contextActionId, HopGuiPipelineContext context) {
+    if (ACTION_ID_PIPELINE_GRAPH_COPY_TEST_ACTION_CLIPBOARD.equals(contextActionId)) {
+      PipelineMeta pipelineMeta = context.getPipelineMeta();
+      if (pipelineMeta == null) {
+        return false;
+      }
+      PipelineUnitTest unitTest = getCurrentUnitTest(pipelineMeta);
+      return unitTest != null;
+    }
+    return true;
+  }
 }


### PR DESCRIPTION
Minor improvement to only show the "Copy unit test as action" option in a pipeline when there's an active unit test to reference.