### PR TITLE
Fix Sonar warning: avoid regex with potential backtracking (ReDoS risk)

### DIFF
--- a/core/src/main/java/org/apache/hop/core/util/StringUtil.java
+++ b/core/src/main/java/org/apache/hop/core/util/StringUtil.java
@@ -602,12 +602,11 @@ public class StringUtil {
    * @return a new string with all instances of the specified character removed from the end
    */
   public static String trimEnd(final String source, char c) {
-    if (source == null) {
-      return null;
+    if (source == null || source.isEmpty()) {
+      return source;
     }
 
     int index = source.length();
-
     while (index > 0 && source.charAt(index - 1) == c) {
       index--;
     }

--- a/core/src/test/java/org/apache/hop/core/util/StringUtilTest.java
+++ b/core/src/test/java/org/apache/hop/core/util/StringUtilTest.java
@@ -217,5 +217,7 @@ class StringUtilTest {
   @Test
   void testTrimEnd_None() {
     assertEquals("/file/path", StringUtil.trimEnd("/file/path", '/'));
+    assertEquals("", StringUtil.trimEnd("/", '/'));
+    assertEquals("", StringUtil.trimEnd("///", '/'));
   }
 }

--- a/plugins/misc/projects/src/main/java/org/apache/hop/projects/git/BitbucketRepositoryBrowser.java
+++ b/plugins/misc/projects/src/main/java/org/apache/hop/projects/git/BitbucketRepositoryBrowser.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import org.apache.hop.core.exception.HopException;
+import org.apache.hop.core.util.StringUtil;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -55,7 +56,7 @@ class BitbucketRepositoryBrowser implements GitRepositoryBrowser {
 
     String base =
         (apiBaseUrl != null && !apiBaseUrl.isBlank())
-            ? apiBaseUrl.replaceAll("/+$", "")
+            ? StringUtil.trimEnd(apiBaseUrl, '/')
             : DEFAULT_API;
 
     // /repositories/{workspace} lists repos for one workspace; /repositories lists all the user
@@ -71,13 +72,9 @@ class BitbucketRepositoryBrowser implements GitRepositoryBrowser {
             .append("&sort=-updated_on");
 
     if (searchQuery != null && !searchQuery.isBlank()) {
-      try {
-        url.append("&q=name+%7E+%22")
-            .append(java.net.URLEncoder.encode(searchQuery, "UTF-8"))
-            .append("%22");
-      } catch (java.io.UnsupportedEncodingException e) {
-        // UTF-8 is always supported
-      }
+      url.append("&q=name+%7E+%22")
+          .append(java.net.URLEncoder.encode(searchQuery, StandardCharsets.UTF_8))
+          .append("%22");
     }
 
     String credentials =
@@ -180,10 +177,6 @@ class BitbucketRepositoryBrowser implements GitRepositoryBrowser {
   }
 
   private static String encode(String value) {
-    try {
-      return java.net.URLEncoder.encode(value, "UTF-8");
-    } catch (java.io.UnsupportedEncodingException e) {
-      return value;
-    }
+    return java.net.URLEncoder.encode(value, StandardCharsets.UTF_8);
   }
 }

--- a/plugins/misc/projects/src/main/java/org/apache/hop/projects/git/GitHubRepositoryBrowser.java
+++ b/plugins/misc/projects/src/main/java/org/apache/hop/projects/git/GitHubRepositoryBrowser.java
@@ -26,6 +26,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.hop.core.exception.HopException;
+import org.apache.hop.core.util.StringUtil;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -49,7 +50,7 @@ class GitHubRepositoryBrowser implements GitRepositoryBrowser {
 
     String base =
         (apiBaseUrl != null && !apiBaseUrl.isBlank())
-            ? apiBaseUrl.replaceAll("/+$", "")
+            ? StringUtil.trimEnd(apiBaseUrl, '/')
             : DEFAULT_API;
     String url =
         base

--- a/plugins/misc/projects/src/main/java/org/apache/hop/projects/git/GitLabRepositoryBrowser.java
+++ b/plugins/misc/projects/src/main/java/org/apache/hop/projects/git/GitLabRepositoryBrowser.java
@@ -22,10 +22,12 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.hop.core.exception.HopException;
+import org.apache.hop.core.util.StringUtil;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -49,7 +51,7 @@ class GitLabRepositoryBrowser implements GitRepositoryBrowser {
 
     String base =
         (apiBaseUrl != null && !apiBaseUrl.isBlank())
-            ? apiBaseUrl.replaceAll("/+$", "")
+            ? StringUtil.trimEnd(apiBaseUrl, '/')
             : DEFAULT_API;
 
     StringBuilder url =
@@ -61,11 +63,8 @@ class GitLabRepositoryBrowser implements GitRepositoryBrowser {
             .append(page);
 
     if (searchQuery != null && !searchQuery.isBlank()) {
-      try {
-        url.append("&search=").append(java.net.URLEncoder.encode(searchQuery, "UTF-8"));
-      } catch (java.io.UnsupportedEncodingException e) {
-        // UTF-8 is always supported
-      }
+      url.append("&search=")
+          .append(java.net.URLEncoder.encode(searchQuery, StandardCharsets.UTF_8));
     }
 
     HttpRequest.Builder requestBuilder =

--- a/plugins/misc/projects/src/main/java/org/apache/hop/projects/gui/SelectRepositoryDialog.java
+++ b/plugins/misc/projects/src/main/java/org/apache/hop/projects/gui/SelectRepositoryDialog.java
@@ -19,6 +19,8 @@ package org.apache.hop.projects.gui;
 
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Getter;
+import org.apache.hop.core.util.StringUtil;
 import org.apache.hop.i18n.BaseMessages;
 import org.apache.hop.projects.git.GitRepoAuth;
 import org.apache.hop.projects.git.GitRepoProvider;
@@ -87,7 +89,7 @@ public class SelectRepositoryDialog extends Dialog {
   private String selectedCloneUrl;
 
   /** The name of the selected repository, or {@code null} if cancelled. */
-  private String selectedRepoName;
+  @Getter private String selectedRepoName;
 
   private final List<GitRepositoryInfo> loadedRepos = new ArrayList<>();
   private int currentPage = 1;
@@ -315,11 +317,7 @@ public class SelectRepositoryDialog extends Dialog {
     wRepoTable.setLayoutData(fdTable);
 
     // Single click selects; double click selects and closes
-    wRepoTable.addListener(
-        SWT.Selection,
-        e -> {
-          wOk.setEnabled(wRepoTable.getSelectionCount() > 0);
-        });
+    wRepoTable.addListener(SWT.Selection, e -> wOk.setEnabled(wRepoTable.getSelectionCount() > 0));
     wRepoTable.addListener(SWT.DefaultSelection, e -> ok());
 
     // --- Load more button ---
@@ -345,11 +343,6 @@ public class SelectRepositoryDialog extends Dialog {
       }
     }
     return selectedCloneUrl;
-  }
-
-  /** Returns the repo name of the last selection. */
-  public String getSelectedRepoName() {
-    return selectedRepoName;
   }
 
   // ---------------------------------------------------------------------------
@@ -503,14 +496,14 @@ public class SelectRepositoryDialog extends Dialog {
     return switch (provider) {
       case GITHUB_ENTERPRISE -> {
         if (!hostValue.isEmpty()) {
-          String base = hostValue.replaceAll("/+$", "");
+          String base = StringUtil.trimEnd(hostValue, '/');
           yield base + "/api/v3";
         }
         yield null;
       }
       case GITLAB -> {
         if (!hostValue.isEmpty()) {
-          String base = hostValue.replaceAll("/+$", "");
+          String base = StringUtil.trimEnd(hostValue, '/');
           yield base + "/api/v4";
         }
         yield null; // default to gitlab.com


### PR DESCRIPTION
Sonar: Using slow regular expressions is security-sensitive [java:S5852](https://sonarcloud.io/organizations/apache/rules?open=java%3AS5852&rule_key=java%3AS5852)

Fix Sonar warning: avoid regex with potential backtracking (ReDoS risk)
This change does not alter the functional behavior.