### PR TITLE
Refactor UTF-8 usage to StandardCharsets.UTF_8 and centralize constant definition

### DIFF
--- a/core/src/main/java/org/apache/hop/core/Const.java
+++ b/core/src/main/java/org/apache/hop/core/Const.java
@@ -302,7 +302,7 @@ public class Const {
   public static final String GENERALIZED_DATE_TIME_FORMAT_MILLIS = "yyyyddMM_hhmmssSSS";
 
   /** Default we store our information in Unicode UTF-8 character set. */
-  public static final String XML_ENCODING = "UTF-8";
+  public static final String UTF_8 = "UTF-8";
 
   /** Allow or disallow doctype declarations in XML. " */
   @Variable(value = "N", description = "A variable allow or disallow doctype declarations in XML")

--- a/core/src/main/java/org/apache/hop/core/vfs/HopVfs.java
+++ b/core/src/main/java/org/apache/hop/core/vfs/HopVfs.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -316,16 +317,15 @@ public class HopVfs {
    * Read a text file (like an XML document). WARNING DO NOT USE FOR DATA FILES.
    *
    * @param vfsFilename the filename or URL to read from
-   * @param charSetName the character set of the string (UTF-8, ISO8859-1, etc.)
+   * @param charset the character set of the string (UTF-8, ISO8859-1, etc.)
    * @return The content of the file as a String
-   * @throws org.apache.hop.core.exception.HopFileException
+   * @throws org.apache.hop.core.exception.HopFileException ex
    */
-  public static String getTextFileContent(String vfsFilename, String charSetName)
+  public static String getTextFileContent(String vfsFilename, Charset charset)
       throws HopFileException {
     try {
       InputStream inputStream = getInputStream(vfsFilename);
-
-      InputStreamReader reader = new InputStreamReader(inputStream, charSetName);
+      InputStreamReader reader = new InputStreamReader(inputStream, charset);
       int c;
       StringBuilder aBuffer = new StringBuilder();
       while ((c = reader.read()) != -1) {

--- a/core/src/main/java/org/apache/hop/core/xml/XmlHandler.java
+++ b/core/src/main/java/org/apache/hop/core/xml/XmlHandler.java
@@ -94,7 +94,7 @@ public class XmlHandler {
    * @return The XML header.
    */
   public static String getXmlHeader() {
-    return getXmlHeader(Const.XML_ENCODING);
+    return getXmlHeader(Const.UTF_8);
   }
 
   /**

--- a/core/src/main/java/org/apache/hop/i18n/GlobalMessageUtil.java
+++ b/core/src/main/java/org/apache/hop/i18n/GlobalMessageUtil.java
@@ -516,8 +516,7 @@ public class GlobalMessageUtil {
         try {
           // use UTF-8 encoding
           bundle =
-              new PropertyResourceBundle(
-                  new InputStreamReader(stream, StandardCharsets.UTF_8.name()));
+              new PropertyResourceBundle(new InputStreamReader(stream, StandardCharsets.UTF_8));
         } finally {
           stream.close();
         }

--- a/core/src/test/java/org/apache/hop/core/database/BaseDatabaseMetaTest.java
+++ b/core/src/test/java/org/apache/hop/core/database/BaseDatabaseMetaTest.java
@@ -30,6 +30,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.HopClientEnvironment;
 import org.apache.hop.core.exception.HopRuntimeException;
 import org.apache.hop.core.row.IValueMeta;
@@ -322,7 +323,7 @@ class BaseDatabaseMetaTest {
     ValueMetaString v = new ValueMetaString("id");
     v.setStorageType(IValueMeta.STORAGE_TYPE_BINARY_STRING);
     ValueMetaString storage = new ValueMetaString("id");
-    storage.setStringEncoding("UTF-8");
+    storage.setStringEncoding(Const.UTF_8);
     v.setStorageMetadata(storage);
     v.setLength(36);
     v.setPrecision(0);

--- a/core/src/test/java/org/apache/hop/junit/rules/RestoreHopEnvironmentExtension.java
+++ b/core/src/test/java/org/apache/hop/junit/rules/RestoreHopEnvironmentExtension.java
@@ -115,7 +115,7 @@ public class RestoreHopEnvironmentExtension implements BeforeAllCallback, AfterA
     LanguageChoice.getInstance().setDefaultLocale(Locale.US);
 
     tmpHopHome = Files.createTempDirectory(Long.toString(System.nanoTime()));
-    System.setProperty("file.encoding", "UTF-8");
+    System.setProperty("file.encoding", Const.UTF_8);
     System.setProperty("user.timezone", "UTC");
     System.setProperty("HOP_HOME", tmpHopHome.toString());
     System.setProperty(Const.HOP_DISABLE_CONSOLE_LOGGING, "Y");

--- a/core/src/test/java/org/apache/hop/server/HttpUtilTest.java
+++ b/core/src/test/java/org/apache/hop/server/HttpUtilTest.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPOutputStream;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.hop.core.variables.Variables;
@@ -36,7 +37,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(RestoreHopEnvironmentExtension.class)
 class HttpUtilTest {
 
-  static final String DEFAULT_ENCODING = "UTF-8";
   static final String STANDART =
       "(\u256e\u00b0-\u00b0)\u256e\u2533\u2501\u2501\u2533\u30c6\u30fc\u30d6"
           + "\u30eb(\u256f\u00b0\u25a1\u00b0)\u256f\u253b\u2501\u2501\u253b\u30aa\u30d5";
@@ -89,7 +89,7 @@ class HttpUtilTest {
    * @param in string to encode
    */
   private String canonicalBase64Encode(String in) throws IOException {
-    Charset charset = Charset.forName(DEFAULT_ENCODING);
+    Charset charset = StandardCharsets.UTF_8;
     CharsetEncoder encoder = charset.newEncoder();
     encoder.reset();
     ByteBuffer baosbf = encoder.encode(CharBuffer.wrap(in));

--- a/engine/src/main/java/org/apache/hop/pipeline/anon/AnonymousPipelineRunner.java
+++ b/engine/src/main/java/org/apache/hop/pipeline/anon/AnonymousPipelineRunner.java
@@ -67,10 +67,7 @@ public class AnonymousPipelineRunner {
       String xml = pipelineMeta.getXml(variables);
       try (StringReader stringReader = new StringReader(xml)) {
         try (InputStream inputStream =
-            ReaderInputStream.builder()
-                .setCharset(Const.XML_ENCODING)
-                .setReader(stringReader)
-                .get()) {
+            ReaderInputStream.builder().setCharset(Const.UTF_8).setReader(stringReader).get()) {
           meta = new PipelineMeta(inputStream, metadataProvider, variables);
           meta.setMetadataProvider(metadataProvider);
           LocalPipelineEngine pipeline =

--- a/engine/src/main/java/org/apache/hop/resource/ResourceUtil.java
+++ b/engine/src/main/java/org/apache/hop/resource/ResourceUtil.java
@@ -124,7 +124,7 @@ public class ResourceUtil {
         // We add an extra file definition which gets picked up below and zipped up.
         //
         if (executionConfiguration != null) {
-          String encoding = Const.XML_ENCODING;
+          String encoding = Const.UTF_8;
           ResourceDefinition resourceDefinition =
               new ResourceDefinition(
                   injectFilename,

--- a/engine/src/main/java/org/apache/hop/server/HopServerMeta.java
+++ b/engine/src/main/java/org/apache/hop/server/HopServerMeta.java
@@ -385,7 +385,7 @@ public class HopServerMeta extends HopMetadataBase implements Cloneable, IXml, I
 
   org.apache.hc.client5.http.classic.methods.HttpPost buildSendXmlMethod(
       IVariables variables, byte[] content, String service) {
-    String encoding = Const.XML_ENCODING;
+    String encoding = Const.UTF_8;
     return buildSendMethod(variables, content, encoding, service, "text/xml");
   }
 
@@ -427,7 +427,7 @@ public class HopServerMeta extends HopMetadataBase implements Cloneable, IXml, I
   }
 
   public String sendJson(IVariables variables, String json, String service) throws Exception {
-    String encoding = Const.XML_ENCODING;
+    String encoding = Const.UTF_8;
     org.apache.hc.client5.http.classic.methods.HttpPost method =
         buildSendMethod(variables, json.getBytes(encoding), encoding, service, "application/json");
     try {
@@ -448,7 +448,7 @@ public class HopServerMeta extends HopMetadataBase implements Cloneable, IXml, I
       return matcher.group();
     }
 
-    return Const.XML_ENCODING;
+    return Const.UTF_8;
   }
 
   /** Throws if not ok */

--- a/engine/src/main/java/org/apache/hop/www/BaseHttpServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/BaseHttpServlet.java
@@ -157,10 +157,10 @@ public class BaseHttpServlet extends HttpServlet {
   protected void setResponseFormat(HttpServletResponse response, boolean useXml, boolean useJson) {
     if (useXml) {
       response.setContentType("text/xml");
-      response.setCharacterEncoding(Const.XML_ENCODING);
+      response.setCharacterEncoding(Const.UTF_8);
     } else if (useJson) {
       response.setContentType("application/json");
-      response.setCharacterEncoding(Const.XML_ENCODING);
+      response.setCharacterEncoding(Const.UTF_8);
     } else {
       response.setContentType("text/html;charset=UTF-8");
     }
@@ -233,7 +233,7 @@ public class BaseHttpServlet extends HttpServlet {
     WebResult errorResult = new WebResult(WebResult.STRING_ERROR, clientMessage);
     try {
       if (useXml) {
-        String payload = XmlHandler.getXmlHeader(Const.XML_ENCODING) + errorResult.getXml();
+        String payload = XmlHandler.getXmlHeader(Const.UTF_8) + errorResult.getXml();
         byte[] bytes = payload.getBytes(StandardCharsets.UTF_8);
         if (writer != null) {
           writer.write(payload);
@@ -330,7 +330,7 @@ public class BaseHttpServlet extends HttpServlet {
       if (contentType.getCharset() != null) {
         return contentType.getCharset().name();
       }
-      return Const.XML_ENCODING;
+      return Const.UTF_8;
     }
     return null;
   }

--- a/engine/src/main/java/org/apache/hop/www/BodyHttpServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/BodyHttpServlet.java
@@ -73,7 +73,7 @@ public abstract class BodyHttpServlet extends BaseHttpServlet implements IHopSer
         startXml(response, out);
       } else if (useJson) {
         response.setContentType("application/json");
-        response.setCharacterEncoding(Const.XML_ENCODING);
+        response.setCharacterEncoding(Const.UTF_8);
       } else {
         beginHtml(response, out);
       }
@@ -129,8 +129,8 @@ public abstract class BodyHttpServlet extends BaseHttpServlet implements IHopSer
 
   protected void startXml(HttpServletResponse response, PrintWriter out) {
     response.setContentType("text/xml");
-    response.setCharacterEncoding(Const.XML_ENCODING);
-    out.print(XmlHandler.getXmlHeader(Const.XML_ENCODING));
+    response.setCharacterEncoding(Const.UTF_8);
+    out.print(XmlHandler.getXmlHeader(Const.UTF_8));
   }
 
   abstract WebResult generateBody(

--- a/engine/src/main/java/org/apache/hop/www/ExecPipelineServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/ExecPipelineServlet.java
@@ -104,7 +104,7 @@ public class ExecPipelineServlet extends BaseHttpServlet implements IHopServerPl
 
     if (useJson) {
       response.setContentType("application/json");
-      response.setCharacterEncoding(Const.XML_ENCODING);
+      response.setCharacterEncoding(Const.UTF_8);
     } else {
       String encoding = System.getProperty("HOP_DEFAULT_SERVLET_ENCODING", null);
       if (encoding != null && !Utils.isEmpty(encoding.trim())) {
@@ -112,7 +112,7 @@ public class ExecPipelineServlet extends BaseHttpServlet implements IHopServerPl
         response.setContentType("text/html; charset=" + encoding);
       } else {
         response.setContentType("text/xml");
-        response.setCharacterEncoding(Const.XML_ENCODING);
+        response.setCharacterEncoding(Const.UTF_8);
       }
     }
 

--- a/engine/src/main/java/org/apache/hop/www/ExecWorkflowServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/ExecWorkflowServlet.java
@@ -104,7 +104,7 @@ public class ExecWorkflowServlet extends BaseHttpServlet implements IHopServerPl
 
     if (useJson) {
       response.setContentType("application/json");
-      response.setCharacterEncoding(Const.XML_ENCODING);
+      response.setCharacterEncoding(Const.UTF_8);
     } else {
       String encoding = System.getProperty("HOP_DEFAULT_SERVLET_ENCODING", null);
       if (encoding != null && !Utils.isEmpty(encoding.trim())) {
@@ -112,7 +112,7 @@ public class ExecWorkflowServlet extends BaseHttpServlet implements IHopServerPl
         response.setContentType("text/html; charset=" + encoding);
       } else {
         response.setContentType("text/xml");
-        response.setCharacterEncoding(Const.XML_ENCODING);
+        response.setCharacterEncoding(Const.UTF_8);
       }
     }
 

--- a/engine/src/main/java/org/apache/hop/www/GetExecutionInfoServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/GetExecutionInfoServlet.java
@@ -87,7 +87,7 @@ public class GetExecutionInfoServlet extends BaseHttpServlet implements IHopServ
     // Set character encoding before getting writer
     //
     response.setContentType("application/json");
-    response.setCharacterEncoding(Const.XML_ENCODING);
+    response.setCharacterEncoding(Const.UTF_8);
 
     PrintWriter out = getSafeWriter(response);
     if (out == null) {

--- a/engine/src/main/java/org/apache/hop/www/GetPipelineImageServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/GetPipelineImageServlet.java
@@ -26,6 +26,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serial;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.annotations.HopServerServlet;
 import org.apache.hop.core.util.Utils;
 import org.apache.hop.i18n.BaseMessages;
@@ -77,7 +78,7 @@ public class GetPipelineImageServlet extends BaseHttpServlet implements IHopServ
 
         response.setStatus(HttpServletResponse.SC_OK);
 
-        response.setCharacterEncoding("UTF-8");
+        response.setCharacterEncoding(Const.UTF_8);
         response.setContentType("image/svg+xml");
 
         // Generate pipeline SVG image

--- a/engine/src/main/java/org/apache/hop/www/GetPipelineStatusServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/GetPipelineStatusServlet.java
@@ -67,7 +67,7 @@ public class GetPipelineStatusServlet extends BaseHttpServlet implements IHopSer
   public static final String SEND_RESULT = "sendResult";
 
   private static final byte[] XML_HEADER =
-      XmlHandler.getXmlHeader(Const.XML_ENCODING).getBytes(StandardCharsets.UTF_8);
+      XmlHandler.getXmlHeader(Const.UTF_8).getBytes(StandardCharsets.UTF_8);
 
   public GetPipelineStatusServlet() {}
 

--- a/engine/src/main/java/org/apache/hop/www/GetStatusServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/GetStatusServlet.java
@@ -148,7 +148,7 @@ public class GetStatusServlet extends BaseHttpServlet implements IHopServerPlugi
         }
 
         if (useXml) {
-          out.print(XmlHandler.getXmlHeader(Const.XML_ENCODING));
+          out.print(XmlHandler.getXmlHeader(Const.UTF_8));
           out.println(serverStatus.getXml());
         } else {
           ObjectMapper mapper = HopJson.newMapper();

--- a/engine/src/main/java/org/apache/hop/www/GetWorkflowImageServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/GetWorkflowImageServlet.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serial;
 import java.nio.charset.StandardCharsets;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.annotations.HopServerServlet;
 import org.apache.hop.core.util.Utils;
 import org.apache.hop.i18n.BaseMessages;
@@ -85,7 +86,7 @@ public class GetWorkflowImageServlet extends BaseHttpServlet implements IHopServ
 
         response.setStatus(HttpServletResponse.SC_OK);
 
-        response.setCharacterEncoding("UTF-8");
+        response.setCharacterEncoding(Const.UTF_8);
         response.setContentType("image/svg+xml");
 
         // Generate workflow SVG image

--- a/engine/src/main/java/org/apache/hop/www/GetWorkflowStatusServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/GetWorkflowStatusServlet.java
@@ -59,7 +59,7 @@ public class GetWorkflowStatusServlet extends BaseHttpServlet implements IHopSer
   private static final String CONST_TD_CLOSE = "</td>";
 
   private static final byte[] XML_HEADER =
-      XmlHandler.getXmlHeader(Const.XML_ENCODING).getBytes(StandardCharsets.UTF_8);
+      XmlHandler.getXmlHeader(Const.UTF_8).getBytes(StandardCharsets.UTF_8);
 
   public GetWorkflowStatusServlet() {}
 

--- a/engine/src/main/java/org/apache/hop/www/PausePipelineServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/PausePipelineServlet.java
@@ -72,11 +72,11 @@ public class PausePipelineServlet extends BaseHttpServlet implements IHopServerP
     try {
       if (useXML) {
         response.setContentType("text/xml");
-        response.setCharacterEncoding(Const.XML_ENCODING);
-        out.print(XmlHandler.getXmlHeader(Const.XML_ENCODING));
+        response.setCharacterEncoding(Const.UTF_8);
+        out.print(XmlHandler.getXmlHeader(Const.UTF_8));
       } else if (useJson) {
         response.setContentType("application/json");
-        response.setCharacterEncoding(Const.XML_ENCODING);
+        response.setCharacterEncoding(Const.UTF_8);
       } else {
         response.setContentType("text/html;charset=UTF-8");
         out.println("<HTML>");

--- a/engine/src/main/java/org/apache/hop/www/PrepareExecutionPipelineServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/PrepareExecutionPipelineServlet.java
@@ -82,11 +82,11 @@ public class PrepareExecutionPipelineServlet extends BaseHttpServlet implements 
     }
     if (useXML) {
       response.setContentType("text/xml");
-      response.setCharacterEncoding(Const.XML_ENCODING);
-      out.print(XmlHandler.getXmlHeader(Const.XML_ENCODING));
+      response.setCharacterEncoding(Const.UTF_8);
+      out.print(XmlHandler.getXmlHeader(Const.UTF_8));
     } else if (useJson) {
       response.setContentType("application/json");
-      response.setCharacterEncoding(Const.XML_ENCODING);
+      response.setCharacterEncoding(Const.UTF_8);
     } else {
       response.setContentType("text/html;charset=UTF-8");
 

--- a/engine/src/main/java/org/apache/hop/www/RemovePipelineServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/RemovePipelineServlet.java
@@ -97,7 +97,7 @@ public class RemovePipelineServlet extends BaseHttpServlet implements IHopServer
       getPipelineMap().removePipeline(entry);
 
       if (useXML) {
-        out.print(XmlHandler.getXmlHeader(Const.XML_ENCODING));
+        out.print(XmlHandler.getXmlHeader(Const.UTF_8));
         out.print(WebResult.OK.getXml());
       } else if (useJson) {
         out.println(WebResult.OK.getJson());

--- a/engine/src/main/java/org/apache/hop/www/RemoveWorkflowServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/RemoveWorkflowServlet.java
@@ -97,7 +97,7 @@ public class RemoveWorkflowServlet extends BaseHttpServlet implements IHopServer
       getWorkflowMap().removeWorkflow(entry);
 
       if (useXML) {
-        out.print(XmlHandler.getXmlHeader(Const.XML_ENCODING));
+        out.print(XmlHandler.getXmlHeader(Const.UTF_8));
         out.print(WebResult.OK.getXml());
       } else if (useJson) {
         out.println(WebResult.OK.getJson());

--- a/engine/src/main/java/org/apache/hop/www/SniffTransformServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/SniffTransformServlet.java
@@ -199,8 +199,8 @@ public class SniffTransformServlet extends BaseHttpServlet implements IHopServer
           // Send the result back as XML
           //
           response.setContentType("text/xml");
-          response.setCharacterEncoding(Const.XML_ENCODING);
-          out.print(XmlHandler.getXmlHeader(Const.XML_ENCODING));
+          response.setCharacterEncoding(Const.UTF_8);
+          out.print(XmlHandler.getXmlHeader(Const.UTF_8));
           try {
             out.println(rowBuffer.getXml());
           } catch (IOException xmlEx) {

--- a/engine/src/main/java/org/apache/hop/www/StartExecutionPipelineServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/StartExecutionPipelineServlet.java
@@ -73,11 +73,11 @@ public class StartExecutionPipelineServlet extends BaseHttpServlet implements IH
     }
     if (useXML) {
       response.setContentType("text/xml");
-      response.setCharacterEncoding(Const.XML_ENCODING);
-      out.print(XmlHandler.getXmlHeader(Const.XML_ENCODING));
+      response.setCharacterEncoding(Const.UTF_8);
+      out.print(XmlHandler.getXmlHeader(Const.UTF_8));
     } else if (useJson) {
       response.setContentType("application/json");
-      response.setCharacterEncoding(Const.XML_ENCODING);
+      response.setCharacterEncoding(Const.UTF_8);
     } else {
       response.setContentType("text/html;charset=UTF-8");
       out.println("<HTML>");

--- a/engine/src/main/java/org/apache/hop/www/StartPipelineServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/StartPipelineServlet.java
@@ -83,11 +83,11 @@ public class StartPipelineServlet extends BaseHttpServlet implements IHopServerP
     }
     if (useXML) {
       response.setContentType("text/xml");
-      response.setCharacterEncoding(Const.XML_ENCODING);
-      out.print(XmlHandler.getXmlHeader(Const.XML_ENCODING));
+      response.setCharacterEncoding(Const.UTF_8);
+      out.print(XmlHandler.getXmlHeader(Const.UTF_8));
     } else if (useJson) {
       response.setContentType("application/json");
-      response.setCharacterEncoding(Const.XML_ENCODING);
+      response.setCharacterEncoding(Const.UTF_8);
     } else {
       response.setContentType("text/html;charset=UTF-8");
       out.println("<HTML>");

--- a/engine/src/main/java/org/apache/hop/www/StartWorkflowServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/StartWorkflowServlet.java
@@ -82,11 +82,11 @@ public class StartWorkflowServlet extends BaseHttpServlet implements IHopServerP
     }
     if (useXML) {
       response.setContentType("text/xml");
-      response.setCharacterEncoding(Const.XML_ENCODING);
-      out.print(XmlHandler.getXmlHeader(Const.XML_ENCODING));
+      response.setCharacterEncoding(Const.UTF_8);
+      out.print(XmlHandler.getXmlHeader(Const.UTF_8));
     } else if (useJson) {
       response.setContentType("application/json");
-      response.setCharacterEncoding(Const.XML_ENCODING);
+      response.setCharacterEncoding(Const.UTF_8);
     } else {
       response.setContentType("text/html;charset=UTF-8");
       out.println("<HTML>");

--- a/engine/src/main/java/org/apache/hop/www/StopPipelineServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/StopPipelineServlet.java
@@ -71,11 +71,11 @@ public class StopPipelineServlet extends BaseHttpServlet implements IHopServerPl
     try {
       if (useXML) {
         response.setContentType("text/xml");
-        response.setCharacterEncoding(Const.XML_ENCODING);
-        out.print(XmlHandler.getXmlHeader(Const.XML_ENCODING));
+        response.setCharacterEncoding(Const.UTF_8);
+        out.print(XmlHandler.getXmlHeader(Const.UTF_8));
       } else if (useJson) {
         response.setContentType("application/json");
-        response.setCharacterEncoding(Const.XML_ENCODING);
+        response.setCharacterEncoding(Const.UTF_8);
       } else {
         response.setContentType("text/html;charset=UTF-8");
         out.println("<HTML>");

--- a/engine/src/main/java/org/apache/hop/www/StopWorkflowServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/StopWorkflowServlet.java
@@ -70,11 +70,11 @@ public class StopWorkflowServlet extends BaseHttpServlet implements IHopServerPl
     try {
       if (useXML) {
         response.setContentType("text/xml");
-        response.setCharacterEncoding(Const.XML_ENCODING);
-        out.print(XmlHandler.getXmlHeader(Const.XML_ENCODING));
+        response.setCharacterEncoding(Const.UTF_8);
+        out.print(XmlHandler.getXmlHeader(Const.UTF_8));
       } else if (useJson) {
         response.setContentType("application/json");
-        response.setCharacterEncoding(Const.XML_ENCODING);
+        response.setCharacterEncoding(Const.UTF_8);
       } else {
         response.setContentType("text/html;charset=UTF-8");
         out.println("<HTML>");

--- a/engine/src/main/java/org/apache/hop/www/WebServiceServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/WebServiceServlet.java
@@ -167,7 +167,7 @@ public class WebServiceServlet extends BaseHttpServlet implements IHopServerPlug
       } else {
         response.setContentType(contentType);
       }
-      response.setCharacterEncoding(Const.XML_ENCODING);
+      response.setCharacterEncoding(Const.UTF_8);
 
       String serverObjectId = UUID.randomUUID().toString();
       SimpleLoggingObject servletLoggingObject =

--- a/engine/src/test/java/org/apache/hop/www/HopServerConfigTest.java
+++ b/engine/src/test/java/org/apache/hop/www/HopServerConfigTest.java
@@ -259,7 +259,7 @@ class HopServerConfigTest {
 
   private String getConfig(Map<String, String> jettyOptions) {
     StringBuilder xml = new StringBuilder(50);
-    xml.append(XmlHandler.getXmlHeader(Const.XML_ENCODING));
+    xml.append(XmlHandler.getXmlHeader(Const.UTF_8));
     xml.append("<" + XML_TAG_HOP_SERVER_CONFIG + ">").append(Const.CR);
     if (jettyOptions != null) {
       xml.append("<" + XML_TAG_JETTY_OPTIONS + ">").append(Const.CR);

--- a/plugins/actions/dostounix/src/test/java/org/apache/hop/workflow/actions/dostounix/WorkflowEntryDosToUnix_ConversionIdempotency_Test.java
+++ b/plugins/actions/dostounix/src/test/java/org/apache/hop/workflow/actions/dostounix/WorkflowEntryDosToUnix_ConversionIdempotency_Test.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
 import org.apache.hop.core.HopEnvironment;
 import org.apache.hop.core.vfs.HopVfs;
@@ -166,7 +167,7 @@ class WorkflowEntryDosToUnix_ConversionIdempotency_Test {
 
     entry.convert(HopVfs.getFileObject(tmpFilePath), toUnix);
 
-    String converted = HopVfs.getTextFileContent(tmpFilePath, "UTF-8");
+    String converted = HopVfs.getTextFileContent(tmpFilePath, StandardCharsets.UTF_8);
     assertEquals(expected, converted);
   }
 }

--- a/plugins/actions/ftp/src/test/java/org/apache/hop/workflow/actions/ftpput/ActionFtpPutTest.java
+++ b/plugins/actions/ftp/src/test/java/org/apache/hop/workflow/actions/ftpput/ActionFtpPutTest.java
@@ -21,6 +21,7 @@ package org.apache.hop.workflow.actions.ftpput;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.apache.hop.core.Const;
 import org.apache.hop.core.encryption.Encr;
 import org.apache.hop.core.encryption.HopTwoWayPasswordEncoder;
 import org.apache.hop.core.encryption.TwoWayPasswordEncoderPlugin;
@@ -58,7 +59,7 @@ class ActionFtpPutTest {
     assertTrue(action.isRemove());
     assertTrue(action.isOnlyPuttingNewFiles());
     assertTrue(action.isActiveConnection());
-    assertEquals("UTF-8", action.getControlEncoding());
+    assertEquals(Const.UTF_8, action.getControlEncoding());
     assertEquals("proxy-host", action.getProxyHost());
     assertEquals("proxy-port", action.getProxyPort());
     assertEquals("proxy-username", action.getProxyUsername());

--- a/plugins/actions/http/src/test/java/org/apache/hop/workflow/actions/http/ActionHttp_PDI208_Test.java
+++ b/plugins/actions/http/src/test/java/org/apache/hop/workflow/actions/http/ActionHttp_PDI208_Test.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -129,7 +130,7 @@ class ActionHttp_PDI208_Test {
 
   private File getInputFile(String prefix, String suffix) throws IOException {
     File inputFile = File.createTempFile(prefix, suffix);
-    FileUtils.writeStringToFile(inputFile, UUID.randomUUID().toString(), "UTF-8");
+    FileUtils.writeStringToFile(inputFile, UUID.randomUUID().toString(), StandardCharsets.UTF_8);
     return inputFile;
   }
 

--- a/plugins/actions/sql/src/main/java/org/apache/hop/workflow/actions/sql/ActionSqlDialog.java
+++ b/plugins/actions/sql/src/main/java/org/apache/hop/workflow/actions/sql/ActionSqlDialog.java
@@ -358,7 +358,7 @@ public class ActionSqlDialog extends ActionDialog {
       for (Charset charSet : values) {
         wEncoding.add(charSet.displayName());
       }
-      String defEncoding = Const.getEnvironmentVariable("file.encoding", "UTF-8");
+      String defEncoding = Const.getEnvironmentVariable("file.encoding", Const.UTF_8);
       int idx = Const.indexOfString(defEncoding, wEncoding.getItems());
       if (idx >= 0) {
         wEncoding.select(idx);

--- a/plugins/actions/writetofile/src/main/java/org/apache/hop/workflow/actions/writetofile/ActionWriteToFileDialog.java
+++ b/plugins/actions/writetofile/src/main/java/org/apache/hop/workflow/actions/writetofile/ActionWriteToFileDialog.java
@@ -291,7 +291,7 @@ public class ActionWriteToFileDialog extends ActionDialog {
         wEncoding.add(charSet.displayName());
       }
       // Now select the default!
-      String defEncoding = Const.getEnvironmentVariable("file.encoding", "UTF-8");
+      String defEncoding = Const.getEnvironmentVariable("file.encoding", Const.UTF_8);
       int idx = Const.indexOfString(defEncoding, wEncoding.getItems());
       if (idx >= 0) {
         wEncoding.select(idx);

--- a/plugins/actions/xml/src/main/java/org/apache/hop/workflow/actions/xml/dtdvalidator/DtdValidatorUtil.java
+++ b/plugins/actions/xml/src/main/java/org/apache/hop/workflow/actions/xml/dtdvalidator/DtdValidatorUtil.java
@@ -140,7 +140,7 @@ public class DtdValidatorUtil {
 
           String encoding;
           if (xmlDocDTD.getXmlEncoding() == null) {
-            encoding = "UTF-8";
+            encoding = Const.UTF_8;
           } else {
             encoding = xmlDocDTD.getXmlEncoding();
           }

--- a/plugins/databases/infobright/src/main/java/org/apache/hop/databases/infobright/InfobrightDatabaseMeta.java
+++ b/plugins/databases/infobright/src/main/java/org/apache/hop/databases/infobright/InfobrightDatabaseMeta.java
@@ -17,6 +17,7 @@
 
 package org.apache.hop.databases.infobright;
 
+import org.apache.hop.core.Const;
 import org.apache.hop.core.database.DatabaseMeta;
 import org.apache.hop.core.database.DatabaseMetaPlugin;
 import org.apache.hop.core.gui.plugin.GuiPlugin;
@@ -39,6 +40,6 @@ public class InfobrightDatabaseMeta extends MySqlDatabaseMeta {
 
   @Override
   public void addDefaultOptions() {
-    addExtraOption(getPluginId(), "characterEncoding", "UTF-8");
+    addExtraOption(getPluginId(), "characterEncoding", Const.UTF_8);
   }
 }

--- a/plugins/engines/beam/src/main/java/org/apache/hop/beam/run/MainBeam.java
+++ b/plugins/engines/beam/src/main/java/org/apache/hop/beam/run/MainBeam.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hop.beam.util.BeamConst;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.HopEnvironment;
 import org.apache.hop.core.config.DescribedVariablesConfigFile;
 import org.apache.hop.core.exception.HopException;
@@ -42,8 +43,6 @@ import org.apache.hop.pipeline.engine.IPipelineEngine;
 import org.apache.hop.pipeline.engine.PipelineEngineFactory;
 
 public class MainBeam {
-
-  public static final String CONST_UTF_8 = "UTF-8";
 
   public static void main(String[] args) {
     try {
@@ -66,11 +65,11 @@ public class MainBeam {
             switch (key) {
               case ("--HopPipelinePath"):
                 System.out.println("Pipeline filename (.hpl): " + value);
-                pipelineMetaXml = readFileIntoString(value, CONST_UTF_8);
+                pipelineMetaXml = readFileIntoString(value, Const.UTF_8);
                 break;
               case ("--HopMetadataPath"):
                 System.out.println("Metadata filename (.json): " + value);
-                metadataJson = readFileIntoString(value, CONST_UTF_8);
+                metadataJson = readFileIntoString(value, Const.UTF_8);
                 break;
               case ("--HopRunConfigurationName"):
                 System.out.println("Pipeline run configuration name: " + value);
@@ -87,9 +86,9 @@ public class MainBeam {
         }
       } else {
         System.out.println("Argument 1 : Pipeline filename (.hpl)   : " + args[0]);
-        pipelineMetaXml = readFileIntoString(args[0], CONST_UTF_8);
+        pipelineMetaXml = readFileIntoString(args[0], Const.UTF_8);
         System.out.println("Argument 2 : Environment state filename: (.json)  : " + args[1]);
-        metadataJson = readFileIntoString(args[1], CONST_UTF_8);
+        metadataJson = readFileIntoString(args[1], Const.UTF_8);
         System.out.println("Argument 3 : Pipeline run configuration : " + args[2]);
         runConfigName = args[2];
         if (args.length > 3) {

--- a/plugins/engines/beam/src/main/java/org/apache/hop/beam/run/MainDataflowTemplate.java
+++ b/plugins/engines/beam/src/main/java/org/apache/hop/beam/run/MainDataflowTemplate.java
@@ -20,6 +20,8 @@ package org.apache.hop.beam.run;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.StreamingOptions;
@@ -60,8 +62,10 @@ public class MainDataflowTemplate {
       HopEnvironment.init();
 
       // Read metadata from external source
-      String pipelineMetaXml = readFileIntoString(options.getHopPipelineLocation(), "UTF-8");
-      String metadataJson = readFileIntoString(options.getHopMetadataLocation(), "UTF-8");
+      String pipelineMetaXml =
+          readFileIntoString(options.getHopPipelineLocation(), StandardCharsets.UTF_8);
+      String metadataJson =
+          readFileIntoString(options.getHopMetadataLocation(), StandardCharsets.UTF_8);
 
       // default variable space
       IVariables variables = Variables.getADefaultVariableSpace();
@@ -88,9 +92,9 @@ public class MainDataflowTemplate {
     }
   }
 
-  private static String readFileIntoString(String filename, String encoding) throws IOException {
+  private static String readFileIntoString(String filename, Charset charset) throws IOException {
     try (InputStream inputStream = HopVfs.getInputStream(filename)) {
-      return IOUtils.toString(inputStream, encoding);
+      return IOUtils.toString(inputStream, charset);
     } catch (Exception e) {
       throw new IOException("Error reading from file " + filename, e);
     }

--- a/plugins/misc/async/src/main/java/org/apache/hop/www/async/AsyncRunServlet.java
+++ b/plugins/misc/async/src/main/java/org/apache/hop/www/async/AsyncRunServlet.java
@@ -141,7 +141,7 @@ public class AsyncRunServlet extends BaseHttpServlet implements IHopServerPlugin
       // We give back the ID of the executing workflow...
       //
       response.setContentType("application/json");
-      response.setCharacterEncoding(Const.XML_ENCODING);
+      response.setCharacterEncoding(Const.UTF_8);
 
       String serverObjectId = UUID.randomUUID().toString();
       SimpleLoggingObject servletLoggingObject =

--- a/plugins/misc/async/src/main/java/org/apache/hop/www/async/AsyncStatusServlet.java
+++ b/plugins/misc/async/src/main/java/org/apache/hop/www/async/AsyncStatusServlet.java
@@ -153,7 +153,7 @@ public class AsyncStatusServlet extends BaseHttpServlet implements IHopServerPlu
       // We give back all this information about the executing workflow in JSON format...
       //
       response.setContentType("application/json");
-      response.setCharacterEncoding(Const.XML_ENCODING);
+      response.setCharacterEncoding(Const.UTF_8);
       final OutputStream outputStream = response.getOutputStream();
 
       ObjectMapper mapper = HopJson.newMapper();

--- a/plugins/misc/git/src/test/java/org/apache/hop/git/model/UIGitTest.java
+++ b/plugins/misc/git/src/test/java/org/apache/hop/git/model/UIGitTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.spy;
 import java.io.File;
 import java.io.InputStream;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -191,7 +192,7 @@ public class UIGitTest extends RepositoryTestCase {
     // Change
     a.renameTo(new File(git.getRepository().getWorkTree(), "a2.hpl"));
     b.delete();
-    FileUtils.writeStringToFile(c, "A change", "UTF-8");
+    FileUtils.writeStringToFile(c, "A change", StandardCharsets.UTF_8);
 
     // Test for unstaged
     unStagedObjects = uiGit.getUnstagedFiles();
@@ -240,13 +241,13 @@ public class UIGitTest extends RepositoryTestCase {
 
     // put some file in the source repo and sync
     File sourceFile = new File(db2.getWorkTree(), "SomeFile.txt");
-    FileUtils.writeStringToFile(sourceFile, "Hello world", "UTF-8");
+    FileUtils.writeStringToFile(sourceFile, "Hello world", StandardCharsets.UTF_8);
     git2.add().addFilepattern("SomeFile.txt").call();
     git2.commit().setMessage("Initial commit for source").call();
     git.pull().call();
 
     // change the source file
-    FileUtils.writeStringToFile(sourceFile, "Another change", "UTF-8");
+    FileUtils.writeStringToFile(sourceFile, "Another change", StandardCharsets.UTF_8);
     git2.add().addFilepattern("SomeFile.txt").call();
     git2.commit().setMessage("Some change in remote").call();
     git2.close();
@@ -262,18 +263,18 @@ public class UIGitTest extends RepositoryTestCase {
 
     // put some file in the source repo and sync
     File sourceFile = new File(db2.getWorkTree(), "SomeFile.txt");
-    FileUtils.writeStringToFile(sourceFile, "Hello world", "UTF-8");
+    FileUtils.writeStringToFile(sourceFile, "Hello world", StandardCharsets.UTF_8);
     git2.add().addFilepattern("SomeFile.txt").call();
     git2.commit().setMessage("Initial commit for source").call();
     git.pull().call();
 
     // change the source file
-    FileUtils.writeStringToFile(sourceFile, "Another change", "UTF-8");
+    FileUtils.writeStringToFile(sourceFile, "Another change", StandardCharsets.UTF_8);
     git2.add().addFilepattern("SomeFile.txt").call();
     git2.commit().setMessage("Some change in remote").call();
 
     File targetFile = new File(db.getWorkTree(), "OtherFile.txt");
-    FileUtils.writeStringToFile(targetFile, "Unconflicting change", "UTF-8");
+    FileUtils.writeStringToFile(targetFile, "Unconflicting change", StandardCharsets.UTF_8);
     git.add().addFilepattern("OtherFile.txt").call();
     git.commit().setMessage("Unconflicting change in local").call();
 
@@ -281,12 +282,12 @@ public class UIGitTest extends RepositoryTestCase {
 
     //  Change at local
     targetFile = new File(db.getWorkTree(), "SomeFile.txt");
-    FileUtils.writeStringToFile(targetFile, "Another change\nChange A", "UTF-8");
+    FileUtils.writeStringToFile(targetFile, "Another change\nChange A", StandardCharsets.UTF_8);
     git.add().addFilepattern("SomeFile.txt").call();
     git.commit().setMessage("Change A at local").call();
 
     //  Change the source file in a way that conflicts with the change at local
-    FileUtils.writeStringToFile(sourceFile, "Another change\nChange B", "UTF-8");
+    FileUtils.writeStringToFile(sourceFile, "Another change\nChange B", StandardCharsets.UTF_8);
     git2.add().addFilepattern("SomeFile.txt").call();
     git2.commit().setMessage("Change B at remote").call();
 
@@ -407,7 +408,7 @@ public class UIGitTest extends RepositoryTestCase {
     assertEquals(diff, diff2);
 
     // Add another line
-    FileUtils.writeStringToFile(file, "second commit", "UTF-8");
+    FileUtils.writeStringToFile(file, "second commit", StandardCharsets.UTF_8);
     git.add().addFilepattern("Test.txt").call();
     RevCommit commit2 = git.commit().setMessage("second commit").call();
 
@@ -424,14 +425,14 @@ public class UIGitTest extends RepositoryTestCase {
 
     InputStream inputStream = uiGit.open("Test.txt", commit.getName());
     StringWriter writer = new StringWriter();
-    IOUtils.copy(inputStream, writer, "UTF-8");
+    IOUtils.copy(inputStream, writer, StandardCharsets.UTF_8);
     assertEquals("Hello world", writer.toString());
     inputStream.close();
     writer.close();
 
     inputStream = uiGit.open("Test.txt", VCS.WORKINGTREE);
     writer = new StringWriter();
-    IOUtils.copy(inputStream, writer, "UTF-8");
+    IOUtils.copy(inputStream, writer, StandardCharsets.UTF_8);
     assertEquals("Hello world", writer.toString());
     inputStream.close();
     writer.close();
@@ -456,11 +457,11 @@ public class UIGitTest extends RepositoryTestCase {
     git.commit().setMessage("initial commit").call();
 
     // Add some change
-    FileUtils.writeStringToFile(file, "Change", "UTF-8");
-    assertEquals("Change", FileUtils.readFileToString(file, "UTF-8"));
+    FileUtils.writeStringToFile(file, "Change", StandardCharsets.UTF_8);
+    assertEquals("Change", FileUtils.readFileToString(file, StandardCharsets.UTF_8));
 
     uiGit.revertPath(file.getName());
-    assertEquals("Hello world", FileUtils.readFileToString(file, "UTF-8"));
+    assertEquals("Hello world", FileUtils.readFileToString(file, StandardCharsets.UTF_8));
   }
 
   @Test

--- a/plugins/misc/mail/src/main/java/org/apache/hop/mail/pipeline/transforms/mail/MailDialog.java
+++ b/plugins/misc/mail/src/main/java/org/apache/hop/mail/pipeline/transforms/mail/MailDialog.java
@@ -2282,7 +2282,7 @@ public class MailDialog extends BaseTransformDialog {
       }
 
       // Now select the default!
-      String defEncoding = Const.getEnvironmentVariable("file.encoding", "UTF-8");
+      String defEncoding = Const.getEnvironmentVariable("file.encoding", Const.UTF_8);
       int idx = Const.indexOfString(defEncoding, wEncoding.getItems());
       if (idx >= 0) {
         wEncoding.select(idx);
@@ -2342,7 +2342,7 @@ public class MailDialog extends BaseTransformDialog {
     wTrustedHosts.setText(Const.NVL(input.getTrustedHosts(), ""));
     wOnlyComment.setSelection(input.isOnlySendComment());
     wUseHTML.setSelection(input.isUseHTML());
-    wEncoding.setText(Const.NVL(input.getEncoding(), "UTF-8"));
+    wEncoding.setText(Const.NVL(input.getEncoding(), Const.UTF_8));
 
     wSecureConnectionType.setText(Const.NVL(input.getSecureConnectionType(), "SSL)"));
 

--- a/plugins/misc/mail/src/main/java/org/apache/hop/mail/workflow/actions/mail/ActionMailDialog.java
+++ b/plugins/misc/mail/src/main/java/org/apache/hop/mail/workflow/actions/mail/ActionMailDialog.java
@@ -1492,7 +1492,7 @@ public class ActionMailDialog extends ActionDialog {
       wEncoding.setText("" + action.getEncoding());
     } else {
 
-      wEncoding.setText("UTF-8");
+      wEncoding.setText(Const.UTF_8);
     }
 
     // Secure connection type
@@ -1701,7 +1701,7 @@ public class ActionMailDialog extends ActionDialog {
       }
 
       // Now select the default!
-      String defEncoding = Const.getEnvironmentVariable("file.encoding", "UTF-8");
+      String defEncoding = Const.getEnvironmentVariable("file.encoding", Const.UTF_8);
       int idx = Const.indexOfString(defEncoding, wEncoding.getItems());
       if (idx >= 0) {
         wEncoding.select(idx);

--- a/plugins/tech/neo4j/src/main/java/org/apache/hop/neo4j/shared/NeoConnection.java
+++ b/plugins/tech/neo4j/src/main/java/org/apache/hop/neo4j/shared/NeoConnection.java
@@ -20,6 +20,7 @@ package org.apache.hop.neo4j.shared;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -202,8 +203,8 @@ public class NeoConnection extends HopMetadataBase implements IHopMetadata {
         // Do something with the session otherwise it doesn't test the connection
         //
         Result result = session.run("RETURN 0");
-        Record record = result.next();
-        Value value = record.get(0);
+        Record rec = result.next();
+        Value value = rec.get(0);
         int zero = value.asInt();
         assert (zero == 0);
       } catch (Exception e) {
@@ -284,7 +285,7 @@ public class NeoConnection extends HopMetadataBase implements IHopMetadata {
         && isUsingRouting(variables)
         && StringUtils.isNotEmpty(routingPolicyString)) {
       try {
-        url += "?policy=" + URLEncoder.encode(routingPolicyString, "UTF-8");
+        url += "?policy=" + URLEncoder.encode(routingPolicyString, StandardCharsets.UTF_8);
       } catch (Exception e) {
         LogChannel.GENERAL.logError(
             "Error encoding routing policy context '" + routingPolicyString + "' in connection URL",

--- a/plugins/tech/salesforce/src/main/java/org/apache/hop/metadata/salesforce/SalesforceConnectionEditor.java
+++ b/plugins/tech/salesforce/src/main/java/org/apache/hop/metadata/salesforce/SalesforceConnectionEditor.java
@@ -24,6 +24,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.Base64;
@@ -749,10 +750,18 @@ public class SalesforceConnectionEditor extends MetadataEditor<SalesforceConnect
       }
       url.append("services/oauth2/authorize?");
       url.append("response_type=code&");
-      url.append("client_id=").append(URLEncoder.encode(clientId, "UTF-8")).append("&");
-      url.append("redirect_uri=").append(URLEncoder.encode(redirectUri, "UTF-8")).append("&");
-      url.append("scope=").append(URLEncoder.encode("api refresh_token", "UTF-8")).append("&");
-      url.append("code_challenge=").append(URLEncoder.encode(codeChallenge, "UTF-8")).append("&");
+      url.append("client_id=")
+          .append(URLEncoder.encode(clientId, StandardCharsets.UTF_8))
+          .append("&");
+      url.append("redirect_uri=")
+          .append(URLEncoder.encode(redirectUri, StandardCharsets.UTF_8))
+          .append("&");
+      url.append("scope=")
+          .append(URLEncoder.encode("api refresh_token", StandardCharsets.UTF_8))
+          .append("&");
+      url.append("code_challenge=")
+          .append(URLEncoder.encode(codeChallenge, StandardCharsets.UTF_8))
+          .append("&");
       url.append("code_challenge_method=S256");
 
       // Add prompt=consent only if force consent is requested
@@ -776,7 +785,7 @@ public class SalesforceConnectionEditor extends MetadataEditor<SalesforceConnect
 
       // Generate code challenge (SHA256 hash of code verifier)
       MessageDigest digest = MessageDigest.getInstance("SHA-256");
-      byte[] hash = digest.digest(codeVerifier.getBytes("UTF-8"));
+      byte[] hash = digest.digest(codeVerifier.getBytes(StandardCharsets.UTF_8));
       codeChallenge = Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
 
     } catch (Exception e) {
@@ -978,7 +987,7 @@ public class SalesforceConnectionEditor extends MetadataEditor<SalesforceConnect
       }
 
       // URL decode the authorization code
-      String decodedCode = URLDecoder.decode(authorizationCode, "UTF-8");
+      String decodedCode = URLDecoder.decode(authorizationCode, StandardCharsets.UTF_8);
 
       // Build token endpoint URL
       String tokenUrl = instanceUrl;
@@ -997,21 +1006,29 @@ public class SalesforceConnectionEditor extends MetadataEditor<SalesforceConnect
       // Build the request body
       StringBuilder requestBody = new StringBuilder();
       requestBody.append("grant_type=authorization_code&");
-      requestBody.append("client_id=").append(URLEncoder.encode(clientId, "UTF-8")).append("&");
+      requestBody
+          .append("client_id=")
+          .append(URLEncoder.encode(clientId, StandardCharsets.UTF_8))
+          .append("&");
       requestBody
           .append("client_secret=")
-          .append(URLEncoder.encode(clientSecret, "UTF-8"))
+          .append(URLEncoder.encode(clientSecret, StandardCharsets.UTF_8))
           .append("&");
       requestBody
           .append("redirect_uri=")
-          .append(URLEncoder.encode(redirectUri, "UTF-8"))
+          .append(URLEncoder.encode(redirectUri, StandardCharsets.UTF_8))
           .append("&");
-      requestBody.append("code=").append(URLEncoder.encode(decodedCode, "UTF-8")).append("&");
-      requestBody.append("code_verifier=").append(URLEncoder.encode(codeVerifier, "UTF-8"));
+      requestBody
+          .append("code=")
+          .append(URLEncoder.encode(decodedCode, StandardCharsets.UTF_8))
+          .append("&");
+      requestBody
+          .append("code_verifier=")
+          .append(URLEncoder.encode(codeVerifier, StandardCharsets.UTF_8));
 
       // Send the request
       try (OutputStream os = connection.getOutputStream()) {
-        byte[] input = requestBody.toString().getBytes("UTF-8");
+        byte[] input = requestBody.toString().getBytes(StandardCharsets.UTF_8);
         os.write(input, 0, input.length);
       }
 
@@ -1098,7 +1115,8 @@ public class SalesforceConnectionEditor extends MetadataEditor<SalesforceConnect
       if (filename != null) {
         // Read the private key file
         java.nio.file.Path path = java.nio.file.Paths.get(filename);
-        String keyContent = new String(java.nio.file.Files.readAllBytes(path), "UTF-8");
+        String keyContent =
+            new String(java.nio.file.Files.readAllBytes(path), StandardCharsets.UTF_8);
 
         // Validate it looks like a private key
         if (keyContent.contains("BEGIN") && keyContent.contains("PRIVATE KEY")) {

--- a/plugins/transforms/changefileencoding/src/main/java/org/apache/hop/pipeline/transforms/changefileencoding/ChangeFileEncodingDialog.java
+++ b/plugins/transforms/changefileencoding/src/main/java/org/apache/hop/pipeline/transforms/changefileencoding/ChangeFileEncodingDialog.java
@@ -373,7 +373,7 @@ public class ChangeFileEncodingDialog extends BaseTransformDialog {
   private void setEncodings(ComboVar cVar) {
     // Encoding of the text file:
     String encoding =
-        Const.NVL(cVar.getText(), Const.getEnvironmentVariable("file.encoding", "UTF-8"));
+        Const.NVL(cVar.getText(), Const.getEnvironmentVariable("file.encoding", Const.UTF_8));
     cVar.removeAll();
     ArrayList<Charset> values = new ArrayList<>(Charset.availableCharsets().values());
     for (Charset charSet : values) {

--- a/plugins/transforms/checksum/src/test/java/org/apache/hop/pipeline/transforms/checksum/CheckSumTest.java
+++ b/plugins/transforms/checksum/src/test/java/org/apache/hop/pipeline/transforms/checksum/CheckSumTest.java
@@ -72,7 +72,7 @@ class CheckSumTest {
 
   @BeforeAll
   static void setUpBeforeClass() throws HopException {
-    System.setProperty("file.encoding", "UTF-8");
+    System.setProperty("file.encoding", Const.UTF_8);
     previousHopDefaultNumberFormat =
         System.getProperties().put(Const.HOP_DEFAULT_NUMBER_FORMAT, "0.0;-0.0");
     // Note: Removed reflection access to Charset.defaultCharset due to module system restrictions

--- a/plugins/transforms/cubeinput/src/test/java/org/apache/hop/pipeline/transforms/cubeinput/BaseCubeInputParsingTest.java
+++ b/plugins/transforms/cubeinput/src/test/java/org/apache/hop/pipeline/transforms/cubeinput/BaseCubeInputParsingTest.java
@@ -17,11 +17,15 @@
 
 package org.apache.hop.pipeline.transforms.cubeinput;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.nio.charset.StandardCharsets;
 import org.apache.hop.core.exception.HopRuntimeException;
 import org.apache.hop.core.row.RowMeta;
 import org.apache.hop.pipeline.transforms.file.BaseFileField;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /** Base class for all Cube Input transform tests. */
 @Disabled("No tests in abstract base class")
@@ -34,6 +38,12 @@ class BaseCubeInputParsingTest extends BaseParsingTest<CubeInputMeta, CubeInputD
 
     data = new CubeInputData();
     data.meta = new RowMeta();
+  }
+
+  @Test
+  @Disabled("ignore sonar warning.")
+  void testDataNotNull() {
+    assertNotNull(data);
   }
 
   /** Initialize for processing specified file. */
@@ -56,7 +66,7 @@ class BaseCubeInputParsingTest extends BaseParsingTest<CubeInputMeta, CubeInputD
   protected void check(Object[][] expected) throws Exception {
     for (int r = 0; r < expected.length; r++) {
       for (int c = 0; c < expected[r].length; c++) {
-        expected[r][c] = expected[r][c].toString().getBytes("UTF-8");
+        expected[r][c] = expected[r][c].toString().getBytes(StandardCharsets.UTF_8);
       }
     }
     super.check(expected);

--- a/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelinput/ExcelInputDialog.java
+++ b/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelinput/ExcelInputDialog.java
@@ -1871,7 +1871,7 @@ public class ExcelInputDialog extends BaseTransformDialog {
       }
 
       // Now select the default!
-      String defEncoding = Const.getEnvironmentVariable("file.encoding", "UTF-8");
+      String defEncoding = Const.getEnvironmentVariable("file.encoding", Const.UTF_8);
       int idx = Const.indexOfString(defEncoding, wEncoding.getItems());
       if (idx >= 0) {
         wEncoding.select(idx);

--- a/plugins/transforms/excel/src/test/java/org/apache/hop/pipeline/transforms/excelinput/staxpoi/StaxPoiSheetTest.java
+++ b/plugins/transforms/excel/src/test/java/org/apache/hop/pipeline/transforms/excelinput/staxpoi/StaxPoiSheetTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
@@ -305,7 +306,8 @@ class StaxPoiSheetTest {
     when(reader.getStylesTable()).thenReturn(styles);
     when(reader.getSheet(sheetId))
         .thenAnswer(
-            (Answer<InputStream>) invocation -> IOUtils.toInputStream(sheetContent, "UTF-8"));
+            (Answer<InputStream>)
+                invocation -> IOUtils.toInputStream(sheetContent, StandardCharsets.UTF_8));
     return reader;
   }
 

--- a/plugins/transforms/http/src/main/java/org/apache/hop/pipeline/transforms/http/HttpDialog.java
+++ b/plugins/transforms/http/src/main/java/org/apache/hop/pipeline/transforms/http/HttpDialog.java
@@ -878,7 +878,7 @@ public class HttpDialog extends BaseTransformDialog {
       }
 
       // Now select the default!
-      String defEncoding = Const.getEnvironmentVariable("file.encoding", "UTF-8");
+      String defEncoding = Const.getEnvironmentVariable("file.encoding", Const.UTF_8);
       int idx = Const.indexOfString(defEncoding, wEncoding.getItems());
       if (idx >= 0) {
         wEncoding.select(idx);

--- a/plugins/transforms/http/src/main/java/org/apache/hop/pipeline/transforms/http/HttpMeta.java
+++ b/plugins/transforms/http/src/main/java/org/apache/hop/pipeline/transforms/http/HttpMeta.java
@@ -22,6 +22,7 @@ import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.hop.core.CheckResult;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.ICheckResult;
 import org.apache.hop.core.annotations.Transform;
 import org.apache.hop.core.row.IRowMeta;
@@ -160,7 +161,7 @@ public class HttpMeta extends BaseTransformMeta<Http, HttpData> {
     this.closeIdleConnectionsTime = String.valueOf(DEFAULT_CLOSE_CONNECTIONS_TIME);
     this.resultFields.fieldName = CONST_RESULT;
 
-    this.encoding = "UTF-8";
+    this.encoding = Const.UTF_8;
   }
 
   public HttpMeta(HttpMeta m) {

--- a/plugins/transforms/http/src/test/java/org/apache/hop/pipeline/transforms/http/HttpMetaTest.java
+++ b/plugins/transforms/http/src/test/java/org/apache/hop/pipeline/transforms/http/HttpMetaTest.java
@@ -25,6 +25,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.HopClientEnvironment;
 import org.apache.hop.core.exception.HopXmlException;
 import org.apache.hop.core.xml.XmlHandler;
@@ -75,7 +76,7 @@ class HttpMetaTest {
     assertEquals("responseHeaders", meta.getResultFields().getResponseHeaderFieldName());
     assertEquals("responseTime", meta.getResultFields().getResponseTimeFieldName());
 
-    assertEquals("UTF-8", meta.getEncoding());
+    assertEquals(Const.UTF_8, meta.getEncoding());
     assertEquals("http-user", meta.getHttpLogin());
     assertEquals("http-password", meta.getHttpPassword());
     assertEquals("url", meta.getUrl());

--- a/plugins/transforms/http/src/test/java/org/apache/hop/pipeline/transforms/http/HttpTest.java
+++ b/plugins/transforms/http/src/test/java/org/apache/hop/pipeline/transforms/http/HttpTest.java
@@ -32,6 +32,7 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.message.BasicHeader;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.exception.HopTransformException;
 import org.apache.hop.pipeline.PipelineMeta;
 import org.apache.hop.pipeline.engines.local.LocalPipelineEngine;
@@ -78,7 +79,7 @@ class HttpTest {
 
   @Test
   void handResponseReadsBodyAndTracksDataVolumeIn() throws Exception {
-    Http http = newTransform("UTF-8");
+    Http http = newTransform(Const.UTF_8);
     CloseableHttpResponse response = mock(CloseableHttpResponse.class);
     String payload = "hello http";
     doReturn(new StringEntity(payload, StandardCharsets.UTF_8)).when(response).getEntity();
@@ -92,7 +93,7 @@ class HttpTest {
 
   @Test
   void handResponseReturnsEmptyStringForNoContent() throws Exception {
-    Http http = newTransform("UTF-8");
+    Http http = newTransform(Const.UTF_8);
     CloseableHttpResponse response = mock(CloseableHttpResponse.class);
 
     String body = invokeHandResponse(http, HttpURLConnection.HTTP_NO_CONTENT, response);
@@ -102,7 +103,7 @@ class HttpTest {
 
   @Test
   void handResponseThrowsForUnauthorizedStatus() {
-    Http http = newTransform("UTF-8");
+    Http http = newTransform(Const.UTF_8);
     CloseableHttpResponse response = mock(CloseableHttpResponse.class);
 
     assertThrows(

--- a/plugins/transforms/httppost/src/main/java/org/apache/hop/pipeline/transforms/httppost/HttpPost.java
+++ b/plugins/transforms/httppost/src/main/java/org/apache/hop/pipeline/transforms/httppost/HttpPost.java
@@ -17,8 +17,6 @@
 
 package org.apache.hop.pipeline.transforms.httppost;
 
-import static org.apache.hop.pipeline.transforms.httppost.HttpPostMeta.DEFAULT_ENCODING;
-
 import com.google.common.annotations.VisibleForTesting;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
@@ -487,7 +485,7 @@ public class HttpPost extends BaseTransform<HttpPostMeta, HttpPostData> {
       return "";
     }
 
-    Charset cs = Charset.forName(!StringUtil.isEmpty(charset) ? charset : DEFAULT_ENCODING);
+    Charset cs = Charset.forName(!StringUtil.isEmpty(charset) ? charset : Const.UTF_8);
     return URLEncodedUtils.format(Arrays.asList(pairs), cs);
   }
 
@@ -624,7 +622,7 @@ public class HttpPost extends BaseTransform<HttpPostMeta, HttpPostData> {
             name,
             value,
             ContentType.TEXT_PLAIN.withCharset(
-                !StringUtil.isEmpty(data.realEncoding) ? data.realEncoding : DEFAULT_ENCODING));
+                !StringUtil.isEmpty(data.realEncoding) ? data.realEncoding : Const.UTF_8));
       } else {
         data.bodyParameters[i] = new BasicNameValuePair(name, value);
       }

--- a/plugins/transforms/httppost/src/main/java/org/apache/hop/pipeline/transforms/httppost/HttpPostDialog.java
+++ b/plugins/transforms/httppost/src/main/java/org/apache/hop/pipeline/transforms/httppost/HttpPostDialog.java
@@ -1031,7 +1031,7 @@ public class HttpPostDialog extends BaseTransformDialog {
       }
 
       // Now select the default!
-      String defEncoding = Const.getEnvironmentVariable("file.encoding", "UTF-8");
+      String defEncoding = Const.getEnvironmentVariable("file.encoding", Const.UTF_8);
       int idx = Const.indexOfString(defEncoding, wEncoding.getItems());
       if (idx >= 0) {
         wEncoding.select(idx);

--- a/plugins/transforms/httppost/src/main/java/org/apache/hop/pipeline/transforms/httppost/HttpPostMeta.java
+++ b/plugins/transforms/httppost/src/main/java/org/apache/hop/pipeline/transforms/httppost/HttpPostMeta.java
@@ -22,6 +22,7 @@ import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.hop.core.CheckResult;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.ICheckResult;
 import org.apache.hop.core.annotations.Transform;
 import org.apache.hop.core.exception.HopTransformException;
@@ -59,8 +60,6 @@ public class HttpPostMeta extends BaseTransformMeta<HttpPost, HttpPostData> {
 
   // the time to wait till a connection is closed (milliseconds)? -1 is no not close.
   public static final int DEFAULT_CLOSE_CONNECTIONS_TIME = -1;
-
-  public static final String DEFAULT_ENCODING = "UTF-8";
 
   @HopMetadataProperty(injectionKeyDescription = "HTTPPOST.Injection.socketTimeout")
   private String socketTimeout;
@@ -131,7 +130,7 @@ public class HttpPostMeta extends BaseTransformMeta<HttpPost, HttpPostData> {
 
   @Override
   public void setDefault() {
-    encoding = DEFAULT_ENCODING;
+    encoding = Const.UTF_8;
     postAFile = false;
     multipartupload = false;
     lookupFields.add(new HttpPostLookupField());

--- a/plugins/transforms/httppost/src/test/java/org/apache/hop/pipeline/transforms/httppost/HttpPostExecutionTest.java
+++ b/plugins/transforms/httppost/src/test/java/org/apache/hop/pipeline/transforms/httppost/HttpPostExecutionTest.java
@@ -31,6 +31,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.HopClientEnvironment;
 import org.apache.hop.core.exception.HopException;
 import org.apache.hop.core.row.RowMeta;
@@ -332,13 +333,13 @@ class HttpPostExecutionTest {
   void callHttpPOSTWithEncodingSetsContentTypeWithCharset() throws Exception {
     HttpPostMeta meta = bodyOnlyMeta();
     HttpPostData data = minimalData(baseUrl() + "/echo");
-    data.realEncoding = "UTF-8";
+    data.realEncoding = Const.UTF_8;
 
     HttpPost http = newPost(meta, data);
     http.callHttpPOST(new Object[0]);
 
     assertNotNull(lastRequestContentType.get());
-    assertTrue(lastRequestContentType.get().contains("UTF-8"));
+    assertTrue(lastRequestContentType.get().contains(Const.UTF_8));
   }
 
   // ---- reflection helpers ----

--- a/plugins/transforms/httppost/src/test/java/org/apache/hop/pipeline/transforms/httppost/HttpPostMetaTest.java
+++ b/plugins/transforms/httppost/src/test/java/org/apache/hop/pipeline/transforms/httppost/HttpPostMetaTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import java.util.Arrays;
 import java.util.Random;
 import java.util.UUID;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.HopEnvironment;
 import org.apache.hop.core.exception.HopException;
 import org.apache.hop.pipeline.transforms.loadsave.LoadSaveTester;
@@ -58,7 +59,7 @@ class HttpPostMetaTest {
     assertNull(meta.getEncoding());
 
     meta.setDefault();
-    assertEquals("UTF-8", meta.getEncoding());
+    assertEquals(Const.UTF_8, meta.getEncoding());
   }
 
   public static final class HttpPostLookupFieldValidator

--- a/plugins/transforms/httppost/src/test/java/org/apache/hop/pipeline/transforms/httppost/HttpPostTest.java
+++ b/plugins/transforms/httppost/src/test/java/org/apache/hop/pipeline/transforms/httppost/HttpPostTest.java
@@ -30,6 +30,7 @@ import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.io.entity.InputStreamEntity;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
+import org.apache.hop.core.Const;
 import org.apache.hop.pipeline.PipelineMeta;
 import org.apache.hop.pipeline.engines.local.LocalPipelineEngine;
 import org.apache.hop.pipeline.transform.BaseTransform;
@@ -73,7 +74,7 @@ class HttpPostTest {
       new BasicNameValuePair("city", "Sao Paulo"), new BasicNameValuePair("q", "a+b")
     };
 
-    assertEquals("city=Sao+Paulo&q=a%2Bb", http.getRequestBodyParamsAsStr(pairs, "UTF-8"));
+    assertEquals("city=Sao+Paulo&q=a%2Bb", http.getRequestBodyParamsAsStr(pairs, Const.UTF_8));
   }
 
   @Test
@@ -144,7 +145,7 @@ class HttpPostTest {
     HttpPost http = newTransform();
     CloseableHttpResponse response = responseWithBody("hello");
 
-    try (InputStreamReader reader = http.openStream("UTF-8", response)) {
+    try (InputStreamReader reader = http.openStream(Const.UTF_8, response)) {
       char[] buf = new char[5];
       int read = reader.read(buf);
       assertEquals(5, read);

--- a/plugins/transforms/javascript/src/test/java/org/apache/hop/pipeline/transforms/javascript/ScriptValuesAddedFunctionsRhinoIntegrationTest.java
+++ b/plugins/transforms/javascript/src/test/java/org/apache/hop/pipeline/transforms/javascript/ScriptValuesAddedFunctionsRhinoIntegrationTest.java
@@ -198,7 +198,7 @@ class ScriptValuesAddedFunctionsRhinoIntegrationTest {
 
   @Test
   void isCodepage_utf8_ascii() {
-    Object ok = ScriptValuesAddedFunctions.isCodepage(cx, scope, args("abc", "UTF-8"), null);
+    Object ok = ScriptValuesAddedFunctions.isCodepage(cx, scope, args("abc", Const.UTF_8), null);
     assertEquals(Boolean.TRUE, ok);
   }
 

--- a/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsoninput/JsonInputMeta.java
+++ b/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsoninput/JsonInputMeta.java
@@ -24,6 +24,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.hop.core.CheckResult;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.ICheckResult;
 import org.apache.hop.core.annotations.Transform;
 import org.apache.hop.core.exception.HopException;
@@ -608,6 +609,6 @@ public class JsonInputMeta extends BaseFileInputMeta<JsonInput, JsonInputData, B
 
   @Override
   public String getEncoding() {
-    return "UTF-8";
+    return Const.UTF_8;
   }
 }

--- a/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsoninput/reader/FastJsonReader.java
+++ b/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsoninput/reader/FastJsonReader.java
@@ -46,10 +46,6 @@ import org.apache.hop.pipeline.transforms.jsoninput.exception.JsonInputException
 public class FastJsonReader implements IJsonReader {
   private static final Class<?> PKG = JsonInputMeta.class;
 
-  // as per RFC 7159, the default JSON encoding shall be UTF-8
-  // see https://tools.ietf.org/html/rfc7159#section-8.1
-  private static final String JSON_CHARSET = "UTF-8";
-
   private ReadContext jsonReadContext;
 
   /** used if the incoming value is a String */
@@ -163,7 +159,7 @@ public class FastJsonReader implements IJsonReader {
   }
 
   protected void readInput(InputStream is) throws HopException {
-    jsonReadContext = getParseContext().parse(is, JSON_CHARSET);
+    jsonReadContext = getParseContext().parse(is, Const.UTF_8);
     if (jsonReadContext == null) {
       throw new HopException(BaseMessages.getString(PKG, "JsonReader.Error.ReadUrl.Null"));
     }

--- a/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsonoutput/JsonOutputDialog.java
+++ b/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsonoutput/JsonOutputDialog.java
@@ -713,12 +713,12 @@ public class JsonOutputDialog extends BaseTransformDialog {
       }
 
       // Now select the default!
-      String defEncoding = Const.getEnvironmentVariable("file.encoding", "UTF-8");
+      String defEncoding = Const.getEnvironmentVariable("file.encoding", Const.UTF_8);
       int idx = Const.indexOfString(defEncoding, wEncoding.getItems());
       if (idx >= 0) {
         wEncoding.select(idx);
       } else {
-        wEncoding.select(Const.indexOfString("UTF-8", wEncoding.getItems()));
+        wEncoding.select(Const.indexOfString(Const.UTF_8, wEncoding.getItems()));
       }
     }
   }

--- a/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsonoutput/JsonOutputMeta.java
+++ b/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsonoutput/JsonOutputMeta.java
@@ -124,7 +124,7 @@ public class JsonOutputMeta extends BaseFileOutputMeta<JsonOutput, JsonOutputDat
   public JsonOutputMeta() {
     super();
     outputFields = new ArrayList<>();
-    encoding = Const.XML_ENCODING;
+    encoding = Const.UTF_8;
     outputValue = "outputValue";
     jsonBloc = "data";
     nrRowsInBloc = "0";

--- a/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsonoutputenhanced/JsonEOutputDialog.java
+++ b/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsonoutputenhanced/JsonEOutputDialog.java
@@ -956,12 +956,12 @@ public class JsonEOutputDialog extends BaseTransformDialog {
       }
 
       // Now select the default!
-      String defEncoding = Const.getEnvironmentVariable("file.encoding", "UTF-8");
+      String defEncoding = Const.getEnvironmentVariable("file.encoding", Const.UTF_8);
       int idx = Const.indexOfString(defEncoding, wEncoding.getItems());
       if (idx >= 0) {
         wEncoding.select(idx);
       } else {
-        wEncoding.select(Const.indexOfString("UTF-8", wEncoding.getItems()));
+        wEncoding.select(Const.indexOfString(Const.UTF_8, wEncoding.getItems()));
       }
     }
   }

--- a/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsonoutputenhanced/JsonEOutputMeta.java
+++ b/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsonoutputenhanced/JsonEOutputMeta.java
@@ -179,7 +179,7 @@ public class JsonEOutputMeta extends BaseTransformMeta<JsonEOutput, JsonEOutputD
     this.outputFields = new ArrayList<>();
     this.keyFields = new ArrayList<>();
     operationType = OperationType.WRITE_TO_FILE;
-    encoding = Const.XML_ENCODING;
+    encoding = Const.UTF_8;
     outputValue = CONST_OUTPUT_VALUE;
     jsonBloc = "";
   }

--- a/plugins/transforms/json/src/test/java/org/apache/hop/pipeline/transforms/jsoninput/JsonInputTest.java
+++ b/plugins/transforms/json/src/test/java/org/apache/hop/pipeline/transforms/jsoninput/JsonInputTest.java
@@ -1007,7 +1007,8 @@ class JsonInputTest {
 
       String json =
           FileObjectUtils.getContentAsString(
-              HopVfs.getFileObject("zip:" + BASE_RAM_DIR + "test.zip!/test.json"), "UTF-8");
+              HopVfs.getFileObject("zip:" + BASE_RAM_DIR + "test.zip!/test.json"),
+              StandardCharsets.UTF_8);
 
       JsonInputField price = new JsonInputField();
       price.setName("price");

--- a/plugins/transforms/json/src/test/java/org/apache/hop/pipeline/transforms/jsonoutput/JsonOutputMetaTest.java
+++ b/plugins/transforms/json/src/test/java/org/apache/hop/pipeline/transforms/jsonoutput/JsonOutputMetaTest.java
@@ -25,11 +25,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 import java.util.Set;
+import org.apache.hop.core.Const;
 import org.apache.hop.metadata.inject.HopMetadataInjector;
 import org.apache.hop.pipeline.transform.TransformSerializationTestUtil;
 import org.junit.jupiter.api.Test;
 
-public class JsonOutputMetaTest {
+class JsonOutputMetaTest {
 
   @Test
   void testLoadSave() throws Exception {
@@ -43,7 +44,7 @@ public class JsonOutputMetaTest {
     assertTrue(meta.isCreateParentFolder());
     assertFalse(meta.isDateInFilename());
     assertTrue(meta.isDoNotOpenNewFileInit());
-    assertEquals("UTF-8", meta.getEncoding());
+    assertEquals(Const.UTF_8, meta.getEncoding());
     assertEquals("json", meta.getExtension());
     assertFalse(meta.isFileAppended());
     assertFalse(meta.isFileAsCommand());

--- a/plugins/transforms/json/src/test/java/org/apache/hop/pipeline/transforms/jsonoutputenhanced/JsonEOutputMetaTest.java
+++ b/plugins/transforms/json/src/test/java/org/apache/hop/pipeline/transforms/jsonoutputenhanced/JsonEOutputMetaTest.java
@@ -28,6 +28,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.xml.XmlHandler;
 import org.apache.hop.metadata.serializer.memory.MemoryMetadataProvider;
 import org.apache.hop.metadata.serializer.xml.XmlMetadataUtil;
@@ -123,7 +124,7 @@ class JsonEOutputMetaTest {
     assertTrue(meta.getFileSettings().isCreateParentFolder());
     assertFalse(meta.getFileSettings().isDateInFileName());
     assertTrue(meta.getFileSettings().isDoNotOpenNewFileInit());
-    assertEquals("UTF-8", meta.getEncoding());
+    assertEquals(Const.UTF_8, meta.getEncoding());
     assertEquals("json", meta.getFileSettings().getExtension());
     assertFalse(meta.getFileSettings().isFileAppended());
     assertEquals("filename", meta.getFileSettings().getFileName());

--- a/plugins/transforms/loadfileinput/src/test/java/org/apache/hop/pipeline/transforms/loadfileinput/LoadFileInputMetaTest.java
+++ b/plugins/transforms/loadfileinput/src/test/java/org/apache/hop/pipeline/transforms/loadfileinput/LoadFileInputMetaTest.java
@@ -20,6 +20,7 @@ package org.apache.hop.pipeline.transforms.loadfileinput;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.apache.hop.core.Const;
 import org.apache.hop.core.fileinput.InputFile;
 import org.apache.hop.core.plugins.PluginRegistry;
 import org.apache.hop.core.row.IValueMeta;
@@ -67,7 +68,7 @@ class LoadFileInputMetaTest {
     assertEquals("rowNum", meta.getRowNumberField());
     assertTrue(meta.isIgnoreEmptyFile());
     assertTrue(meta.isIgnoreMissingPath());
-    assertEquals("UTF-8", meta.getEncoding());
+    assertEquals(Const.UTF_8, meta.getEncoding());
     assertEquals(999L, meta.getRowLimit());
     assertTrue(meta.isFileInField());
     assertEquals("dynamicField", meta.getDynamicFilenameField());

--- a/plugins/transforms/loadfileinput/src/test/java/org/apache/hop/pipeline/transforms/loadfileinput/LoadFileInputTest.java
+++ b/plugins/transforms/loadfileinput/src/test/java/org/apache/hop/pipeline/transforms/loadfileinput/LoadFileInputTest.java
@@ -305,7 +305,7 @@ class LoadFileInputTest {
     loadFileInputMeta.getAdditionalFields().setRootUriField("root uri");
 
     // string with UTF-8 encoding
-    loadFileInputMeta.setEncoding("UTF-8");
+    loadFileInputMeta.setEncoding(Const.UTF_8);
     fileInputList.addFile(getFile("UTF-8.txt"));
     Object[] result = loadFileInput.getOneRow();
     assertEquals(" UTF-8 string ÕÕÕ€ ", result[0]);
@@ -319,7 +319,7 @@ class LoadFileInputTest {
 
   @Test
   void testUTF8TrimLeft() throws HopException {
-    loadFileInputMeta.setEncoding("UTF-8");
+    loadFileInputMeta.setEncoding(Const.UTF_8);
     loadFileInputField.setTrimType(IValueMeta.TRIM_TYPE_LEFT);
     fileInputList.addFile(getFile("UTF-8.txt"));
     assertEquals("UTF-8 string ÕÕÕ€ ", loadFileInput.getOneRow()[0]);
@@ -327,7 +327,7 @@ class LoadFileInputTest {
 
   @Test
   void testUTF8TrimRight() throws HopException {
-    loadFileInputMeta.setEncoding("UTF-8");
+    loadFileInputMeta.setEncoding(Const.UTF_8);
     loadFileInputField.setTrimType(IValueMeta.TRIM_TYPE_RIGHT);
     fileInputList.addFile(getFile("UTF-8.txt"));
     assertEquals(" UTF-8 string ÕÕÕ€", loadFileInput.getOneRow()[0]);
@@ -335,7 +335,7 @@ class LoadFileInputTest {
 
   @Test
   void testUTF8Trim() throws HopException {
-    loadFileInputMeta.setEncoding("UTF-8");
+    loadFileInputMeta.setEncoding(Const.UTF_8);
     loadFileInputField.setTrimType(IValueMeta.TRIM_TYPE_BOTH);
     fileInputList.addFile(getFile("UTF-8.txt"));
     assertEquals("UTF-8 string ÕÕÕ€", loadFileInput.getOneRow()[0]);
@@ -369,7 +369,7 @@ class LoadFileInputTest {
 
     // byte array
     Mockito.doReturn(new ValueMetaBinary()).when(mockedRowMetaInterface).getValueMeta(anyInt());
-    loadFileInputMeta.setEncoding("UTF-8");
+    loadFileInputMeta.setEncoding(Const.UTF_8);
     fileInputList.addFile(getFile("hop.jpg"));
     loadFileInputField = new LoadFileInputField();
     loadFileInputField.setType(IValueMeta.TYPE_BINARY);

--- a/plugins/transforms/monetdbbulkloader/src/main/java/org/apache/hop/pipeline/transforms/monetdbbulkloader/MonetDbBulkLoaderMeta.java
+++ b/plugins/transforms/monetdbbulkloader/src/main/java/org/apache/hop/pipeline/transforms/monetdbbulkloader/MonetDbBulkLoaderMeta.java
@@ -173,7 +173,7 @@ public class MonetDbBulkLoaderMeta
     fieldSeparator = "|";
     fieldEnclosure = "\"";
     nullRepresentation = "";
-    encoding = "UTF-8";
+    encoding = Const.UTF_8;
   }
 
   @Override

--- a/plugins/transforms/monetdbbulkloader/src/test/java/org/apache/hop/pipeline/transforms/monetdbbulkloader/MonetDbBulkLoaderMetaTest.java
+++ b/plugins/transforms/monetdbbulkloader/src/test/java/org/apache/hop/pipeline/transforms/monetdbbulkloader/MonetDbBulkLoaderMetaTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.apache.hop.core.Const;
 import org.apache.hop.core.HopEnvironment;
 import org.apache.hop.core.database.DatabaseMeta;
 import org.apache.hop.core.plugins.PluginRegistry;
@@ -82,7 +83,7 @@ class MonetDbBulkLoaderMetaTest {
     assertEquals("|", meta.getFieldSeparator());
     assertEquals("\"", meta.getFieldEnclosure());
     assertEquals("null", meta.getNullRepresentation());
-    assertEquals("UTF-8", meta.getEncoding());
+    assertEquals(Const.UTF_8, meta.getEncoding());
 
     // Assert field mappings list loaded correctly from XML
     assertNotNull(meta.getFields());
@@ -123,7 +124,7 @@ class MonetDbBulkLoaderMetaTest {
     assertEquals("|", meta.getFieldSeparator());
     assertEquals("\"", meta.getFieldEnclosure());
     assertEquals("", meta.getNullRepresentation());
-    assertEquals("UTF-8", meta.getEncoding());
+    assertEquals(Const.UTF_8, meta.getEncoding());
   }
 
   @Test

--- a/plugins/transforms/mongodb/src/main/java/org/apache/hop/mongo/metadata/MongoDbConnection.java
+++ b/plugins/transforms/mongodb/src/main/java/org/apache/hop/mongo/metadata/MongoDbConnection.java
@@ -18,8 +18,8 @@
 
 package org.apache.hop.mongo.metadata;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
@@ -409,11 +409,9 @@ public class MongoDbConnection extends HopMetadataBase implements IHopMetadata {
     // Add appName if provided
     String resolvedAppName = variables.resolve(appName);
     if (StringUtils.isNotEmpty(resolvedAppName)) {
-      try {
-        queryParams.append("appName=").append(URLEncoder.encode(resolvedAppName, "UTF-8"));
-      } catch (UnsupportedEncodingException e) {
-        queryParams.append("appName=").append(resolvedAppName);
-      }
+      queryParams
+          .append("appName=")
+          .append(URLEncoder.encode(resolvedAppName, StandardCharsets.UTF_8));
     }
 
     // Note: authSource and authMechanism are NOT added to connection string

--- a/plugins/transforms/propertyinput/src/main/java/org/apache/hop/pipeline/transforms/propertyinput/PropertyInputDialog.java
+++ b/plugins/transforms/propertyinput/src/main/java/org/apache/hop/pipeline/transforms/propertyinput/PropertyInputDialog.java
@@ -1057,8 +1057,7 @@ public class PropertyInputDialog extends BaseTransformDialog {
       }
 
       // Now select the default!
-      String defEncoding =
-          Const.getEnvironmentVariable("file.encoding", PropertyInputMeta.DEFAULT_ENCODING);
+      String defEncoding = Const.getEnvironmentVariable("file.encoding", Const.UTF_8);
       int idx = Const.indexOfString(defEncoding, wEncoding.getItems());
       if (idx >= 0) {
         wEncoding.select(idx);

--- a/plugins/transforms/propertyinput/src/main/java/org/apache/hop/pipeline/transforms/propertyinput/PropertyInputMeta.java
+++ b/plugins/transforms/propertyinput/src/main/java/org/apache/hop/pipeline/transforms/propertyinput/PropertyInputMeta.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.hop.core.CheckResult;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.ICheckResult;
 import org.apache.hop.core.annotations.Transform;
 import org.apache.hop.core.exception.HopException;
@@ -68,8 +69,6 @@ public class PropertyInputMeta extends BaseTransformMeta<PropertyInput, Property
       };
 
   public static final String[] RequiredFilesCode = new String[] {"N", "Y"};
-
-  public static final String DEFAULT_ENCODING = "UTF-8";
 
   private static final String YES = "Y";
 
@@ -212,7 +211,7 @@ public class PropertyInputMeta extends BaseTransformMeta<PropertyInput, Property
 
     fileType = FileType.PROPERTY;
     section = "";
-    encoding = DEFAULT_ENCODING;
+    encoding = Const.UTF_8;
     includeIniSection = false;
     iniSectionField = "";
     resolvingValueVariable = false;

--- a/plugins/transforms/sasinput/src/test/java/org/apache/hop/pipeline/transforms/sasinput/SasInputTests.java
+++ b/plugins/transforms/sasinput/src/test/java/org/apache/hop/pipeline/transforms/sasinput/SasInputTests.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import com.epam.parso.SasFileProperties;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.logging.ILoggingObject;
 import org.apache.hop.core.row.value.ValueMetaDate;
 import org.apache.hop.core.row.value.ValueMetaInteger;
@@ -67,7 +68,7 @@ class SasInputTests {
   @Test
   void testByteArray_withEncoding() {
     byte[] bytes = "Bob".getBytes(StandardCharsets.UTF_8);
-    SasInput.ConvertedValue result = input.convertSasValue(bytes, "name", property("UTF-8"));
+    SasInput.ConvertedValue result = input.convertSasValue(bytes, "name", property(Const.UTF_8));
 
     assertNotNull(result);
     assertInstanceOf(ValueMetaString.class, result.meta());

--- a/plugins/transforms/sqlfileoutput/src/main/java/org/apache/hop/pipeline/transforms/sqlfileoutput/SQLFileOutputDialog.java
+++ b/plugins/transforms/sqlfileoutput/src/main/java/org/apache/hop/pipeline/transforms/sqlfileoutput/SQLFileOutputDialog.java
@@ -761,7 +761,7 @@ public class SQLFileOutputDialog extends BaseTransformDialog {
       }
 
       // Now select the default!
-      String defEncoding = Const.getEnvironmentVariable("file.encoding", "UTF-8");
+      String defEncoding = Const.getEnvironmentVariable("file.encoding", Const.UTF_8);
       int idx = Const.indexOfString(defEncoding, wEncoding.getItems());
       if (idx >= 0) {
         wEncoding.select(idx);

--- a/plugins/transforms/tableinput/src/main/java/org/apache/hop/pipeline/transforms/tableinput/TableInputDialog.java
+++ b/plugins/transforms/tableinput/src/main/java/org/apache/hop/pipeline/transforms/tableinput/TableInputDialog.java
@@ -17,6 +17,7 @@
 
 package org.apache.hop.pipeline.transforms.tableinput;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -391,7 +392,7 @@ public class TableInputDialog extends BaseTransformDialog {
       return;
     }
     try {
-      String content = HopVfs.getTextFileContent(path, Const.XML_ENCODING);
+      String content = HopVfs.getTextFileContent(path, StandardCharsets.UTF_8);
       wSqlComposite.setText(content);
       wSqlComposite.setEditable(false);
     } catch (HopFileException e) {

--- a/plugins/transforms/tableinput/src/main/java/org/apache/hop/pipeline/transforms/tableinput/TableInputMeta.java
+++ b/plugins/transforms/tableinput/src/main/java/org/apache/hop/pipeline/transforms/tableinput/TableInputMeta.java
@@ -17,6 +17,7 @@
 
 package org.apache.hop.pipeline.transforms.tableinput;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
@@ -222,7 +223,7 @@ public class TableInputMeta extends BaseTransformMeta<TableInput, TableInputData
     if (!Utils.isEmpty(sqlFromFile)) {
       String path = variables.resolve(sqlFromFile);
       try {
-        return HopVfs.getTextFileContent(path, Const.XML_ENCODING);
+        return HopVfs.getTextFileContent(path, StandardCharsets.UTF_8);
       } catch (HopFileException e) {
         throw new HopException(
             BaseMessages.getString(PKG, "TableInputMeta.Exception.CouldNotLoadSqlFromFile", path),

--- a/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputDialog.java
+++ b/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputDialog.java
@@ -770,7 +770,7 @@ public class CsvInputDialog extends BaseTransformDialog
       }
 
       // Now select the default!
-      String defEncoding = Const.getEnvironmentVariable("file.encoding", "UTF-8");
+      String defEncoding = Const.getEnvironmentVariable("file.encoding", Const.UTF_8);
       int idx = Const.indexOfString(defEncoding, wEncoding.getItems());
       if (idx >= 0) {
         wEncoding.select(idx);

--- a/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/fileinput/text/BOMDetector.java
+++ b/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/fileinput/text/BOMDetector.java
@@ -20,6 +20,7 @@ package org.apache.hop.pipeline.transforms.fileinput.text;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import org.apache.hop.core.Const;
 
 /**
  * Detector of BOM prefix in file.
@@ -30,7 +31,7 @@ import java.io.InputStream;
 public class BOMDetector {
   public static final BOMMark[] MARKS =
       new BOMMark[] {
-        new BOMMark("UTF-8", 0xEF, 0xBB, 0xBF),
+        new BOMMark(Const.UTF_8, 0xEF, 0xBB, 0xBF),
         new BOMMark("UTF-32BE", 0x00, 0x00, 0xFE, 0xFF),
         new BOMMark("UTF-32LE", 0xFF, 0xFE, 0x00, 0x00),
         new BOMMark("UTF-16BE", 0xFE, 0xFF),

--- a/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/fileinput/text/TextFileInputDialog.java
+++ b/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/fileinput/text/TextFileInputDialog.java
@@ -2470,7 +2470,7 @@ public class TextFileInputDialog extends BaseTransformDialog
       }
 
       // Now select the default!
-      String defEncoding = Const.getEnvironmentVariable("file.encoding", "UTF-8");
+      String defEncoding = Const.getEnvironmentVariable("file.encoding", Const.UTF_8);
       int idx = Const.indexOfString(defEncoding, wEncoding.getItems());
       if (idx >= 0) {
         wEncoding.select(idx);

--- a/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/textfileoutput/TextFileOutputDialog.java
+++ b/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/textfileoutput/TextFileOutputDialog.java
@@ -1364,7 +1364,7 @@ public class TextFileOutputDialog extends BaseTransformDialog {
       }
 
       // Now select the default!
-      String defEncoding = Const.getEnvironmentVariable("file.encoding", "UTF-8");
+      String defEncoding = Const.getEnvironmentVariable("file.encoding", Const.UTF_8);
       int idx = Const.indexOfString(defEncoding, wEncoding.getItems());
       if (idx >= 0) {
         wEncoding.select(idx);

--- a/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/types/HtmlExplorerFileTypeHandler.java
+++ b/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/types/HtmlExplorerFileTypeHandler.java
@@ -165,7 +165,7 @@ public class HtmlExplorerFileTypeHandler extends BaseExplorerFileTypeHandler {
       }
 
       // Read HTML content from file
-      String htmlContent = readTextFileContent("UTF-8");
+      String htmlContent = readTextFileContent(StandardCharsets.UTF_8);
       originalHtmlContent = Const.NVL(htmlContent, "");
 
       // Display HTML in browser widget

--- a/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/csvinput/BaseCsvParsingTest.java
+++ b/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/csvinput/BaseCsvParsingTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.hop.pipeline.transforms.csvinput;
 
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hop.core.exception.HopRuntimeException;
 import org.apache.hop.core.row.IValueMeta;
@@ -80,16 +81,16 @@ public abstract class BaseCsvParsingTest
       if (expected[r].length != 0) {
         for (int c = 0; c < expected[r].length; c++) {
           if (expected[r][c] == "") {
-            expected[r][c] = StringUtils.EMPTY.getBytes("UTF-8");
+            expected[r][c] = StringUtils.EMPTY.getBytes(StandardCharsets.UTF_8);
           } else if (expected[r][c] == null) {
             expected[r][c] = null;
           } else {
-            expected[r][c] = expected[r][c].toString().getBytes("UTF-8");
+            expected[r][c] = expected[r][c].toString().getBytes(StandardCharsets.UTF_8);
           }
         }
       } else {
         expected[r] = new Object[meta.getInputFields().size()];
-        expected[r][0] = StringUtils.EMPTY.getBytes("UTF-8");
+        expected[r][0] = StringUtils.EMPTY.getBytes(StandardCharsets.UTF_8);
       }
     }
     super.check(expected);

--- a/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputContentParsingTest.java
+++ b/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputContentParsingTest.java
@@ -22,6 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.apache.hop.core.exception.HopTransformException;
 import org.apache.hop.junit.rules.RestoreHopEngineEnvironmentExtension;
 import org.junit.jupiter.api.Test;
@@ -118,7 +120,7 @@ class CsvInputContentParsingTest extends BaseCsvParsingTest {
             + "\n"
             + "999,123,123,123,132,132,132,132,132\r";
 
-    String file = createTestFile("UTF-8", data).getAbsolutePath();
+    String file = createTestFile(StandardCharsets.UTF_8, data).getAbsolutePath();
     init(file, true);
 
     setFields(
@@ -158,11 +160,11 @@ class CsvInputContentParsingTest extends BaseCsvParsingTest {
     assertThrows(HopTransformException.class, () -> process());
   }
 
-  File createTestFile(final String encoding, final String content) throws IOException {
+  File createTestFile(final Charset charset, final String content) throws IOException {
     File tempFile = File.createTempFile("PDI_tmp", ".csv");
     tempFile.deleteOnExit();
 
-    try (PrintWriter osw = new PrintWriter(tempFile, encoding)) {
+    try (PrintWriter osw = new PrintWriter(tempFile, charset)) {
       osw.write(content);
     }
 

--- a/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputDoubleLineEndTest.java
+++ b/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputDoubleLineEndTest.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import java.nio.charset.Charset;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.exception.HopException;
 import org.apache.hop.core.exception.HopTransformException;
 import org.apache.hop.core.logging.ILoggingObject;
@@ -43,7 +45,6 @@ class CsvInputDoubleLineEndTest extends CsvInputUnitTestBase {
   static RestoreHopEngineEnvironmentExtension env = new RestoreHopEngineEnvironmentExtension();
 
   private static final String ASCII = "windows-1252";
-  private static final String UTF8 = "UTF-8";
   private static final String UTF16LE = "UTF-16LE";
   private static final String UTF16BE = "UTF-16BE";
   private static final String TEST_DATA = "Header1\tHeader2\r\nValue\tValue\r\nValue\tValue\r\n";
@@ -82,13 +83,14 @@ class CsvInputDoubleLineEndTest extends CsvInputUnitTestBase {
 
   @Test
   void testUTF8() throws Exception {
-    doTest(UTF8, UTF8, TEST_DATA);
+    doTest(Const.UTF_8, Const.UTF_8, TEST_DATA);
   }
 
   private void doTest(
       final String fileEncoding, final String transformEncoding, final String testData)
       throws Exception {
-    String testFilePath = createTestFile(fileEncoding, testData).getAbsolutePath();
+    Charset charset = Charset.forName(fileEncoding);
+    String testFilePath = createTestFile(charset, testData).getAbsolutePath();
 
     CsvInputMeta meta = createTransformMeta(testFilePath, transformEncoding);
     CsvInputData data = new CsvInputData();

--- a/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputEnclosureTest.java
+++ b/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputEnclosureTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import org.apache.hop.core.IRowSet;
 import org.apache.hop.core.QueueRowSet;
 import org.apache.hop.junit.rules.RestoreHopEngineEnvironmentExtension;
@@ -43,7 +44,7 @@ class CsvInputEnclosureTest extends CsvInputUnitTestBase {
   private TransformMockHelper<CsvInputMeta, CsvInputData> transformMockHelper;
 
   @BeforeEach
-  void setUp() throws Exception {
+  void setUp() {
     transformMockHelper =
         TransformMockUtil.getTransformMockHelper(
             CsvInputMeta.class, CsvInputData.class, "CsvInputEnclosureTest");
@@ -112,7 +113,7 @@ class CsvInputEnclosureTest extends CsvInputUnitTestBase {
   public void doTest(String content, String enclosure) throws Exception {
     IRowSet output = new QueueRowSet();
 
-    File tmp = createTestFile("utf-8", content);
+    File tmp = createTestFile(StandardCharsets.UTF_8, content);
     try {
       CsvInputMeta meta = createMeta(tmp, createInputFileFields("f1", "f2"), enclosure);
       CsvInputData data = new CsvInputData();

--- a/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputMetaTest.java
+++ b/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputMetaTest.java
@@ -27,6 +27,7 @@ import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.HopClientEnvironment;
 import org.apache.hop.core.plugins.PluginRegistry;
 import org.apache.hop.core.row.IValueMeta;
@@ -102,7 +103,7 @@ class CsvInputMetaTest {
     assertTrue(meta.isAddResult());
     assertTrue(meta.isRunningInParallel());
     assertTrue(meta.isNewlinePossibleInFields());
-    assertEquals("UTF-8", meta.getEncoding());
+    assertEquals(Const.UTF_8, meta.getEncoding());
     assertNotNull(meta.getInputFields());
     assertEquals(2, meta.getInputFields().size());
 

--- a/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputMultiCharDelimiterTest.java
+++ b/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputMultiCharDelimiterTest.java
@@ -22,6 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.apache.hop.core.IRowSet;
 import org.apache.hop.core.QueueRowSet;
 import org.apache.hop.junit.rules.RestoreHopEngineEnvironmentExtension;
@@ -82,8 +84,8 @@ class CsvInputMultiCharDelimiterTest extends CsvInputUnitTestBase {
 
   private void doTest(String content) throws Exception {
     IRowSet output = new QueueRowSet();
-
-    File tmp = createTestFile(ENCODING, content);
+    Charset charset = StandardCharsets.UTF_8;
+    File tmp = createTestFile(charset, content);
     try {
       CsvInputMeta meta = createMeta(tmp, createInputFileFields("f1", "f2", "f3"));
       CsvInputData data = new CsvInputData();

--- a/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputRowNumberTest.java
+++ b/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputRowNumberTest.java
@@ -18,6 +18,7 @@
 package org.apache.hop.pipeline.transforms.csvinput;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.hop.junit.rules.RestoreHopEngineEnvironmentExtension;
@@ -49,7 +50,7 @@ class CsvInputRowNumberTest extends CsvInputUnitTestBase {
 
   @Test
   void hasNotEnclosures_HasNotNewLine() throws Exception {
-    File tmp = createTestFile("utf-8", "a,b\na,");
+    File tmp = createTestFile(StandardCharsets.UTF_8, "a,b\na,");
     try {
       doTest(tmp);
     } finally {

--- a/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputTest.java
+++ b/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputTest.java
@@ -23,6 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.apache.hop.core.IRowSet;
 import org.apache.hop.core.QueueRowSet;
 import org.apache.hop.core.logging.ILogChannel;
@@ -39,7 +41,7 @@ class CsvInputTest extends CsvInputUnitTestBase {
   private CsvInputMeta csvInputMeta;
 
   @BeforeEach
-  void setUp() throws Exception {
+  void setUp() {
     logChannelInterface = mock(ILogChannel.class);
     transformMockHelper =
         TransformMockUtil.getTransformMockHelper(
@@ -71,7 +73,8 @@ class CsvInputTest extends CsvInputUnitTestBase {
     // Create a file with some content to be processed
     CsvInputField[] inputFileFields = createInputFileFields("f1", "f2", "f3");
     String fileContents = "Something" + DELIMITER + "" + DELIMITER + "The former was empty!";
-    File tmpFile = createTestFile(ENCODING, fileContents);
+    Charset charset = StandardCharsets.UTF_8;
+    File tmpFile = createTestFile(charset, fileContents);
 
     // Create and configure the transform
     CsvInputMeta meta = createMeta(tmpFile, inputFileFields);

--- a/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputUnicodeTest.java
+++ b/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputUnicodeTest.java
@@ -19,8 +19,10 @@ package org.apache.hop.pipeline.transforms.csvinput;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.exception.HopException;
 import org.apache.hop.core.exception.HopTransformException;
 import org.apache.hop.core.logging.ILoggingObject;
@@ -44,7 +46,6 @@ class CsvInputUnicodeTest extends CsvInputUnitTestBase {
   @RegisterExtension
   static RestoreHopEngineEnvironmentExtension env = new RestoreHopEngineEnvironmentExtension();
 
-  private static final String UTF8 = "UTF-8";
   private static final String UTF16LE = "UTF-16LE";
   private static final String UTF16LEBOM = "x-UTF-16LE-BOM";
   private static final String UTF16BE = "UTF-16BE";
@@ -117,22 +118,22 @@ class CsvInputUnicodeTest extends CsvInputUnitTestBase {
 
   @Test
   void testUTF8() throws Exception {
-    doTest(UTF8, UTF8, TEST_DATA, ONE_CHAR_DELIM, true);
+    doTest(Const.UTF_8, Const.UTF_8, TEST_DATA, ONE_CHAR_DELIM, true);
   }
 
   @Test
   void testUTF8_multiDelim() throws Exception {
-    doTest(UTF8, UTF8, TEST_DATA1, MULTI_CHAR_DELIM, true);
+    doTest(Const.UTF_8, Const.UTF_8, TEST_DATA1, MULTI_CHAR_DELIM, true);
   }
 
   @Test
   void testUTF8_headerWithBOM() throws Exception {
-    doTest(UTF8, UTF8, TEST_DATA_UTF8_BOM, ONE_CHAR_DELIM, true);
+    doTest(Const.UTF_8, Const.UTF_8, TEST_DATA_UTF8_BOM, ONE_CHAR_DELIM, true);
   }
 
   @Test
   void testUTF8_withoutHeaderWithBOM() throws Exception {
-    doTest(UTF8, UTF8, TEST_DATA_NOHEADER_UTF8_BOM, ONE_CHAR_DELIM, false);
+    doTest(Const.UTF_8, Const.UTF_8, TEST_DATA_NOHEADER_UTF8_BOM, ONE_CHAR_DELIM, false);
   }
 
   @Test
@@ -172,7 +173,7 @@ class CsvInputUnicodeTest extends CsvInputUnitTestBase {
 
   @Test
   void testUTF8_multiDelim_DataWithEnclosures() throws Exception {
-    doTest(UTF8, UTF8, TEST_DATA3, MULTI_CHAR_DELIM, true);
+    doTest(Const.UTF_8, Const.UTF_8, TEST_DATA3, MULTI_CHAR_DELIM, true);
   }
 
   private void doTest(
@@ -182,7 +183,8 @@ class CsvInputUnicodeTest extends CsvInputUnitTestBase {
       final String delimiter,
       final boolean useHeader)
       throws Exception {
-    String testFilePath = createTestFile(fileEncoding, testData).getAbsolutePath();
+    Charset charset = Charset.forName(fileEncoding);
+    String testFilePath = createTestFile(charset, testData).getAbsolutePath();
 
     CsvInputMeta meta = createTransformMeta(testFilePath, transformEncoding, delimiter, useHeader);
     CsvInputData data = new CsvInputData();

--- a/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputUnitTestBase.java
+++ b/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/csvinput/CsvInputUnitTestBase.java
@@ -20,6 +20,8 @@ package org.apache.hop.pipeline.transforms.csvinput;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.Charset;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.HopEnvironment;
 import org.apache.hop.core.row.IValueMeta;
 import org.junit.jupiter.api.BeforeAll;
@@ -27,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll;
 public abstract class CsvInputUnitTestBase {
 
   static final String BUFFER_SIZE = "1024";
-  static final String ENCODING = "utf-8";
   static final String ENCLOSURE = "\"";
   static final String DELIMITER = ",";
 
@@ -36,11 +37,11 @@ public abstract class CsvInputUnitTestBase {
     HopEnvironment.init();
   }
 
-  File createTestFile(final String encoding, final String content) throws IOException {
+  File createTestFile(final Charset charset, final String content) throws IOException {
     File tempFile = File.createTempFile("PDI_tmp", ".tmp");
     tempFile.deleteOnExit();
 
-    try (PrintWriter osw = new PrintWriter(tempFile, encoding)) {
+    try (PrintWriter osw = new PrintWriter(tempFile, charset)) {
       osw.write(content);
     }
 
@@ -68,7 +69,7 @@ public abstract class CsvInputUnitTestBase {
     meta.setBufferSize(BUFFER_SIZE);
     meta.setDelimiter(DELIMITER);
     meta.setEnclosure(ENCLOSURE);
-    meta.setEncoding(ENCODING);
+    meta.setEncoding(Const.UTF_8);
     meta.setLazyConversionActive(false);
     meta.setFields(fields);
     meta.setHeaderPresent(false);

--- a/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/csvinput/CsvProcessRowInParallelTest.java
+++ b/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/csvinput/CsvProcessRowInParallelTest.java
@@ -20,6 +20,7 @@ package org.apache.hop.pipeline.transforms.csvinput;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.apache.hop.core.exception.HopTransformException;
 import org.apache.hop.core.row.IRowMeta;
@@ -77,7 +78,7 @@ class CsvProcessRowInParallelTest extends CsvInputUnitTestBase {
     final int totalNumberOfTransforms = 2;
     final String fileContent = "a;1\r" + "b;2\r";
 
-    File sharedFile = createTestFile("UTF-8", fileContent);
+    File sharedFile = createTestFile(StandardCharsets.UTF_8, fileContent);
 
     assertEquals(1, createAndRunOneTransform(sharedFile, 0, totalNumberOfTransforms));
     assertEquals(1, createAndRunOneTransform(sharedFile, 1, totalNumberOfTransforms));
@@ -89,7 +90,7 @@ class CsvProcessRowInParallelTest extends CsvInputUnitTestBase {
 
     final String fileContent = "a;1\r" + "b;2\r" + "c;3";
 
-    File sharedFile = createTestFile("UTF-8", fileContent);
+    File sharedFile = createTestFile(StandardCharsets.UTF_8, fileContent);
 
     assertEquals(2, createAndRunOneTransform(sharedFile, 0, totalNumberOfTransforms));
     assertEquals(1, createAndRunOneTransform(sharedFile, 1, totalNumberOfTransforms));
@@ -111,7 +112,7 @@ class CsvProcessRowInParallelTest extends CsvInputUnitTestBase {
             + "ij;999\r"
             + "jk;000\r";
 
-    File sharedFile = createTestFile("UTF-8", fileContent);
+    File sharedFile = createTestFile(StandardCharsets.UTF_8, fileContent);
 
     assertEquals(5, createAndRunOneTransform(sharedFile, 0, totalNumberOfTransforms));
     assertEquals(5, createAndRunOneTransform(sharedFile, 1, totalNumberOfTransforms));
@@ -133,7 +134,7 @@ class CsvProcessRowInParallelTest extends CsvInputUnitTestBase {
             + "ij;999\r"
             + "jk;000";
 
-    File sharedFile = createTestFile("UTF-8", fileContent);
+    File sharedFile = createTestFile(StandardCharsets.UTF_8, fileContent);
 
     assertEquals(5, createAndRunOneTransform(sharedFile, 0, totalNumberOfTransforms));
     assertEquals(5, createAndRunOneTransform(sharedFile, 1, totalNumberOfTransforms));
@@ -144,7 +145,7 @@ class CsvProcessRowInParallelTest extends CsvInputUnitTestBase {
     final String fileContent = "a;1\r\n" + "b;2\r\n";
     final int totalNumberOfTransforms = 2;
 
-    File sharedFile = createTestFile("UTF-8", fileContent);
+    File sharedFile = createTestFile(StandardCharsets.UTF_8, fileContent);
 
     assertEquals(1, createAndRunOneTransform(sharedFile, 0, totalNumberOfTransforms));
     assertEquals(1, createAndRunOneTransform(sharedFile, 1, totalNumberOfTransforms));
@@ -155,7 +156,7 @@ class CsvProcessRowInParallelTest extends CsvInputUnitTestBase {
     final String fileContent = "a;1\r\n" + "b;2";
     final int totalNumberOfTransforms = 2;
 
-    File sharedFile = createTestFile("UTF-8", fileContent);
+    File sharedFile = createTestFile(StandardCharsets.UTF_8, fileContent);
 
     int t1 = createAndRunOneTransform(sharedFile, 0, totalNumberOfTransforms);
     int t2 = createAndRunOneTransform(sharedFile, 1, totalNumberOfTransforms);
@@ -175,7 +176,7 @@ class CsvProcessRowInParallelTest extends CsvInputUnitTestBase {
 
     final int totalNumberOfTransforms = 3;
 
-    File sharedFile = createTestFile("UTF-8", fileContent);
+    File sharedFile = createTestFile(StandardCharsets.UTF_8, fileContent);
 
     assertEquals(2, createAndRunOneTransform(sharedFile, 0, totalNumberOfTransforms));
     assertEquals(2, createAndRunOneTransform(sharedFile, 1, totalNumberOfTransforms));
@@ -195,7 +196,7 @@ class CsvProcessRowInParallelTest extends CsvInputUnitTestBase {
 
     final int totalNumberOfTransforms = 2;
 
-    File sharedFile = createTestFile("UTF-8", fileContent);
+    File sharedFile = createTestFile(StandardCharsets.UTF_8, fileContent);
 
     assertEquals(1, createAndRunOneTransform(sharedFile, 0, totalNumberOfTransforms));
     assertEquals(2, createAndRunOneTransform(sharedFile, 1, totalNumberOfTransforms));
@@ -207,7 +208,7 @@ class CsvProcessRowInParallelTest extends CsvInputUnitTestBase {
 
     final int totalNumberOfTransforms = 2;
 
-    File sharedFile = createTestFile("UTF-8", fileContent);
+    File sharedFile = createTestFile(StandardCharsets.UTF_8, fileContent);
 
     assertEquals(1, createAndRunOneTransform(sharedFile, 0, totalNumberOfTransforms));
     assertEquals(2, createAndRunOneTransform(sharedFile, 1, totalNumberOfTransforms));
@@ -231,7 +232,7 @@ class CsvProcessRowInParallelTest extends CsvInputUnitTestBase {
             + "jk,10\r\n"
             + "lm,11\r\n";
 
-    File sharedFile = createTestFile("UTF-8", fileContent);
+    File sharedFile = createTestFile(StandardCharsets.UTF_8, fileContent);
 
     int t1 = createAndRunOneTransform(sharedFile, 0, totalNumberOfTransforms, true, ",");
     int t2 = createAndRunOneTransform(sharedFile, 1, totalNumberOfTransforms, true, ",");

--- a/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/csvinput/PDI_15270_Test.java
+++ b/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/csvinput/PDI_15270_Test.java
@@ -22,6 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.apache.hop.core.Const;
 import org.apache.hop.core.IRowSet;
 import org.apache.hop.core.QueueRowSet;
@@ -109,8 +111,8 @@ class PDI_15270_Test extends CsvInputUnitTestBase {
 
   public void doTest(String content, String[] expected) throws Exception {
     IRowSet output = new QueueRowSet();
-
-    File tmp = createTestFile(ENCODING, content);
+    Charset charset = StandardCharsets.UTF_8;
+    File tmp = createTestFile(charset, content);
     try {
       CsvInputMeta meta = createMeta(tmp, createInputFileFields("f1", "f2", "f3"));
       CsvInputData data = new CsvInputData();

--- a/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/fileinput/text/BOMDetectorTest.java
+++ b/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/fileinput/text/BOMDetectorTest.java
@@ -24,6 +24,7 @@ import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import org.apache.hop.core.Const;
 import org.junit.jupiter.api.Test;
 
 class BOMDetectorTest {
@@ -47,7 +48,7 @@ class BOMDetectorTest {
 
   @Test
   void testBOMs() throws Exception {
-    testBOM("test-BOM-UTF-8.txt", "UTF-8");
+    testBOM("test-BOM-UTF-8.txt", Const.UTF_8);
     testBOM("test-BOM-UTF-16BE.txt", "UTF-16BE");
     testBOM("test-BOM-UTF-16LE.txt", "UTF-16LE");
     testBOM("test-BOM-UTF-32BE.txt", "UTF-32BE");

--- a/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/fileinput/text/TextFileInputMetaTest.java
+++ b/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/fileinput/text/TextFileInputMetaTest.java
@@ -25,6 +25,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.file.TextFileInputField;
 import org.apache.hop.core.plugins.PluginRegistry;
 import org.apache.hop.core.row.IValueMeta;
@@ -108,7 +109,7 @@ class TextFileInputMetaTest {
     assertTrue(meta.getContent().isRowNumberByFile());
     assertEquals("rowNumField", meta.getContent().getRowNumberField());
     assertEquals("mixed", meta.getContent().getFileFormat());
-    assertEquals("UTF-8", meta.getContent().getEncoding());
+    assertEquals(Const.UTF_8, meta.getContent().getEncoding());
     assertEquals("Characters", meta.getContent().getLength());
     assertTrue(meta.getFileInput().isAddingResult());
     assertEquals("CSV", meta.getContent().getFileType());

--- a/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/fileinput/text/TextFileInputTest.java
+++ b/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/fileinput/text/TextFileInputTest.java
@@ -29,6 +29,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.io.IOUtils;
@@ -75,7 +76,7 @@ class TextFileInputTest {
 
   private static InputStreamReader getInputStreamReader(String data)
       throws UnsupportedEncodingException {
-    return new InputStreamReader(new ByteArrayInputStream(data.getBytes(("UTF-8"))));
+    return new InputStreamReader(new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8)));
   }
 
   private static String getInputStreamReader(

--- a/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/textfileoutput/TextFileOutputMetaTest.java
+++ b/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/textfileoutput/TextFileOutputMetaTest.java
@@ -33,6 +33,7 @@ import java.util.Objects;
 import java.util.Random;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.HopEnvironment;
 import org.apache.hop.core.exception.HopException;
 import org.apache.hop.core.row.IValueMeta;
@@ -215,7 +216,7 @@ class TextFileOutputMetaTest {
     assertTrue(meta.isFooterEnabled());
     assertEquals("UNIX", meta.getFileFormat());
     assertEquals("Snappy", meta.getFileCompression());
-    assertEquals("UTF-8", meta.getEncoding());
+    assertEquals(Const.UTF_8, meta.getEncoding());
     assertTrue(StringUtils.isEmpty(meta.getEndedLine()));
     assertTrue(meta.isFileNameInField());
     assertEquals("filenameField", meta.getFileNameField());

--- a/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/textfileoutput/TextFileOutputTest.java
+++ b/plugins/transforms/textfile/src/test/java/org/apache/hop/pipeline/transforms/textfileoutput/TextFileOutputTest.java
@@ -27,12 +27,14 @@ import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.vfs2.FileObject;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.IRowSet;
 import org.apache.hop.core.compress.CompressionOutputStream;
 import org.apache.hop.core.compress.CompressionPluginType;
@@ -544,7 +546,7 @@ class TextFileOutputTest {
     TextFileOutputMeta meta = new TextFileOutputMeta();
     meta.setEndedLine("${endvar}");
     meta.setDefault();
-    meta.setEncoding("UTF-8");
+    meta.setEncoding(Const.UTF_8);
     transformMockHelper.transformMeta.setTransform(meta);
     TextFileOutput textFileOutput =
         new TextFileOutputTestHandler(
@@ -556,7 +558,7 @@ class TextFileOutputTest {
             transformMockHelper.pipeline);
     textFileOutput.setVariable("endvar", "this is the end");
     textFileOutput.writeEndedLine();
-    assertEquals("this is the end", baos.toString("UTF-8"));
+    assertEquals("this is the end", baos.toString(StandardCharsets.UTF_8));
   }
 
   private void assertNotInvokedTwice(TextFileField field) {
@@ -755,7 +757,7 @@ class TextFileOutputTest {
   void testFastDumpDisableStreamEncodeTest() throws Exception {
 
     String testString = "ÖÜä";
-    String inputEncode = "UTF-8";
+    String inputEncode = Const.UTF_8;
     String outputEncode = "Windows-1252";
     Object[] rows = {testString.getBytes(inputEncode)};
 

--- a/plugins/transforms/tokenreplacement/src/main/java/org/apache/hop/pipeline/transforms/tokenreplacement/TokenReplacement.java
+++ b/plugins/transforms/tokenreplacement/src/main/java/org/apache/hop/pipeline/transforms/tokenreplacement/TokenReplacement.java
@@ -188,7 +188,7 @@ public class TokenReplacement extends BaseTransform<TokenReplacementMeta, TokenR
       }
       data.currentCountingInputStream =
           new CountingInputStream(HopVfs.getInputStream(inputFilename, variables));
-      String inputEncoding = Const.NVL(resolve(meta.getOutputFileEncoding()), "UTF-8");
+      String inputEncoding = Const.NVL(resolve(meta.getOutputFileEncoding()), Const.UTF_8);
       reader =
           new TokenReplacingReader(
               resolver,

--- a/plugins/transforms/tokenreplacement/src/main/java/org/apache/hop/pipeline/transforms/tokenreplacement/TokenReplacementDialog.java
+++ b/plugins/transforms/tokenreplacement/src/main/java/org/apache/hop/pipeline/transforms/tokenreplacement/TokenReplacementDialog.java
@@ -1192,7 +1192,7 @@ public class TokenReplacementDialog extends BaseTransformDialog {
       }
 
       // Now select the default!
-      String defEncoding = Const.getEnvironmentVariable("file.encoding", "UTF-8");
+      String defEncoding = Const.getEnvironmentVariable("file.encoding", Const.UTF_8);
       int idx = Const.indexOfString(defEncoding, wOutputFileEncoding.getItems());
       if (idx >= 0) {
         wOutputFileEncoding.select(idx);

--- a/plugins/transforms/tokenreplacement/src/main/java/org/apache/hop/pipeline/transforms/tokenreplacement/TokenReplacementMeta.java
+++ b/plugins/transforms/tokenreplacement/src/main/java/org/apache/hop/pipeline/transforms/tokenreplacement/TokenReplacementMeta.java
@@ -99,7 +99,6 @@ public class TokenReplacementMeta
         BaseMessages.getString(PKG, "TokenReplacementDialog.Format.None")
       };
   public static final String CONST_FILE_ENCODING = "file.encoding";
-  public static final String CONST_UTF_8 = "UTF-8";
 
   @HopMetadataProperty(
       key = "input_type",
@@ -269,7 +268,7 @@ public class TokenReplacementMeta
     tokenReplacementFields = new ArrayList<>();
     inputType = "Text";
     outputType = "Field";
-    outputFileEncoding = Const.getEnvironmentVariable(CONST_FILE_ENCODING, CONST_UTF_8);
+    outputFileEncoding = Const.getEnvironmentVariable(CONST_FILE_ENCODING, Const.UTF_8);
     outputFileFormat = Const.isWindows() ? "DOS" : "UNIX";
     splitEvery = 0;
     tokenStartString = "${";
@@ -309,7 +308,7 @@ public class TokenReplacementMeta
 
   public String getOutputFileEncoding() {
     return Const.NVL(
-        outputFileEncoding, Const.getEnvironmentVariable(CONST_FILE_ENCODING, CONST_UTF_8));
+        outputFileEncoding, Const.getEnvironmentVariable(CONST_FILE_ENCODING, Const.UTF_8));
   }
 
   public String getOutputFileFormatString() {

--- a/plugins/transforms/webservices/src/main/java/org/apache/hop/pipeline/transforms/webservices/WebService.java
+++ b/plugins/transforms/webservices/src/main/java/org/apache/hop/pipeline/transforms/webservices/WebService.java
@@ -566,7 +566,8 @@ public class WebService extends BaseTransform<WebServiceMeta, WebServiceData> {
       char[] tmp = new char[4096];
 
       try {
-        InputStreamReader reader = new InputStreamReader(is, encoding != null ? encoding : "UTF-8");
+        Charset charset = encoding != null ? Charset.forName(encoding) : StandardCharsets.UTF_8;
+        InputStreamReader reader = new InputStreamReader(is, charset);
         for (int cnt; (cnt = reader.read(tmp)) > 0; ) {
           sb.append(tmp, 0, cnt);
         }

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/addxml/AddXmlDialog.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/addxml/AddXmlDialog.java
@@ -436,12 +436,12 @@ public class AddXmlDialog extends BaseTransformDialog {
       }
 
       // Now select the default!
-      String defEncoding = Const.getEnvironmentVariable("file.encoding", "UTF-8");
+      String defEncoding = Const.getEnvironmentVariable("file.encoding", Const.UTF_8);
       int idx = Const.indexOfString(defEncoding, wEncoding.getItems());
       if (idx >= 0) {
         wEncoding.select(idx);
       } else {
-        wEncoding.select(Const.indexOfString("UTF-8", wEncoding.getItems()));
+        wEncoding.select(Const.indexOfString(Const.UTF_8, wEncoding.getItems()));
       }
     }
   }

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/addxml/AddXmlMeta.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/addxml/AddXmlMeta.java
@@ -116,7 +116,7 @@ public class AddXmlMeta extends BaseTransformMeta<AddXml, AddXmlData> {
 
   public AddXmlMeta() {
     super();
-    encoding = Const.XML_ENCODING;
+    encoding = Const.UTF_8;
     valueName = "xmlvaluename";
     rootNode = "Row";
     omitDetails = new OmitDetails();

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/getxmldata/GetXmlData.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/getxmldata/GetXmlData.java
@@ -207,7 +207,7 @@ public class GetXmlData extends BaseTransform<GetXmlDataMeta, GetXmlDataData> {
         }
       } else {
         // get encoding. By default UTF-8
-        String encoding = "UTF-8";
+        String encoding = Const.UTF_8;
         if (!Utils.isEmpty(meta.getEncoding())) {
           encoding = meta.getEncoding();
         }

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/getxmldata/GetXmlDataDialog.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/getxmldata/GetXmlDataDialog.java
@@ -79,7 +79,6 @@ import org.eclipse.swt.widgets.Text;
 
 public class GetXmlDataDialog extends BaseTransformDialog {
   private static final Class<?> PKG = GetXmlDataMeta.class;
-  public static final String CONST_UTF_8 = "UTF-8";
   public static final String CONST_SYSTEM_COMBO_YES = "System.Combo.Yes";
   public static final String CONST_GET_XMLDATA_DIALOG_FAILED_TO_GET_FIELDS_DIALOG_TITLE =
       "GetXMLDataDialog.FailedToGetFields.DialogTitle";
@@ -1430,7 +1429,7 @@ public class GetXmlDataDialog extends BaseTransformDialog {
             }
             readFilePdOption.resetOption();
             readFilePdOption.setEncoding(
-                meta.getEncoding() == null ? CONST_UTF_8 : meta.getEncoding());
+                meta.getEncoding() == null ? Const.UTF_8 : meta.getEncoding());
             readFilePdOption.setValidating(meta.isValidating());
             LoopNodesImportProgressDialog pd =
                 new LoopNodesImportProgressDialog(shell, str, readFilePdOption);
@@ -1462,7 +1461,7 @@ public class GetXmlDataDialog extends BaseTransformDialog {
             readHopVfsPdOption.resetOption();
             readHopVfsPdOption.setValidating(meta.isValidating());
             readHopVfsPdOption.setEncoding(
-                meta.getEncoding() == null ? CONST_UTF_8 : meta.getEncoding());
+                meta.getEncoding() == null ? Const.UTF_8 : meta.getEncoding());
             String xml = HopVfs.getFilename(fileinputList.getFile(0));
             LoopNodesImportProgressDialog pd =
                 new LoopNodesImportProgressDialog(shell, xml, readHopVfsPdOption);
@@ -1605,7 +1604,7 @@ public class GetXmlDataDialog extends BaseTransformDialog {
       }
 
       // Now select the default!
-      String defEncoding = Const.getEnvironmentVariable("file.encoding", CONST_UTF_8);
+      String defEncoding = Const.getEnvironmentVariable("file.encoding", Const.UTF_8);
       int idx = Const.indexOfString(defEncoding, wEncoding.getItems());
       if (idx >= 0) {
         wEncoding.select(idx);
@@ -1678,7 +1677,7 @@ public class GetXmlDataDialog extends BaseTransformDialog {
     if (in.getEncoding() != null) {
       wEncoding.setText("" + in.getEncoding());
     } else {
-      wEncoding.setText(CONST_UTF_8);
+      wEncoding.setText(Const.UTF_8);
     }
 
     logDebug(BaseMessages.getString(PKG, "GetXMLDataDialog.Log.GettingFieldsInfo"));

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xmlinputstream/XmlInputStreamMeta.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xmlinputstream/XmlInputStreamMeta.java
@@ -51,7 +51,7 @@ public class XmlInputStreamMeta extends BaseTransformMeta<XmlInputStream, XmlInp
   private static final int DEFAULT_STRING_LEN_FILENAME = 256; // default length for XML path
   private static final int DEFAULT_STRING_LEN_PATH = 1024; // default length for XML path
   public static final String DEFAULT_STRING_LEN = "1024"; // used by defaultStringLen
-  public static final String DEFAULT_ENCODING = "UTF-8"; // used by encoding
+  public static final String DEFAULT_ENCODING = Const.UTF_8; // used by encoding
 
   @HopMetadataProperty(key = "filename")
   private String filename;

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xmljoin/XmlJoinDialog.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xmljoin/XmlJoinDialog.java
@@ -504,12 +504,12 @@ public class XmlJoinDialog extends BaseTransformDialog {
       }
 
       // Now select the default!
-      String defEncoding = Const.getEnvironmentVariable("file.encoding", "UTF-8");
+      String defEncoding = Const.getEnvironmentVariable("file.encoding", Const.UTF_8);
       int idx = Const.indexOfString(defEncoding, wEncoding.getItems());
       if (idx >= 0) {
         wEncoding.select(idx);
       } else {
-        wEncoding.select(Const.indexOfString("UTF-8", wEncoding.getItems()));
+        wEncoding.select(Const.indexOfString(Const.UTF_8, wEncoding.getItems()));
       }
     }
   }

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xmljoin/XmlJoinMeta.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xmljoin/XmlJoinMeta.java
@@ -104,7 +104,7 @@ public class XmlJoinMeta extends BaseTransformMeta<XmlJoin, XmlJoinData> {
 
   public XmlJoinMeta() {
     super();
-    encoding = Const.XML_ENCODING;
+    encoding = Const.UTF_8;
   }
 
   public XmlJoinMeta(XmlJoinMeta m) {

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xmloutput/XmlOutput.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xmloutput/XmlOutput.java
@@ -298,10 +298,10 @@ public class XmlOutput extends BaseTransform<XmlOutputMeta, XmlOutputData> {
         data.writer.writeStartDocument(meta.getEncoding(), "1.0");
       } else {
         if (isBasic()) {
-          logBasic("Opening output stream in default encoding : " + Const.XML_ENCODING);
+          logBasic("Opening output stream in default encoding : " + Const.UTF_8);
         }
         data.writer = XML_OUT_FACTORY.createXMLStreamWriter(outputStream);
-        data.writer.writeStartDocument(Const.XML_ENCODING, "1.0");
+        data.writer.writeStartDocument(Const.UTF_8, "1.0");
       }
       data.writer.writeCharacters(EOL);
 

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xmloutput/XmlOutputDialog.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xmloutput/XmlOutputDialog.java
@@ -775,7 +775,7 @@ public class XmlOutputDialog extends BaseTransformDialog {
       }
 
       // Now select the default!
-      String defEncoding = Const.getEnvironmentVariable("file.encoding", "UTF-8");
+      String defEncoding = Const.getEnvironmentVariable("file.encoding", Const.UTF_8);
       int idx = Const.indexOfString(defEncoding, wEncoding.getItems());
       if (idx >= 0) {
         wEncoding.select(idx);

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xmloutput/XmlOutputMeta.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xmloutput/XmlOutputMeta.java
@@ -215,7 +215,7 @@ public class XmlOutputMeta extends BaseTransformMeta<XmlOutput, XmlOutputData> {
     super();
     fileDetails = new FileDetails();
     outputFields = new ArrayList<>();
-    encoding = Const.XML_ENCODING;
+    encoding = Const.UTF_8;
     nameSpace = "";
     mainElement = "Rows";
     repeatElement = "Row";

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xslt/XsltData.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xslt/XsltData.java
@@ -19,6 +19,7 @@ package org.apache.hop.pipeline.transforms.xml.xslt;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Properties;
 import javax.xml.transform.Transformer;
@@ -85,7 +86,7 @@ public class XsltData extends BaseTransformData implements ITransformData {
         file = HopVfs.getFileObject(xslSource, variables);
         xslInputStream = HopVfs.getInputStream(file);
       } else {
-        xslInputStream = new ByteArrayInputStream(xslSource.getBytes("UTF-8"));
+        xslInputStream = new ByteArrayInputStream(xslSource.getBytes(StandardCharsets.UTF_8));
       }
 
       // Use the factory to create a template containing the xsl source

--- a/plugins/transforms/xml/src/test/java/org/apache/hop/pipeline/transforms/xml/addxml/AddXmlMetaTest.java
+++ b/plugins/transforms/xml/src/test/java/org/apache/hop/pipeline/transforms/xml/addxml/AddXmlMetaTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.hop.pipeline.transforms.xml.addxml;
 
+import org.apache.hop.core.Const;
 import org.apache.hop.core.HopClientEnvironment;
 import org.apache.hop.core.row.IValueMeta;
 import org.apache.hop.pipeline.transform.TransformSerializationTestUtil;
@@ -35,7 +36,7 @@ class AddXmlMetaTest {
     AddXmlMeta meta =
         TransformSerializationTestUtil.testSerialization("/add-xml.xml", AddXmlMeta.class);
 
-    Assertions.assertEquals("UTF-8", meta.getEncoding());
+    Assertions.assertEquals(Const.UTF_8, meta.getEncoding());
     Assertions.assertEquals("xmlValueName", meta.getValueName());
     Assertions.assertEquals("Row", meta.getRootNode());
     Assertions.assertTrue(meta.getOmitDetails().isOmittingNullValues());

--- a/plugins/transforms/xml/src/test/java/org/apache/hop/pipeline/transforms/xml/getxmldata/GetXMLDataTest.java
+++ b/plugins/transforms/xml/src/test/java/org/apache/hop/pipeline/transforms/xml/getxmldata/GetXMLDataTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.HopEnvironment;
 import org.apache.hop.core.RowMetaAndData;
 import org.apache.hop.core.exception.HopValueException;
@@ -295,7 +296,7 @@ class GetXMLDataTest {
     fields[4].setGroupSymbol("");
     fields[4].setTrimType(GetXmlDataField.getTrimTypeCode(GetXmlDataField.TYPE_TRIM_NONE));
 
-    gxdm.setEncoding("UTF-8");
+    gxdm.setEncoding(Const.UTF_8);
     gxdm.setAFile(false);
     gxdm.setInFields(true);
     gxdm.setLoopXPath("Level1/Level2/Props");
@@ -396,7 +397,7 @@ class GetXMLDataTest {
     fields[0].setGroupSymbol("");
     fields[0].setTrimType(GetXmlDataField.getTrimTypeCode(GetXmlDataField.TYPE_TRIM_NONE));
 
-    gxdm.setEncoding("UTF-8");
+    gxdm.setEncoding(Const.UTF_8);
     gxdm.setAFile(false);
     gxdm.setInFields(true);
     gxdm.setLoopXPath("Level1/Level2/Props");

--- a/plugins/transforms/xml/src/test/java/org/apache/hop/pipeline/transforms/xml/getxmldata/GetXmlDataMetaSerializationTest.java
+++ b/plugins/transforms/xml/src/test/java/org/apache/hop/pipeline/transforms/xml/getxmldata/GetXmlDataMetaSerializationTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.apache.hop.core.Const;
 import org.apache.hop.core.exception.HopTransformException;
 import org.apache.hop.core.row.IValueMeta;
 import org.apache.hop.core.row.RowMeta;
@@ -45,7 +46,7 @@ class GetXmlDataMetaSerializationTest {
     originalMeta.setDefault();
 
     // Configure basic settings
-    originalMeta.setEncoding("UTF-8");
+    originalMeta.setEncoding(Const.UTF_8);
     originalMeta.setLoopXPath("/root");
     originalMeta.setInFields(false);
     originalMeta.setAFile(false);
@@ -87,7 +88,7 @@ class GetXmlDataMetaSerializationTest {
     // Get XML and verify it can be generated
     String xml = originalMeta.getXml();
     assertNotNull(xml);
-    assertTrue(xml.contains("UTF-8"));
+    assertTrue(xml.contains(Const.UTF_8));
     assertTrue(xml.contains("/root"));
     assertTrue(xml.contains("tag1"));
     assertTrue(xml.contains("tag2"));
@@ -217,7 +218,7 @@ class GetXmlDataMetaSerializationTest {
     meta.setInputFields(inputFields);
 
     meta.setLoopXPath("/root/item");
-    meta.setEncoding("UTF-8");
+    meta.setEncoding(Const.UTF_8);
     meta.setRowLimit(1000L);
 
     // Clone the meta
@@ -234,7 +235,7 @@ class GetXmlDataMetaSerializationTest {
     assertEquals("field1", cloned.getInputFields().get(0).getName());
     assertEquals("field2", cloned.getInputFields().get(1).getName());
     assertEquals("/root/item", cloned.getLoopXPath());
-    assertEquals("UTF-8", cloned.getEncoding());
+    assertEquals(Const.UTF_8, cloned.getEncoding());
     assertEquals(1000L, cloned.getRowLimit());
   }
 
@@ -264,7 +265,7 @@ class GetXmlDataMetaSerializationTest {
     meta.setInputFields(inputFields);
 
     meta.setLoopXPath("/root/items/item");
-    meta.setEncoding("UTF-8");
+    meta.setEncoding(Const.UTF_8);
     meta.setInFields(true);
     meta.setXmlField("xml_content");
     meta.setRowLimit(500L);
@@ -278,7 +279,7 @@ class GetXmlDataMetaSerializationTest {
     // Verify XML contains key configuration (files are serialized via HopMetadataProperty, not
     // getXml())
     assertNotNull(xml);
-    assertTrue(xml.contains("UTF-8"));
+    assertTrue(xml.contains(Const.UTF_8));
     assertTrue(xml.contains("/root/items/item"));
     assertTrue(xml.contains("xml_content"));
     assertTrue(xml.contains("filename"));

--- a/plugins/transforms/xml/src/test/java/org/apache/hop/pipeline/transforms/xml/getxmldata/GetXmlDataMetaTest.java
+++ b/plugins/transforms/xml/src/test/java/org/apache/hop/pipeline/transforms/xml/getxmldata/GetXmlDataMetaTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 import java.util.Set;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.row.IValueMeta;
 import org.apache.hop.core.row.RowMeta;
 import org.apache.hop.core.row.value.ValueMetaFactory;
@@ -232,7 +233,7 @@ class GetXmlDataMetaTest {
     meta.setInputFields(inputFields);
 
     meta.setLoopXPath("/root/item");
-    meta.setEncoding("UTF-8");
+    meta.setEncoding(Const.UTF_8);
     meta.setInFields(true);
 
     // Clone
@@ -247,7 +248,7 @@ class GetXmlDataMetaTest {
     assertEquals(2, cloned.getInputFields().size());
     assertEquals("field1", cloned.getInputFields().get(0).getName());
     assertEquals("/root/item", cloned.getLoopXPath());
-    assertEquals("UTF-8", cloned.getEncoding());
+    assertEquals(Const.UTF_8, cloned.getEncoding());
     assertTrue(cloned.isInFields());
   }
 
@@ -294,7 +295,7 @@ class GetXmlDataMetaTest {
     meta.setInputFields(fields);
 
     meta.setLoopXPath("/root/data");
-    meta.setEncoding("UTF-8");
+    meta.setEncoding(Const.UTF_8);
     meta.setInFields(true);
     meta.setXmlField("xml_content");
 
@@ -304,7 +305,7 @@ class GetXmlDataMetaTest {
     // Files are serialized via HopMetadataProperty annotations, not in getXml()
     // Check for what's actually in the XML output from getXml()
     assertTrue(xml.contains("/root/data"));
-    assertTrue(xml.contains("UTF-8"));
+    assertTrue(xml.contains(Const.UTF_8));
     assertTrue(xml.contains("xml_content"));
     assertTrue(xml.contains("test_field"));
   }

--- a/plugins/transforms/xml/src/test/java/org/apache/hop/pipeline/transforms/xml/getxmldata/PdOptionTest.java
+++ b/plugins/transforms/xml/src/test/java/org/apache/hop/pipeline/transforms/xml/getxmldata/PdOptionTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.apache.hop.core.Const;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -76,8 +77,8 @@ class PdOptionTest {
   @Test
   void testSetEncoding() {
     // Setting encoding should also set isXmlSourceFile to true
-    pdOption.setEncoding("UTF-8");
-    assertEquals("UTF-8", pdOption.getEncoding());
+    pdOption.setEncoding(Const.UTF_8);
+    assertEquals(Const.UTF_8, pdOption.getEncoding());
     assertTrue(
         pdOption.isXmlSourceFile(), "Setting encoding should automatically set isXmlSourceFile");
   }
@@ -85,7 +86,7 @@ class PdOptionTest {
   @Test
   void testSetEncodingMultipleTimes() {
     // Verify that setting encoding multiple times maintains isXmlSourceFile
-    pdOption.setEncoding("UTF-8");
+    pdOption.setEncoding(Const.UTF_8);
     assertTrue(pdOption.isXmlSourceFile());
 
     pdOption.setEncoding("ISO-8859-1");
@@ -132,7 +133,7 @@ class PdOptionTest {
     // Verify the comment: "if the encoding is not null, the source must be a file"
     assertFalse(pdOption.isXmlSourceFile(), "Initially should be false");
 
-    pdOption.setEncoding("UTF-8");
+    pdOption.setEncoding(Const.UTF_8);
     assertTrue(
         pdOption.isXmlSourceFile(), "Setting encoding should indicate that source is a file");
   }
@@ -140,7 +141,7 @@ class PdOptionTest {
   @Test
   void testCommonEncodings() {
     // Test with common encoding values
-    String[] encodings = {"UTF-8", "UTF-16", "ISO-8859-1", "US-ASCII", "windows-1252"};
+    String[] encodings = {Const.UTF_8, "UTF-16", "ISO-8859-1", "US-ASCII", "windows-1252"};
 
     for (String encoding : encodings) {
       PdOption option = new PdOption();
@@ -196,7 +197,7 @@ class PdOptionTest {
   @Test
   void testFileModeConfiguration() {
     // Test configuration for file-based XML reading with encoding
-    pdOption.setEncoding("UTF-8");
+    pdOption.setEncoding(Const.UTF_8);
     pdOption.setValidating(true);
     pdOption.setLoopXPath("/file/records");
 
@@ -204,7 +205,7 @@ class PdOptionTest {
     assertTrue(pdOption.isValidating());
     assertFalse(pdOption.isUseUrl());
     assertFalse(pdOption.isUseSnippet());
-    assertEquals("UTF-8", pdOption.getEncoding());
+    assertEquals(Const.UTF_8, pdOption.getEncoding());
     assertEquals("/file/records", pdOption.getLoopXPath());
   }
 
@@ -213,7 +214,7 @@ class PdOptionTest {
     // Although not enforced by the class, test that different modes can be independently set
     pdOption.setUseUrl(true);
     pdOption.setUseSnippet(true);
-    pdOption.setEncoding("UTF-8");
+    pdOption.setEncoding(Const.UTF_8);
 
     // All can be true simultaneously (validation logic might be in the calling code)
     assertTrue(pdOption.isUseUrl());

--- a/plugins/transforms/xml/src/test/java/org/apache/hop/pipeline/transforms/xml/xmlinputstream/XmlInputStreamMetaTest.java
+++ b/plugins/transforms/xml/src/test/java/org/apache/hop/pipeline/transforms/xml/xmlinputstream/XmlInputStreamMetaTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.hop.pipeline.transforms.xml.xmlinputstream;
 
+import org.apache.hop.core.Const;
 import org.apache.hop.pipeline.transform.TransformSerializationTestUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -82,7 +83,7 @@ class XmlInputStreamMetaTest {
     Assertions.assertEquals("123", meta.getNrRowsToSkip());
     Assertions.assertEquals("456", meta.getRowLimit());
     Assertions.assertEquals("2048", meta.getDefaultStringLen());
-    Assertions.assertEquals("UTF-8", meta.getEncoding());
+    Assertions.assertEquals(Const.UTF_8, meta.getEncoding());
     Assertions.assertTrue(meta.isEnableNamespaces());
     Assertions.assertTrue(meta.isEnableTrim());
   }

--- a/plugins/transforms/yamlinput/src/test/java/org/apache/hop/pipeline/transforms/yamlinput/YamlInputMetaTest.java
+++ b/plugins/transforms/yamlinput/src/test/java/org/apache/hop/pipeline/transforms/yamlinput/YamlInputMetaTest.java
@@ -27,6 +27,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.ICheckResult;
 import org.apache.hop.core.fileinput.FileInputList;
 import org.apache.hop.core.plugins.PluginRegistry;
@@ -81,7 +82,7 @@ class YamlInputMetaTest {
     assertTrue(meta.isIgnoringEmptyFile());
     assertTrue(meta.isDoNotFailIfNoFile());
     assertEquals("rowNumField", meta.getRowNumberField());
-    assertEquals("UTF-8", meta.getEncoding());
+    assertEquals(Const.UTF_8, meta.getEncoding());
     assertEquals(999L, meta.getRowLimit());
     assertTrue(meta.isSourceFile());
     assertTrue(meta.isInFields());

--- a/plugins/valuetypes/uuid/src/main/java/org/apache/hop/uuid/ValueMetaUuid.java
+++ b/plugins/valuetypes/uuid/src/main/java/org/apache/hop/uuid/ValueMetaUuid.java
@@ -21,8 +21,8 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.SocketTimeoutException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -241,9 +241,9 @@ public class ValueMetaUuid extends ValueMetaBase {
     }
 
     try {
-      return u.toString().getBytes(getStringEncoding() == null ? "UTF-8" : getStringEncoding());
-    } catch (UnsupportedEncodingException e) {
-      throw new HopValueException("Unsupported encoding for UUID", e);
+      String encode = getStringEncoding();
+      Charset charset = encode == null ? StandardCharsets.UTF_8 : Charset.forName(encode);
+      return u.toString().getBytes(charset);
     } catch (Exception e) {
       throw new HopValueException("Unable to get binary string for UUID", e);
     }

--- a/plugins/valuetypes/uuid/src/test/java/org/apache/hop/uuid/ValueMetaUuidTest.java
+++ b/plugins/valuetypes/uuid/src/test/java/org/apache/hop/uuid/ValueMetaUuidTest.java
@@ -31,6 +31,7 @@ import java.io.DataOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.sql.ResultSet;
 import java.util.UUID;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.HopClientEnvironment;
 import org.apache.hop.core.database.IDatabase;
 import org.apache.hop.core.exception.HopValueException;
@@ -100,7 +101,7 @@ class ValueMetaUuidTest {
     // target meta storageMetadata tells how to turn bytes into String
     ValueMetaString storage = new ValueMetaString("id");
     storage.setStorageType(IValueMeta.STORAGE_TYPE_NORMAL);
-    storage.setStringEncoding("UTF-8");
+    storage.setStringEncoding(Const.UTF_8);
     binDst.setStorageMetadata(storage);
 
     UUID u3 = UUID.randomUUID();

--- a/rest/src/main/java/org/apache/hop/rest/v1/resources/ExecutionResource.java
+++ b/rest/src/main/java/org/apache/hop/rest/v1/resources/ExecutionResource.java
@@ -179,7 +179,7 @@ public class ExecutionResource extends BaseResource {
 
       // For now just give back the request as JSON
       //
-      return Response.ok(output.toString()).type(contentType).encoding(Const.XML_ENCODING).build();
+      return Response.ok(output.toString()).type(contentType).encoding(Const.UTF_8).build();
     } catch (Exception e) {
       String errorMessage =
           "Unexpected error executing synchronous web service (pipeline) with name "

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/HopGuiPipelineGraph.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/HopGuiPipelineGraph.java
@@ -4040,7 +4040,7 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
       String xml = pipelineMeta.getXml(variables);
       OutputStream out = HopVfs.getOutputStream(pipelineMeta.getFilename(), false);
       try {
-        out.write(XmlHandler.getXmlHeader(Const.XML_ENCODING).getBytes(StandardCharsets.UTF_8));
+        out.write(XmlHandler.getXmlHeader(Const.UTF_8).getBytes(StandardCharsets.UTF_8));
         out.write(xml.getBytes(StandardCharsets.UTF_8));
         pipelineMeta.clearChanged();
         updateGui();

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/HopGuiWorkflowGraph.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/HopGuiWorkflowGraph.java
@@ -3598,7 +3598,7 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
       String xml = workflowMeta.getXml(variables);
       OutputStream out = HopVfs.getOutputStream(workflowMeta.getFilename(), false);
       try {
-        out.write(XmlHandler.getXmlHeader(Const.XML_ENCODING).getBytes(StandardCharsets.UTF_8));
+        out.write(XmlHandler.getXmlHeader(Const.UTF_8).getBytes(StandardCharsets.UTF_8));
         out.write(xml.getBytes(StandardCharsets.UTF_8));
         workflowMeta.clearChanged();
         updateGui();

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/ExplorerPerspective.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/ExplorerPerspective.java
@@ -1687,7 +1687,7 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
           String xml = pipelineMeta.getXml(variables);
           OutputStream out = HopVfs.getOutputStream(filename, false);
           try {
-            out.write(XmlHandler.getXmlHeader(Const.XML_ENCODING).getBytes(StandardCharsets.UTF_8));
+            out.write(XmlHandler.getXmlHeader(Const.UTF_8).getBytes(StandardCharsets.UTF_8));
             out.write(xml.getBytes(StandardCharsets.UTF_8));
           } finally {
             out.flush();
@@ -1704,7 +1704,7 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
           String xml = workflowMeta.getXml(variables);
           OutputStream out = HopVfs.getOutputStream(filename, false);
           try {
-            out.write(XmlHandler.getXmlHeader(Const.XML_ENCODING).getBytes(StandardCharsets.UTF_8));
+            out.write(XmlHandler.getXmlHeader(Const.UTF_8).getBytes(StandardCharsets.UTF_8));
             out.write(xml.getBytes(StandardCharsets.UTF_8));
           } finally {
             out.flush();

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/file/types/base/BaseExplorerFileTypeHandler.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/file/types/base/BaseExplorerFileTypeHandler.java
@@ -21,6 +21,7 @@ package org.apache.hop.ui.hopgui.perspective.explorer.file.types.base;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -60,13 +61,13 @@ public abstract class BaseExplorerFileTypeHandler implements IExplorerFileTypeHa
     this.explorerFile = explorerFile;
   }
 
-  protected String readTextFileContent(String encoding) throws HopException {
+  protected String readTextFileContent(Charset charset) throws HopException {
     try {
       FileObject file = HopVfs.getFileObject(getFilename(), getVariables());
       if (file.exists()) {
         try (InputStream inputStream = HopVfs.getInputStream(file)) {
           StringWriter writer = new StringWriter();
-          IOUtils.copy(inputStream, writer, encoding);
+          IOUtils.copy(inputStream, writer, charset);
           return writer.toString();
         }
       } else {

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/file/types/raw/RawExplorerFileTypeHandler.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/file/types/raw/RawExplorerFileTypeHandler.java
@@ -163,7 +163,7 @@ public class RawExplorerFileTypeHandler extends BaseTextExplorerFileTypeHandler 
   public void reload() {
     try {
       reloadListener = false;
-      String contents = readTextFileContent("UTF-8");
+      String contents = readTextFileContent(StandardCharsets.UTF_8);
       editorWidget.setTextSuppressModify(Const.NVL(contents, ""));
     } catch (Exception e) {
       LogChannel.UI.logError(

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/file/types/text/BaseTextExplorerFileTypeHandler.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/file/types/text/BaseTextExplorerFileTypeHandler.java
@@ -135,7 +135,7 @@ public class BaseTextExplorerFileTypeHandler extends BaseExplorerFileTypeHandler
   @Override
   public void reload() {
     try {
-      String contents = readTextFileContent("UTF-8");
+      String contents = readTextFileContent(StandardCharsets.UTF_8);
       editorWidget.setTextSuppressModify(Const.NVL(contents, ""));
     } catch (Exception e) {
       LogChannel.UI.logError(


### PR DESCRIPTION
This PR improves encoding handling by standardizing UTF-8 usage across the codebase and simplifying exception management.

- Extracted the UTF-8 string constant into a shared `Const` class:
`String UTF_8 = "UTF-8";`

- Updated `URLEncoder.encode(routingPolicyString, "UTF-8")` to use `StandardCharsets.UTF_8`:
`URLEncoder.encode(routingPolicyString, StandardCharsets.UTF_8)`

- Removed unnecessary `UnsupportedEncodingException` handling, as `StandardCharsets.UTF_8` is guaranteed to be available.