### PR TITLE
Fix#6981 BaseRowSet use the default hashCode/equals implementation

### DIFF
--- a/core/src/main/java/org/apache/hop/core/BaseRowSet.java
+++ b/core/src/main/java/org/apache/hop/core/BaseRowSet.java
@@ -17,7 +17,6 @@
 
 package org.apache.hop.core;
 
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -77,24 +76,6 @@ abstract class BaseRowSet implements Comparable<IRowSet>, IRowSet {
             + rowSet.getDestinationTransformCopy();
 
     return target.compareTo(comp);
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof IRowSet other)) {
-      return false;
-    }
-
-    return compareTo(other) == 0;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        remoteHopServerName, destinationTransformName, destinationTransformCopy.get());
   }
 
   /*

--- a/core/src/test/java/org/apache/hop/core/BaseRowSetTests.java
+++ b/core/src/test/java/org/apache/hop/core/BaseRowSetTests.java
@@ -50,8 +50,10 @@ class BaseRowSetTests {
     r2.setThreadNameFromToCopy("X", 9, "B", 2);
 
     assertEquals(0, r1.compareTo(r2));
-    assertEquals(r1, r2);
-    assertEquals(r1.hashCode(), r2.hashCode());
+    assertNotEquals(r1, r2);
+    assertNotEquals(r1.hashCode(), r2.hashCode());
+
+    assertEquals(0, r1.compareTo(r2));
   }
 
   @Test


### PR DESCRIPTION
Fix https://github.com/apache/hop/issues/6981

For `BaseRowSet`, use the default `hashCode`/`equals` implementation.