### PR TITLE
Refactor Map initialization patterns and migrate string concatenations to text blocks

### DIFF
--- a/core/src/main/java/org/apache/hop/core/Const.java
+++ b/core/src/main/java/org/apache/hop/core/Const.java
@@ -304,6 +304,9 @@ public class Const {
   /** Default we store our information in Unicode UTF-8 character set. */
   public static final String UTF_8 = "UTF-8";
 
+  /** Placeholder for the project home directory. */
+  public static final String VAR_PROJECT_HOME = "${PROJECT_HOME}";
+
   /** Allow or disallow doctype declarations in XML. " */
   @Variable(value = "N", description = "A variable allow or disallow doctype declarations in XML")
   public static final String XML_ALLOW_DOCTYPE_DECL = "XML_ALLOW_DOCTYPE_DECL";

--- a/engine/src/main/java/org/apache/hop/core/injection/bean/BeanInjectionInfo.java
+++ b/engine/src/main/java/org/apache/hop/core/injection/bean/BeanInjectionInfo.java
@@ -171,12 +171,14 @@ public class BeanInjectionInfo<Meta extends Object> {
 
       Group group = null;
       if (StringUtils.isNotEmpty(injectionGroupKey)) {
-        group = groupsMap.get(injectionGroupKey);
-        if (group == null) {
-          group = new Group(injectionGroupKey, injectionGroupDescription);
-          groupsMap.put(injectionGroupKey, group);
-          groupsList.add(group);
-        }
+        group =
+            groupsMap.computeIfAbsent(
+                injectionGroupKey,
+                key -> {
+                  Group newGroup = new Group(key, injectionGroupDescription);
+                  groupsList.add(newGroup);
+                  return newGroup;
+                });
       }
 
       if (StringUtils.isNotEmpty(injectionGroupKey)) {

--- a/engine/src/main/java/org/apache/hop/metadata/refactor/MetadataReferenceFinder.java
+++ b/engine/src/main/java/org/apache/hop/metadata/refactor/MetadataReferenceFinder.java
@@ -24,7 +24,7 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +34,7 @@ import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSelectInfo;
 import org.apache.commons.vfs2.FileSelector;
 import org.apache.commons.vfs2.FileType;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.exception.HopException;
 import org.apache.hop.core.exception.HopXmlException;
 import org.apache.hop.core.plugins.ActionPluginType;
@@ -176,7 +177,8 @@ public class MetadataReferenceFinder {
    */
   private Map<HopMetadataPropertyType, List<MetadataClassField>>
       buildPropertyTypeToMetadataFields() {
-    Map<HopMetadataPropertyType, List<MetadataClassField>> map = new HashMap<>();
+    Map<HopMetadataPropertyType, List<MetadataClassField>> map =
+        new EnumMap<>(HopMetadataPropertyType.class);
     try {
       // Layer 1: direct fields on top-level metadata classes
       for (Class<? extends IHopMetadata> metadataClass : metadataProvider.getMetadataClasses()) {
@@ -352,14 +354,14 @@ public class MetadataReferenceFinder {
    * returned value preserves the variable style (e.g. {@code ${PROJECT_HOME}/new.hpl}).
    */
   private static String computeNewFilePath(String stored, String newPath, IVariables variables) {
-    if (variables != null && stored != null && stored.contains("${PROJECT_HOME}")) {
-      String projectHome = variables.resolve("${PROJECT_HOME}");
+    if (variables != null && stored != null && stored.contains(Const.VAR_PROJECT_HOME)) {
+      String projectHome = variables.resolve(Const.VAR_PROJECT_HOME);
       if (projectHome != null && !projectHome.isEmpty() && newPath.startsWith(projectHome)) {
         String rel = newPath.substring(projectHome.length());
         if (!rel.startsWith("/")) {
           rel = "/" + rel;
         }
-        return "${PROJECT_HOME}" + rel;
+        return Const.VAR_PROJECT_HOME + rel;
       }
     }
     return newPath;
@@ -367,10 +369,10 @@ public class MetadataReferenceFinder {
 
   /**
    * Builds a map from each HopMetadataPropertyType to the set of XML tag names that store a
-   * reference of that type (from @HopMetadataProperty on transform and action meta classes).
+   * reference of that type (from @HopMetadataProperty on transform and action metaclasses).
    */
   private static Map<HopMetadataPropertyType, Set<String>> buildPropertyTypeToTagNames() {
-    Map<HopMetadataPropertyType, Set<String>> map = new HashMap<>();
+    Map<HopMetadataPropertyType, Set<String>> map = new EnumMap<>(HopMetadataPropertyType.class);
     PluginRegistry registry = PluginRegistry.getInstance();
 
     for (HopMetadataPropertyType type : HopMetadataPropertyType.values()) {
@@ -415,11 +417,7 @@ public class MetadataReferenceFinder {
           continue;
         }
         collectTagsFromClass(metaClass, tags, targetType, new HashSet<>());
-      } catch (NoClassDefFoundError e) {
-        // Skip plugin if a dependency is missing (e.g. Saxon in plugin classloader)
-      } catch (ClassNotFoundException e) {
-        // Skip plugin if we can't load it
-      } catch (Exception e) {
+      } catch (Exception ignore) {
         // Skip plugin if we can't load or reflect
       }
     }
@@ -1203,9 +1201,8 @@ public class MetadataReferenceFinder {
           }
           if (matches) {
             count[0]++;
-            if (replace && node instanceof Element && newNameForReplace != null) {
-              ((Element) node)
-                  .setTextContent(computeNewFilePath(trimmed, newNameForReplace, variables));
+            if (replace && node instanceof Element el && newNameForReplace != null) {
+              el.setTextContent(computeNewFilePath(trimmed, newNameForReplace, variables));
             }
           }
         }

--- a/engine/src/main/java/org/apache/hop/pipeline/transform/TransformMeta.java
+++ b/engine/src/main/java/org/apache/hop/pipeline/transform/TransformMeta.java
@@ -468,7 +468,7 @@ public class TransformMeta
       return new HashMap<>();
     }
 
-    Map<String, Map<String, String>> result = new HashMap<>(map.size());
+    Map<String, Map<String, String>> result = HashMap.newHashMap(map.size());
     for (Map.Entry<String, Map<String, String>> entry : map.entrySet()) {
       Map<String, String> value = entry.getValue();
       HashMap<String, String> copy = (value == null) ? null : new HashMap<>(value);

--- a/engine/src/main/java/org/apache/hop/pipeline/transform/copy/DefaultTransformMetaCopyFactory.java
+++ b/engine/src/main/java/org/apache/hop/pipeline/transform/copy/DefaultTransformMetaCopyFactory.java
@@ -199,7 +199,7 @@ public class DefaultTransformMetaCopyFactory implements ITransformMetaCopyFactor
       return new HashMap<>();
     }
 
-    Map<String, Map<String, String>> copy = new HashMap<>(source.size());
+    Map<String, Map<String, String>> copy = HashMap.newHashMap(source.size());
     for (Map.Entry<String, Map<String, String>> entry : source.entrySet()) {
       Map<String, String> value = entry.getValue();
       HashMap<String, String> valueCopy = (value == null) ? null : new HashMap<>(value);

--- a/engine/src/test/java/org/apache/hop/www/GetPipelineImageServletTest.java
+++ b/engine/src/test/java/org/apache/hop/www/GetPipelineImageServletTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.hop.www;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -67,6 +66,6 @@ class GetPipelineImageServletTest {
 
     servlet.doGet(request, response);
 
-    verify(response).setStatus(eq(HttpServletResponse.SC_NO_CONTENT));
+    verify(response).setStatus(HttpServletResponse.SC_NO_CONTENT);
   }
 }

--- a/engine/src/test/java/org/apache/hop/www/GetRootServletTest.java
+++ b/engine/src/test/java/org/apache/hop/www/GetRootServletTest.java
@@ -18,7 +18,6 @@
 package org.apache.hop.www;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -62,6 +61,6 @@ class GetRootServletTest {
         when(mock(HttpServletRequest.class).getRequestURI()).thenReturn("/wrong_path").getMock();
     HttpServletResponse response = mock(HttpServletResponse.class);
     servlet.doGet(request, response);
-    verify(response).sendError(eq(HttpServletResponse.SC_NOT_FOUND), eq("Not found."));
+    verify(response).sendError(HttpServletResponse.SC_NOT_FOUND, "Not found.");
   }
 }

--- a/engine/src/test/java/org/apache/hop/www/GetWorkflowImageServletTest.java
+++ b/engine/src/test/java/org/apache/hop/www/GetWorkflowImageServletTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.hop.www;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -67,6 +66,6 @@ class GetWorkflowImageServletTest {
 
     servlet.doGet(request, response);
 
-    verify(response).setStatus(eq(HttpServletResponse.SC_NO_CONTENT));
+    verify(response).setStatus(HttpServletResponse.SC_NO_CONTENT);
   }
 }

--- a/engine/src/test/java/org/apache/hop/www/HopServerServletTest.java
+++ b/engine/src/test/java/org/apache/hop/www/HopServerServletTest.java
@@ -18,7 +18,6 @@
 package org.apache.hop.www;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -72,7 +71,7 @@ class HopServerServletTest {
 
     servlet.doGet(req, resp);
 
-    verify(resp).sendError(eq(HttpServletResponse.SC_NOT_FOUND), eq("Not found."));
+    verify(resp).sendError(HttpServletResponse.SC_NOT_FOUND, "Not found.");
   }
 
   @Test
@@ -102,8 +101,7 @@ class HopServerServletTest {
 
     servlet.doGet(req, resp);
 
-    verify(resp)
-        .sendError(eq(HttpServletResponse.SC_INTERNAL_SERVER_ERROR), eq("Plugin request failed."));
+    verify(resp).sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Plugin request failed.");
   }
 
   @Test
@@ -118,7 +116,6 @@ class HopServerServletTest {
 
     verify(resp)
         .sendError(
-            eq(HttpServletResponse.SC_INTERNAL_SERVER_ERROR),
-            eq("Unable to process server request."));
+            HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Unable to process server request.");
   }
 }

--- a/plugins/actions/ftp/src/main/java/org/apache/hop/workflow/actions/ftp/ActionFtp.java
+++ b/plugins/actions/ftp/src/main/java/org/apache/hop/workflow/actions/ftp/ActionFtp.java
@@ -83,10 +83,6 @@ public class ActionFtp extends ActionBase implements Cloneable, IAction, IFtpCon
   /** Default encoding when making a new ftp action instance. */
   private static final String DEFAULT_CONTROL_ENCODING = "ISO-8859-1";
 
-  /*
-  IfFileExists.add();
-    wIfFileExists.add();
-    wIfFileExists.add();*/
   @Getter
   public enum IfFileExistsOperation implements IEnumHasCodeAndDescription {
     SKIP("ifFileExistsSkip", BaseMessages.getString(PKG, "ActionFtp.Skip.Label")),
@@ -677,9 +673,8 @@ public class ActionFtp extends ActionBase implements Cloneable, IAction, IFtpCon
           logError(BaseMessages.getString(PKG, CONST_LOCAL_FILE_EXISTS), filename);
           updateErrors();
         }
-        case SKIP -> {
-          logDebug(toString(), BaseMessages.getString(PKG, CONST_LOCAL_FILE_EXISTS), filename);
-        }
+        case SKIP ->
+            logDebug(toString(), BaseMessages.getString(PKG, CONST_LOCAL_FILE_EXISTS), filename);
       }
     }
 

--- a/plugins/actions/shell/src/test/java/org/apache/hop/workflow/actions/shell/WorkflowActionShellLoadSaveTest.java
+++ b/plugins/actions/shell/src/test/java/org/apache/hop/workflow/actions/shell/WorkflowActionShellLoadSaveTest.java
@@ -19,6 +19,7 @@ package org.apache.hop.workflow.actions.shell;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.apache.hop.core.Const;
 import org.apache.hop.workflow.action.ActionSerializationTestUtil;
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +30,7 @@ class WorkflowActionShellLoadSaveTest {
         ActionSerializationTestUtil.testSerialization("/shell-action.xml", ActionShell.class);
 
     assertEquals("${PROJECT_HOME}/0002-shell-test.sh", meta.getFilename());
-    assertEquals("${PROJECT_HOME}", meta.getWorkDirectory());
+    assertEquals(Const.VAR_PROJECT_HOME, meta.getWorkDirectory());
     assertEquals(1, meta.getArguments().size());
   }
 

--- a/plugins/misc/import/src/main/java/org/apache/hop/imports/kettle/KettleImport.java
+++ b/plugins/misc/import/src/main/java/org/apache/hop/imports/kettle/KettleImport.java
@@ -727,7 +727,8 @@ public class KettleImport extends HopImportBase implements IHopImport {
         // pipeline
         // filename.
         if (!StringUtils.isEmpty(transName) && !StringUtils.isEmpty(directoryPath)) {
-          filenameNode.setTextContent("${PROJECT_HOME}" + directoryPath + '/' + transName + ".hpl");
+          filenameNode.setTextContent(
+              Const.VAR_PROJECT_HOME + directoryPath + '/' + transName + ".hpl");
         }
 
         // add the default pipeline run configuration.
@@ -817,7 +818,7 @@ public class KettleImport extends HopImportBase implements IHopImport {
   private Node processRepositoryNode(Node repositoryNode) {
 
     String filename = "";
-    String directory = "${PROJECT_HOME}";
+    String directory = Const.VAR_PROJECT_HOME;
     String type = "";
     Node filenameNode = null;
 

--- a/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/AzureFileObject.java
+++ b/plugins/tech/azure/src/main/java/org/apache/hop/vfs/azure/AzureFileObject.java
@@ -81,11 +81,6 @@ public class AzureFileObject extends AbstractFileObject<AzureFileSystem> {
     }
 
     @Override
-    public void flush() throws IOException {
-      super.flush();
-    }
-
-    @Override
     public void close() throws IOException {
       outputStream.close();
     }
@@ -101,7 +96,7 @@ public class AzureFileObject extends AbstractFileObject<AzureFileSystem> {
   private String currentFilePath;
   private PathItem pathItem;
   private PathItem dirPathItem;
-  private final String markerFileName = ".cvfs.temp";
+  private static final String MARKER_FILE_NAME = ".cvfs.temp";
   private OutputStream blobOutputStream;
   private String containerName;
 
@@ -365,7 +360,7 @@ public class AzureFileObject extends AbstractFileObject<AzureFileSystem> {
 
   @Override
   protected boolean doIsHidden() throws Exception {
-    return getName().getBaseName().equals(markerFileName);
+    return getName().getBaseName().equals(MARKER_FILE_NAME);
   }
 
   /**
@@ -413,7 +408,7 @@ public class AzureFileObject extends AbstractFileObject<AzureFileSystem> {
           // If this was the last file in the create, we create a new
           // marker file to keep the directory open
           if (lastFile) {
-            FileObject marker = parent.resolveFile(markerFileName);
+            FileObject marker = parent.resolveFile(MARKER_FILE_NAME);
             marker.createFile();
           }
         }
@@ -465,7 +460,7 @@ public class AzureFileObject extends AbstractFileObject<AzureFileSystem> {
   @Override
   protected void doCreateFolder() {
     service.getFileSystemClient(containerName).createDirectory(currentFilePath.substring(1));
-    if (containerName != null && currentFilePath != null) {
+    if (containerName != null) {
       getAbstractFileSystem()
           .invalidateListCacheForParentOf(
               containerName, StringUtils.removeStart(currentFilePath, "/"));
@@ -548,7 +543,6 @@ public class AzureFileObject extends AbstractFileObject<AzureFileSystem> {
       return true;
     } catch (Exception e) {
       return false;
-      // TODO log an error
     }
   }
 

--- a/plugins/tech/google/src/main/java/org/apache/hop/pipeline/transforms/googlesheets/GoogleSheetsCredentials.java
+++ b/plugins/tech/google/src/main/java/org/apache/hop/pipeline/transforms/googlesheets/GoogleSheetsCredentials.java
@@ -36,6 +36,7 @@ import org.apache.hop.core.vfs.HopVfs;
 
 /** Describe your transform plugin. */
 public class GoogleSheetsCredentials {
+  private GoogleSheetsCredentials() {}
 
   public static final String APPLICATION_NAME = "Apache-Hop-Google-Sheets";
 
@@ -63,22 +64,12 @@ public class GoogleSheetsCredentials {
     credential = GoogleCredentials.fromStream(in);
 
     if (httpTransport != null) {
-      HttpTransportFactory proxyTransportFactory =
-          new HttpTransportFactory() {
-            @Override
-            public HttpTransport create() {
-              return httpTransport;
-            }
-          };
+      HttpTransportFactory proxyTransportFactory = () -> httpTransport;
 
-      if (credential instanceof ServiceAccountCredentials) {
-        credential =
-            ((ServiceAccountCredentials) credential)
-                .toBuilder().setHttpTransportFactory(proxyTransportFactory).build();
-      } else if (credential instanceof UserCredentials) {
-        credential =
-            ((UserCredentials) credential)
-                .toBuilder().setHttpTransportFactory(proxyTransportFactory).build();
+      if (credential instanceof ServiceAccountCredentials sc) {
+        credential = sc.toBuilder().setHttpTransportFactory(proxyTransportFactory).build();
+      } else if (credential instanceof UserCredentials uc) {
+        credential = uc.toBuilder().setHttpTransportFactory(proxyTransportFactory).build();
       }
     }
 
@@ -97,10 +88,12 @@ public class GoogleSheetsCredentials {
   public static HttpRequestInitializer setHttpTimeout(
       final HttpRequestInitializer requestInitializer, final String timeout) {
     return httpRequest -> {
-      Integer TO = Integer.parseInt(timeout);
+      int t0 = Integer.parseInt(timeout);
       requestInitializer.initialize(httpRequest);
-      httpRequest.setConnectTimeout(TO * 60000); // 10 minutes connect timeout
-      httpRequest.setReadTimeout(TO * 60000); // 10 minutes read timeout
+      // 10 minutes connect timeout
+      httpRequest.setConnectTimeout(t0 * 60000);
+      // 10 minutes read timeout
+      httpRequest.setReadTimeout(t0 * 60000);
     };
   }
 }

--- a/plugins/transforms/combinationlookup/src/main/java/org/apache/hop/pipeline/transforms/combinationlookup/CombinationLookup.java
+++ b/plugins/transforms/combinationlookup/src/main/java/org/apache/hop/pipeline/transforms/combinationlookup/CombinationLookup.java
@@ -700,7 +700,7 @@ public class CombinationLookup extends BaseTransform<CombinationLookupMeta, Comb
       data.realTableName = resolve(meta.getTableName());
 
       if (meta.getCacheSize() > 0) {
-        data.cache = new HashMap<>((int) (meta.getCacheSize() * 1.5));
+        data.cache = HashMap.newHashMap((int) (meta.getCacheSize() * 1.5));
       } else {
         data.cache = new HashMap<>();
       }

--- a/plugins/transforms/databaselookup/src/main/java/org/apache/hop/pipeline/transforms/databaselookup/DefaultCache.java
+++ b/plugins/transforms/databaselookup/src/main/java/org/apache/hop/pipeline/transforms/databaselookup/DefaultCache.java
@@ -45,7 +45,7 @@ public class DefaultCache implements DatabaseLookupData.ICache {
 
   DefaultCache(DatabaseLookupData data, int capacity) {
     this.data = data;
-    map = new LinkedHashMap<>(capacity);
+    map = LinkedHashMap.newLinkedHashMap(capacity);
   }
 
   @Override
@@ -59,7 +59,7 @@ public class DefaultCache implements DatabaseLookupData.ICache {
       }
     } else { // special handling of conditions <,>, <> etc.
       if (!data.hasDBCondition) { // e.g. LIKE not handled by this routine, yet
-        // TODO: find an alternative way to look up the data based on the condition.
+        //  find an alternative way to look up the data based on the condition.
         // Not all conditions are "=" so we are going to have to evaluate row by row
         // A sorted list or index might be a good solution here...
         //
@@ -109,7 +109,7 @@ public class DefaultCache implements DatabaseLookupData.ICache {
                 }
                 lookupIndex++;
                 break;
-                // TODO: add LIKE operator (think of changing the hasDBCondition logic then)
+                //  add LIKE operator (think of changing the hasDBCondition logic then)
               default:
                 match = false;
                 data.hasDBCondition =

--- a/plugins/transforms/dimensionlookup/src/main/java/org/apache/hop/pipeline/transforms/dimensionlookup/DimensionLookupMeta.java
+++ b/plugins/transforms/dimensionlookup/src/main/java/org/apache/hop/pipeline/transforms/dimensionlookup/DimensionLookupMeta.java
@@ -342,9 +342,7 @@ public class DimensionLookupMeta extends BaseTransformMeta<DimensionLookup, Dime
       throws HopTransformException {
     IValueMeta tkValueMeta;
     switch (fields.returns.creationMethod) {
-      case SEQUENCE:
-      case TABLE_MAXIMUM:
-      case AUTO_INCREMENT:
+      case SEQUENCE, TABLE_MAXIMUM, AUTO_INCREMENT:
         tkValueMeta = new ValueMetaInteger(name, 9, 0);
         break;
       case UUID:

--- a/plugins/transforms/getsubfolders/src/test/java/org/apache/hop/pipeline/transforms/getsubfolders/GetSubFoldersMetaTest.java
+++ b/plugins/transforms/getsubfolders/src/test/java/org/apache/hop/pipeline/transforms/getsubfolders/GetSubFoldersMetaTest.java
@@ -20,6 +20,7 @@ package org.apache.hop.pipeline.transforms.getsubfolders;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.apache.hop.core.Const;
 import org.apache.hop.pipeline.transform.TransformSerializationTestUtil;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +33,7 @@ class GetSubFoldersMetaTest {
 
     assertTrue(meta.isIncludeRowNumber());
     assertEquals(1, meta.getFiles().size());
-    assertEquals("${PROJECT_HOME}", meta.getFiles().get(0).getName());
+    assertEquals(Const.VAR_PROJECT_HOME, meta.getFiles().get(0).getName());
     assertTrue(meta.getFiles().get(0).isRequired());
     assertEquals("rowNumber", meta.getRowNumberField());
     assertEquals(123L, meta.getRowLimit());

--- a/plugins/transforms/janino/src/test/java/org/apache/hop/pipeline/transforms/userdefinedjavaclass/UserDefinedJavaClassMetaTest.java
+++ b/plugins/transforms/janino/src/test/java/org/apache/hop/pipeline/transforms/userdefinedjavaclass/UserDefinedJavaClassMetaTest.java
@@ -57,13 +57,15 @@ class UserDefinedJavaClassMetaTest {
   @Test
   void cookClassErrorCompilationTest() {
     String wrongCode =
-        "public boolean processRow() {\n"
-            + "   return true;\n"
-            + "}\n"
-            + "\n"
-            + "public boolean processRow() {\n"
-            + "   return true;\n"
-            + "}\n";
+        """
+        public boolean processRow() {
+           return true;
+        }
+
+        public boolean processRow() {
+           return true;
+        }
+        """;
 
     UserDefinedJavaClassMeta userDefinedJavaClassMeta = new UserDefinedJavaClassMeta();
 
@@ -91,12 +93,20 @@ class UserDefinedJavaClassMetaTest {
 
   @Test
   void cookClassesCachingTest() throws Exception {
-    String codeBlock1 = "public boolean processRow() {\n" + "    return true;\n" + "}\n\n";
+    String codeBlock1 =
+        """
+        public boolean processRow() {
+            return true;
+        }
+        """;
+
     String codeBlock2 =
-        "public boolean processRow() {\n"
-            + "    // Random comment\n"
-            + "    return true;\n"
-            + "}\n\n";
+        """
+        public boolean processRow() {
+            // Random comment
+            return true;
+        }
+        """;
     UserDefinedJavaClassMeta userDefinedJavaClassMeta1 = new UserDefinedJavaClassMeta();
 
     UserDefinedJavaClassDef userDefinedJavaClassDef1 =
@@ -133,7 +143,13 @@ class UserDefinedJavaClassMetaTest {
 
   @Test
   void oderDefinitionTest() {
-    String codeBlock1 = "public boolean processRow() {\n" + "    return true;\n" + "}\n\n";
+    String codeBlock1 =
+        """
+        public boolean processRow() {
+            return true;
+        }
+
+        """;
     UserDefinedJavaClassMeta userDefinedJavaClassMeta = new UserDefinedJavaClassMeta();
     UserDefinedJavaClassDef processClassDef =
         new UserDefinedJavaClassDef(
@@ -363,9 +379,11 @@ class UserDefinedJavaClassMetaTest {
   @Test
   void cookClass_target8_staticInterfaceMethod_succeeds() throws Exception {
     String code =
-        "public int cmp() {\n"
-            + "  return java.util.Comparator.naturalOrder().compare(Integer.valueOf(3), Integer.valueOf(5));\n"
-            + "}\n";
+        """
+        public int cmp() {
+          return java.util.Comparator.naturalOrder().compare(Integer.valueOf(3), Integer.valueOf(5));
+        }
+        """;
     UserDefinedJavaClassMeta meta = new UserDefinedJavaClassMeta();
     meta.setJavaTargetVersion(8);
     UserDefinedJavaClassDef def =
@@ -380,9 +398,11 @@ class UserDefinedJavaClassMetaTest {
   @Test
   void cookClass_target17_staticInterfaceMethod_succeeds() throws Exception {
     String code =
-        "public int cmp() {\n"
-            + "  return java.util.Comparator.naturalOrder().compare(Integer.valueOf(3), Integer.valueOf(5));\n"
-            + "}\n";
+        """
+        public int cmp() {
+          return java.util.Comparator.naturalOrder().compare(Integer.valueOf(3), Integer.valueOf(5));
+        }
+        """;
     UserDefinedJavaClassMeta meta = new UserDefinedJavaClassMeta();
     meta.setJavaTargetVersion(17);
     UserDefinedJavaClassDef def =
@@ -396,9 +416,11 @@ class UserDefinedJavaClassMetaTest {
   @Test
   void cookClass_target6_staticInterfaceMethod_throwsCompileException() {
     String code =
-        "public int cmp() {\n"
-            + "  return java.util.Comparator.naturalOrder().compare(Integer.valueOf(3), Integer.valueOf(5));\n"
-            + "}\n";
+        """
+        public int cmp() {
+          return java.util.Comparator.naturalOrder().compare(Integer.valueOf(3), Integer.valueOf(5));
+        }
+        """;
     UserDefinedJavaClassMeta meta = new UserDefinedJavaClassMeta();
     meta.setJavaTargetVersion(6);
     UserDefinedJavaClassDef def =
@@ -531,7 +553,7 @@ class UserDefinedJavaClassMetaTest {
     newFields.add(new UserDefinedJavaClassMeta.FieldInfo("a", IValueMeta.TYPE_STRING, 10, -1));
     meta.replaceFields(newFields);
     assertEquals(1, meta.getFields().size());
-    assertEquals("a", meta.getFields().get(0).getName());
+    assertEquals("a", meta.getFields().getFirst().getName());
   }
 
   @Test
@@ -541,7 +563,7 @@ class UserDefinedJavaClassMetaTest {
     fields.add(new UserDefinedJavaClassMeta.FieldInfo("b", IValueMeta.TYPE_INTEGER, 9, 0));
     meta.setFieldInfo(fields);
     assertEquals(1, meta.getFields().size());
-    assertEquals("b", meta.getFields().get(0).getName());
+    assertEquals("b", meta.getFields().getFirst().getName());
   }
 
   // ------------------------------------------------------------------ replaceDefinitions

--- a/plugins/transforms/janino/src/test/java/org/apache/hop/pipeline/transforms/userdefinedjavaclass/UserDefinedJavaClassTest.java
+++ b/plugins/transforms/janino/src/test/java/org/apache/hop/pipeline/transforms/userdefinedjavaclass/UserDefinedJavaClassTest.java
@@ -17,6 +17,7 @@
 package org.apache.hop.pipeline.transforms.userdefinedjavaclass;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -116,8 +117,10 @@ class UserDefinedJavaClassTest {
     UserDefinedJavaClassMeta meta = new UserDefinedJavaClassMeta();
     // Duplicate method → compilation error
     String badSource =
-        "public boolean processRow() { return true; }\n"
-            + "public boolean processRow() { return true; }\n";
+        """
+        public boolean processRow() { return true; }
+        public boolean processRow() { return true; }
+        """;
     meta.getDefinitions()
         .add(new UserDefinedJavaClassDef(ClassType.NORMAL_CLASS, "BadClass", badSource));
 
@@ -132,9 +135,13 @@ class UserDefinedJavaClassTest {
 
   @Test
   void constructor_copyNrNonZero_constructsWithoutThrowingAndNoCookErrors() {
-    // copyNr=1: explicit cookClasses() call in the constructor body is skipped;
-    // cooking happens lazily inside newChildInstance() via checkClassCooked().
-    // For a clean meta with no definitions, no cook errors occur.
+    /*
+     * Note:
+     * For copyNr=1, the explicit cookClasses() call in the constructor body is skipped.
+     * Cooking is performed lazily inside newChildInstance() via checkClassCooked().
+     *
+     * For a clean meta with no definitions, no cook errors will occur.
+     */
     UserDefinedJavaClassMeta meta = new UserDefinedJavaClassMeta();
 
     new UserDefinedJavaClass(
@@ -156,10 +163,12 @@ class UserDefinedJavaClassTest {
     // (child instantiation fails in tests because pipelineMeta.getPrevTransformFields returns
     // null).
     String source =
-        "public boolean processRow() throws org.apache.hop.core.exception.HopException {\n"
-            + "  setOutputDone();\n"
-            + "  return false;\n"
-            + "}\n";
+        """
+        public boolean processRow() throws org.apache.hop.core.exception.HopException {
+          setOutputDone();
+          return false;
+        }
+        """;
 
     UserDefinedJavaClassMeta meta = new UserDefinedJavaClassMeta();
     meta.getDefinitions()
@@ -168,7 +177,7 @@ class UserDefinedJavaClassTest {
     meta.cookClasses();
 
     assertTrue(meta.getCookErrors().isEmpty(), "Expected no cook errors");
-    assertFalse(meta.getCookedTransformClass() == null, "Expected cookedTransformClass to be set");
+    assertNotNull(meta.getCookedTransformClass(), "Expected cookedTransformClass to be set");
   }
 
   // ------------------------------------------------------------------ getDefinitions / hasChanged

--- a/plugins/transforms/json/src/test/java/org/apache/hop/pipeline/transforms/jsonoutputenhanced/JsonEOutputMetaTest.java
+++ b/plugins/transforms/json/src/test/java/org/apache/hop/pipeline/transforms/jsonoutputenhanced/JsonEOutputMetaTest.java
@@ -45,41 +45,43 @@ class JsonEOutputMetaTest {
   @Test
   void deserializeSelfClosingJsonBloc_overridesConstructor() throws Exception {
     String xml =
-        "<transform>\n"
-            + "  <outputValue>prompt</outputValue>\n"
-            + "  <jsonBloc/>\n"
-            + "  <operation_type>outputvalue</operation_type>\n"
-            + "  <use_arrays_with_single_instance>N</use_arrays_with_single_instance>\n"
-            + "  <use_single_item_per_group>N</use_single_item_per_group>\n"
-            + "  <json_prittified>N</json_prittified>\n"
-            + "  <encoding>UTF-8</encoding>\n"
-            + "  <addtoresult>N</addtoresult>\n"
-            + "  <file>\n"
-            + "    <name/>\n"
-            + "    <split_output_after>0</split_output_after>\n"
-            + "    <extention>json</extention>\n"
-            + "    <append>N</append>\n"
-            + "    <split>N</split>\n"
-            + "    <haspartno>N</haspartno>\n"
-            + "    <add_date>N</add_date>\n"
-            + "    <add_time>N</add_time>\n"
-            + "    <create_parent_folder>N</create_parent_folder>\n"
-            + "    <doNotOpenNewFileInit>N</doNotOpenNewFileInit>\n"
-            + "  </file>\n"
-            + "  <additional_fields>\n"
-            + "    <json_size_field/>\n"
-            + "  </additional_fields>\n"
-            + "  <key_fields/>\n"
-            + "  <fields>\n"
-            + "    <field>\n"
-            + "      <name>role</name>\n"
-            + "      <element>role</element>\n"
-            + "      <json_fragment>N</json_fragment>\n"
-            + "      <is_without_enclosing>N</is_without_enclosing>\n"
-            + "      <remove_if_blank>Y</remove_if_blank>\n"
-            + "    </field>\n"
-            + "  </fields>\n"
-            + "</transform>\n";
+        """
+        <transform>
+          <outputValue>prompt</outputValue>
+          <jsonBloc/>
+          <operation_type>outputvalue</operation_type>
+          <use_arrays_with_single_instance>N</use_arrays_with_single_instance>
+          <use_single_item_per_group>N</use_single_item_per_group>
+          <json_prittified>N</json_prittified>
+          <encoding>UTF-8</encoding>
+          <addtoresult>N</addtoresult>
+          <file>
+            <name/>
+            <split_output_after>0</split_output_after>
+            <extention>json</extention>
+            <append>N</append>
+            <split>N</split>
+            <haspartno>N</haspartno>
+            <add_date>N</add_date>
+            <add_time>N</add_time>
+            <create_parent_folder>N</create_parent_folder>
+            <doNotOpenNewFileInit>N</doNotOpenNewFileInit>
+          </file>
+          <additional_fields>
+            <json_size_field/>
+          </additional_fields>
+          <key_fields/>
+          <fields>
+            <field>
+              <name>role</name>
+              <element>role</element>
+              <json_fragment>N</json_fragment>
+              <is_without_enclosing>N</is_without_enclosing>
+              <remove_if_blank>Y</remove_if_blank>
+            </field>
+          </fields>
+        </transform>
+        """;
     JsonEOutputMeta meta = new JsonEOutputMeta();
     XmlMetadataUtil.deSerializeFromXml(
         XmlHandler.loadXmlString(xml, TransformMeta.XML_TAG),
@@ -136,7 +138,7 @@ class JsonEOutputMetaTest {
 
     assertNotNull(meta.getOutputFields());
     assertEquals(3, meta.getOutputFields().size());
-    JsonEOutputField f1 = meta.getOutputFields().get(0);
+    JsonEOutputField f1 = meta.getOutputFields().getFirst();
     assertEquals("f1", f1.getFieldName());
     assertEquals("element1", f1.getElementName());
 

--- a/plugins/transforms/ldap/src/main/java/org/apache/hop/pipeline/transforms/ldapoutput/LdapOutputMeta.java
+++ b/plugins/transforms/ldap/src/main/java/org/apache/hop/pipeline/transforms/ldapoutput/LdapOutputMeta.java
@@ -48,8 +48,6 @@ import org.apache.hop.pipeline.transforms.ldapinput.LdapProtocolFactory;
 public class LdapOutputMeta extends BaseTransformMeta<LdapOutput, LdapOutputData>
     implements ILdapMeta {
   private static final Class<?> PKG = LdapOutputMeta.class;
-  public static final String CONST_SPACES = "        ";
-  public static final String CONST_FIELD = "field";
 
   /**
    * Flag indicating that we use authentication for connection -- GETTER --
@@ -98,10 +96,13 @@ public class LdapOutputMeta extends BaseTransformMeta<LdapOutput, LdapOutputData
    * @param port The port to set.
    */
   @HopMetadataProperty(key = "port")
+  @Getter
   private String port;
 
   /** The name of DN field */
   @HopMetadataProperty(key = "dnFieldName")
+  @Getter
+  @Setter
   private String dnFieldName;
 
   /**
@@ -257,17 +258,7 @@ public class LdapOutputMeta extends BaseTransformMeta<LdapOutput, LdapOutputData
 
   public static final int DEREFALIASES_TYPE_ALWAYS = 0;
 
-  public static final int DEREFALIASES_TYPE_NEVER = 1;
-
-  public static final int DEREFALIASES_TYPE_SEARCHING = 2;
-
-  public static final int DEREFALIASES_TYPE_FINDING = 3;
-
-  /**
-   * Protocol -- SETTER --
-   *
-   * @param value the protocol to set.
-   */
+  /** Protocol -- SETTER -- */
   @HopMetadataProperty(key = "protocol")
   private String protocol;
 
@@ -529,32 +520,6 @@ public class LdapOutputMeta extends BaseTransformMeta<LdapOutput, LdapOutputData
     return this.dnFieldName;
   }
 
-  /**
-   * Setter for metadata serialization - matches field name dnFieldName
-   *
-   * @param value The DN field name to set
-   */
-  public void setDnFieldName(String value) {
-    this.dnFieldName = value;
-  }
-
-  /**
-   * Getter for metadata serialization - matches field name dnFieldName
-   *
-   * @return The DN field name
-   */
-  public String getDnFieldName() {
-    return this.dnFieldName;
-  }
-
-  /**
-   * @return Returns the Port.
-   */
-  @Override
-  public String getPort() {
-    return port;
-  }
-
   @Override
   public Object clone() {
     LdapOutputMeta retval = (LdapOutputMeta) super.clone();
@@ -678,12 +643,14 @@ public class LdapOutputMeta extends BaseTransformMeta<LdapOutput, LdapOutputData
               ICheckResult.TYPE_RESULT_ERROR,
               BaseMessages.getString(PKG, "LdapOutputUpdateMeta.CheckResult.NoFields"),
               transformMeta);
+      remarks.add(cr);
     } else {
       cr =
           new CheckResult(
               ICheckResult.TYPE_RESULT_OK,
               BaseMessages.getString(PKG, "LdapOutputUpdateMeta.CheckResult.FieldsOk"),
               transformMeta);
+      remarks.add(cr);
     }
   }
 

--- a/plugins/transforms/memgroupby/src/main/java/org/apache/hop/pipeline/transforms/memgroupby/MemoryGroupBy.java
+++ b/plugins/transforms/memgroupby/src/main/java/org/apache/hop/pipeline/transforms/memgroupby/MemoryGroupBy.java
@@ -554,7 +554,7 @@ public class MemoryGroupBy extends BaseTransform<MemoryGroupByMeta, MemoryGroupB
   public boolean init() {
 
     if (super.init()) {
-      data.map = new HashMap<>(5000);
+      data.map = HashMap.newHashMap(5000);
       return true;
     }
     return false;

--- a/plugins/transforms/metainject/src/main/java/org/apache/hop/pipeline/transforms/metainject/MetaInjectDialog.java
+++ b/plugins/transforms/metainject/src/main/java/org/apache/hop/pipeline/transforms/metainject/MetaInjectDialog.java
@@ -928,12 +928,6 @@ public class MetaInjectDialog extends BaseTransformDialog {
   }
 
   /**
-   * @param transformMeta The transform meta
-   * @param transformItem The TreeItem
-   * @param metaInterface The transform ITransformMeta
-   * @return true if there was at least one used key
-   */
-  /**
    * Match a tree row to a saved mapping by target transform and injection key only. {@link
    * MetaInjectMapping#equals} also compares {@code targetDetail}; older pipelines may store {@code
    * target_detail=Y} for scalar {@link org.apache.hop.metadata.api.HopMetadataProperty} keys that

--- a/plugins/transforms/mongodb/src/main/java/org/apache/hop/pipeline/transforms/mongodbinput/MongoDbInputDialog.java
+++ b/plugins/transforms/mongodb/src/main/java/org/apache/hop/pipeline/transforms/mongodbinput/MongoDbInputDialog.java
@@ -552,7 +552,7 @@ public class MongoDbInputDialog extends BaseTransformDialog {
   }
 
   public void updateFieldTableFields(List<MongoField> fields) {
-    Map<String, MongoField> fieldMap = new HashMap<>(fields.size());
+    Map<String, MongoField> fieldMap = HashMap.newHashMap(fields.size());
     for (MongoField field : fields) {
       fieldMap.put(field.fieldName, field);
     }

--- a/plugins/transforms/pipelineexecutor/src/test/java/org/apache/hop/pipeline/transforms/pipelineexecutor/PipelineExecutorTest.java
+++ b/plugins/transforms/pipelineexecutor/src/test/java/org/apache/hop/pipeline/transforms/pipelineexecutor/PipelineExecutorTest.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -120,6 +119,7 @@ class PipelineExecutorTest {
     data.setExecutorPipeline(null);
     PipelineExecutor executor = newExecutor(meta, data);
 
+    assertNotNull(executor);
     executor.discardLogLines(data);
   }
 
@@ -149,7 +149,7 @@ class PipelineExecutorTest {
     PipelineExecutor executor = newExecutor(meta, data);
     executor.passParametersToPipeline(Arrays.asList("1", "from-row"));
 
-    verify(child, atLeastOnce()).setParameterValue(eq("MYPARAM"), eq("from-row"));
+    verify(child, atLeastOnce()).setParameterValue("MYPARAM", "from-row");
   }
 
   @Test
@@ -177,7 +177,7 @@ class PipelineExecutorTest {
     PipelineExecutor executor = newExecutor(meta, data);
     executor.passParametersToPipeline(Collections.singletonList("row-id"));
 
-    verify(child, atLeastOnce()).setParameterValue(eq("P"), eq("static-value"));
+    verify(child, atLeastOnce()).setParameterValue("P", "static-value");
   }
 
   @Test
@@ -205,7 +205,7 @@ class PipelineExecutorTest {
     PipelineExecutor executor = newExecutor(meta, data);
     executor.passParametersToPipeline(null);
 
-    verify(child, atLeastOnce()).setParameterValue(eq("P"), eq("fallback"));
+    verify(child, atLeastOnce()).setParameterValue("P", "fallback");
   }
 
   @Test
@@ -235,11 +235,12 @@ class PipelineExecutorTest {
     data.setExecutorPipeline(null);
     PipelineExecutor executor = newExecutor(meta, data);
 
+    assertNotNull(executor);
     executor.stopRunning();
   }
 
   @Test
-  void stopAllDelegatesToExecutorWhenPresent() throws HopException {
+  void stopAllDelegatesToExecutorWhenPresent() {
     PipelineExecutorMeta meta = new PipelineExecutorMeta();
     meta.setDefault();
     PipelineExecutorData data = new PipelineExecutorData();
@@ -269,7 +270,7 @@ class PipelineExecutorTest {
   }
 
   @Test
-  void disposeClearsGroupBuffer() throws HopException {
+  void disposeClearsGroupBuffer() {
     PipelineExecutorMeta meta = new PipelineExecutorMeta();
     meta.setDefault();
     PipelineExecutorData data = new PipelineExecutorData();
@@ -283,7 +284,7 @@ class PipelineExecutorTest {
   }
 
   @Test
-  void initFailsWhenStaticFilenameMissing() throws HopException {
+  void initFailsWhenStaticFilenameMissing() {
     PipelineExecutorMeta meta = new PipelineExecutorMeta();
     meta.setDefault();
     meta.setFilenameInField(false);
@@ -295,7 +296,7 @@ class PipelineExecutorTest {
   }
 
   @Test
-  void initSucceedsWhenFilenameComesFromField() throws HopException {
+  void initSucceedsWhenFilenameComesFromField() {
     PipelineExecutorMeta meta = new PipelineExecutorMeta();
     meta.setDefault();
     meta.setFilenameInField(true);
@@ -308,7 +309,7 @@ class PipelineExecutorTest {
   }
 
   @Test
-  void initLoadsChildPipelineFromFilesystemPath() throws HopException, URISyntaxException {
+  void initLoadsChildPipelineFromFilesystemPath() throws URISyntaxException {
     String path =
         Paths.get(
                 Objects.requireNonNull(

--- a/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/textfileoutput/TextFileOutput.java
+++ b/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/textfileoutput/TextFileOutput.java
@@ -284,11 +284,11 @@ public class TextFileOutput extends BaseTransform<TextFileOutputMeta, TextFileOu
   }
 
   public int getFlushInterval() {
-    String var = variables.getVariable("HOP_FILE_OUTPUT_MAX_STREAM_LIFE");
+    String maxStreamLife = variables.getVariable("HOP_FILE_OUTPUT_MAX_STREAM_LIFE");
     int flushInterval = 0;
-    if (var != null) {
+    if (maxStreamLife != null) {
       try {
-        flushInterval = Integer.parseInt(var);
+        flushInterval = Integer.parseInt(maxStreamLife);
       } catch (Exception ex) {
         // Do nothing
       }
@@ -297,11 +297,11 @@ public class TextFileOutput extends BaseTransform<TextFileOutputMeta, TextFileOu
   }
 
   public int getMaxOpenFiles() {
-    String var = variables.getVariable("HOP_FILE_OUTPUT_MAX_STREAM_COUNT");
+    String maxStreamCountVar = variables.getVariable("HOP_FILE_OUTPUT_MAX_STREAM_COUNT");
     int maxStreamCount = 0;
-    if (var != null) {
+    if (maxStreamCountVar != null) {
       try {
-        maxStreamCount = Integer.parseInt(var);
+        maxStreamCount = Integer.parseInt(maxStreamCountVar);
       } catch (Exception ex) {
         // Do nothing
       }

--- a/ui/src/main/java/org/apache/hop/ui/core/dialog/PreviewRowsDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/dialog/PreviewRowsDialog.java
@@ -173,8 +173,6 @@ public class PreviewRowsDialog {
     }
 
     shell = new Shell(parentShell, style);
-    PropsUi props = PropsUi.getInstance();
-
     PropsUi.setLook(shell);
     shell.setImage(GuiResource.getInstance().getImageHopUi());
 
@@ -230,14 +228,9 @@ public class PreviewRowsDialog {
     }
 
     // Position the buttons...
-    //
-    bottomButton = buttons.get(0);
+    bottomButton = buttons.getFirst();
     BaseTransformDialog.positionBottomButtons(
         shell, buttons.toArray(new Button[buttons.size()]), PropsUi.getMargin(), null);
-
-    if (addFields()) {
-      return;
-    }
 
     KeyListener escapeListener =
         new KeyAdapter() {

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/HopGuiPipelineGraph.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/HopGuiPipelineGraph.java
@@ -1853,15 +1853,11 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
 
   @Override
   public void mouseHover(MouseEvent event) {
-    boolean tip = true;
-
     toolTip.setVisible(false);
     Point real = screen2real(event.x, event.y);
 
     // Show a tool tip upon mouse-over of an object on the canvas
-    if (tip) {
-      setToolTip(real.x, real.y, event.x, event.y);
-    }
+    setToolTip(real.x, real.y, event.x, event.y);
   }
 
   protected void moveSelected(int dx, int dy) {
@@ -3721,9 +3717,6 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
   }
 
   public void drawPipelineImage(GC swtGc, int width, int height) {
-
-    if (EnvironmentUtils.getInstance().isWeb()) {}
-
     IGc gc = new SwtGc(swtGc, width, height, iconSize);
     try {
       PropsUi propsUi = PropsUi.getInstance();
@@ -4094,7 +4087,7 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
             log, variables, HopExtensionPoint.PipelineAfterSave.id, pipelineMeta);
 
         // If we create a new file, refresh the explorer perspective tree
-        // TODO: find a better way to refresh only a partial tree item
+        //  find a better way to refresh only a partial tree item
         if (!fileExist) {
           perspective.refresh();
         }

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/PipelineMetricDisplayUtil.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/PipelineMetricDisplayUtil.java
@@ -68,29 +68,28 @@ public final class PipelineMetricDisplayUtil {
     if (code == null) {
       return null;
     }
-    switch (code) {
+
+    return switch (code) {
       case Pipeline.METRIC_NAME_INPUT,
-          Pipeline.METRIC_NAME_READ,
-          Pipeline.METRIC_NAME_WRITTEN,
-          Pipeline.METRIC_NAME_OUTPUT,
-          Pipeline.METRIC_NAME_UPDATED,
-          Pipeline.METRIC_NAME_REJECTED,
-          Pipeline.METRIC_NAME_ERROR,
-          Pipeline.METRIC_NAME_BUFFER_IN,
-          Pipeline.METRIC_NAME_BUFFER_OUT:
-        return "rows";
-      case Pipeline.METRIC_NAME_INIT:
-        return "runs";
-      case Pipeline.METRIC_NAME_FLUSH_BUFFER:
-        return "flushes";
-      case Pipeline.METRIC_NAME_DATA_VOLUME:
-        return null; // Cell shows scaled unit (B/KB/MB/GB) via formatDataVolume()
-      case Pipeline.METRIC_NAME_DATA_VOLUME_IN:
-      case Pipeline.METRIC_NAME_DATA_VOLUME_OUT:
-        return null; // Cell shows scaled unit (B/KB/MB/GB) via formatDataVolume()
-      default:
-        return null;
-    }
+              Pipeline.METRIC_NAME_READ,
+              Pipeline.METRIC_NAME_WRITTEN,
+              Pipeline.METRIC_NAME_OUTPUT,
+              Pipeline.METRIC_NAME_UPDATED,
+              Pipeline.METRIC_NAME_REJECTED,
+              Pipeline.METRIC_NAME_ERROR,
+              Pipeline.METRIC_NAME_BUFFER_IN,
+              Pipeline.METRIC_NAME_BUFFER_OUT ->
+          "rows";
+      case Pipeline.METRIC_NAME_INIT -> "runs";
+      case Pipeline.METRIC_NAME_FLUSH_BUFFER -> "flushes";
+      case Pipeline.METRIC_NAME_DATA_VOLUME ->
+          // Cell shows scaled unit (B/KB/MB/GB) via formatDataVolume()
+          null;
+      case Pipeline.METRIC_NAME_DATA_VOLUME_IN, Pipeline.METRIC_NAME_DATA_VOLUME_OUT ->
+          // Cell shows scaled unit (B/KB/MB/GB) via formatDataVolume()
+          null;
+      default -> null;
+    };
   }
 
   /**

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/delegates/HopGuiPipelineRunDelegate.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/delegates/HopGuiPipelineRunDelegate.java
@@ -103,11 +103,9 @@ public class HopGuiPipelineRunDelegate {
     if (previewDebug) {
       // Collect the first N rows from selected transforms; pause-on-breakpoint is configured per
       // transform in the dialog (TransformDebugMeta#setPausingOnBreakPoint).
-      pipelineDebugMeta = pipelinePreviewDebugMetaMap.get(pipelineMeta);
-      if (pipelineDebugMeta == null) {
-        pipelineDebugMeta = new PipelineDebugMeta(pipelineMeta);
-        pipelinePreviewDebugMetaMap.put(pipelineMeta, pipelineDebugMeta);
-      }
+      pipelineDebugMeta =
+          pipelinePreviewDebugMetaMap.computeIfAbsent(pipelineMeta, PipelineDebugMeta::new);
+
       // Reset execution-state flag from any previous run so the finished listener
       // is not silently skipped when the same PipelineDebugMeta object is reused.
       pipelineDebugMeta.setStopClosePressed(false);

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/ExplorerPerspective.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/ExplorerPerspective.java
@@ -1035,7 +1035,7 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
   private static String toDisplayPath(String path, String projectHome) {
     if (!StringUtils.isEmpty(projectHome) && path.startsWith(projectHome)) {
       String rel = path.substring(projectHome.length());
-      return "${PROJECT_HOME}" + (rel.startsWith("/") ? rel : "/" + rel);
+      return Const.VAR_PROJECT_HOME + (rel.startsWith("/") ? rel : "/" + rel);
     }
     return path;
   }
@@ -1047,9 +1047,9 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
    */
   private boolean confirmDeleteWithReferenceCheck(List<String> filePaths, String displayName)
       throws HopException {
-    String projectHome = hopGui.getVariables().resolve("${PROJECT_HOME}");
+    String projectHome = hopGui.getVariables().resolve(Const.VAR_PROJECT_HOME);
     List<String> searchRoots =
-        (!Utils.isEmpty(projectHome) && !"${PROJECT_HOME}".equals(projectHome))
+        (!Utils.isEmpty(projectHome) && !Const.VAR_PROJECT_HOME.equals(projectHome))
             ? List.of(projectHome)
             : Collections.emptyList();
 
@@ -1146,21 +1146,20 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
             PKG, "ExplorerPerspective.DeleteFile.WithReferences.Button.Details"));
     wDetails.addListener(
         SWT.Selection,
-        e -> {
-          new DetailsDialog(
-                  shell,
-                  BaseMessages.getString(
-                      PKG,
-                      "ExplorerPerspective.DeleteFile.WithReferences.Details.Title",
-                      displayName),
-                  GuiResource.getInstance().getImageHop(),
-                  BaseMessages.getString(
-                      PKG,
-                      "ExplorerPerspective.DeleteFile.WithReferences.Details.Message",
-                      displayName),
-                  String.join(Const.CR, detailLines))
-              .open();
-        });
+        e ->
+            new DetailsDialog(
+                    shell,
+                    BaseMessages.getString(
+                        PKG,
+                        "ExplorerPerspective.DeleteFile.WithReferences.Details.Title",
+                        displayName),
+                    GuiResource.getInstance().getImageHop(),
+                    BaseMessages.getString(
+                        PKG,
+                        "ExplorerPerspective.DeleteFile.WithReferences.Details.Message",
+                        displayName),
+                    String.join(Const.CR, detailLines))
+                .open());
     Button wNo = new Button(shell, SWT.PUSH);
     PropsUi.setLook(wNo);
     wNo.setText(BaseMessages.getString("System.Button.No"));
@@ -1518,8 +1517,8 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
     if (oldPaths == null || newPaths == null || oldPaths.size() != newPaths.size()) {
       return;
     }
-    String projectHome = hopGui.getVariables().resolve("${PROJECT_HOME}");
-    if (Utils.isEmpty(projectHome) || "${PROJECT_HOME}".equals(projectHome)) {
+    String projectHome = hopGui.getVariables().resolve(Const.VAR_PROJECT_HOME);
+    if (Utils.isEmpty(projectHome) || Const.VAR_PROJECT_HOME.equals(projectHome)) {
       return;
     }
     List<String> searchRoots = java.util.Collections.singletonList(projectHome);
@@ -1528,7 +1527,6 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
       Map<String, String> oldToNew = new HashMap<>();
 
       // File references (pipeline/workflow files referencing the renamed file)
-      List<MetadataReferenceResult> allFileRefs = new ArrayList<>();
       java.util.Set<String> allFilePaths = new java.util.HashSet<>();
       int totalFileRefCount = 0;
 
@@ -1550,9 +1548,7 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
             finder.findFileReferences(searchRoots, oldPath, hopGui.getVariables());
         for (MetadataReferenceResult r : refs) {
           totalFileRefCount += r.getReferenceCount();
-          if (allFilePaths.add(r.getFilePath())) {
-            allFileRefs.add(r);
-          }
+          allFilePaths.add(r.getFilePath());
         }
 
         // Find references in metadata objects (resolve variables so ${PROJECT_HOME}/... matches)
@@ -2853,7 +2849,7 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
 
   public IHopFileType getFileType(String path) throws HopException {
 
-    // TODO: get this list from the plugin registry...
+    // get this list from the plugin registry...
     //
     for (IHopFileType hopFileType : fileTypes) {
       // Only look at the extension of the file

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/metadata/MetadataPerspective.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/metadata/MetadataPerspective.java
@@ -925,20 +925,14 @@ public class MetadataPerspective implements IHopPerspective, TabClosable, IMetad
   }
 
   /**
-   * If the metadata type supports global replace, finds references to oldName in pipeline/workflow
-   * files, optionally shows the update dialog, and replaces references with newName. Reloads open
-   * tabs for modified files. Call this when a metadata element is renamed (from tree or from
-   * editor).
-   *
-   * @param objectKey metadata type key (e.g. "rdbms", "restconnection")
-   * @param oldName the name before rename
-   * @param newName the name after rename
-   */
-  /**
    * Finds references to {@code oldName} in pipelines/workflows and other metadata, asks the user to
    * update them, and performs the replacement. Returns {@code true} if the operation completed (or
    * there was nothing to do), {@code false} if the user cancelled a save-changes dialog and the
    * caller should abort its own operation too.
+   *
+   * @param objectKey metadata type key (e.g. "rdbms", "reconnection")
+   * @param oldName the name before rename
+   * @param newName the name after rename
    */
   public boolean performGlobalReplaceIfSupported(String objectKey, String oldName, String newName)
       throws HopException {
@@ -962,8 +956,8 @@ public class MetadataPerspective implements IHopPerspective, TabClosable, IMetad
       return true;
     }
     List<String> searchRoots = new ArrayList<>();
-    String projectHome = hopGui.getVariables().resolve("${PROJECT_HOME}");
-    if (Utils.isEmpty(projectHome) || "${PROJECT_HOME}".equals(projectHome)) {
+    String projectHome = hopGui.getVariables().resolve(Const.VAR_PROJECT_HOME);
+    if (Utils.isEmpty(projectHome) || Const.VAR_PROJECT_HOME.equals(projectHome)) {
       return true;
     }
     searchRoots.add(projectHome);
@@ -1378,10 +1372,10 @@ public class MetadataPerspective implements IHopPerspective, TabClosable, IMetad
     try {
       // Check for references in pipelines/workflows and other metadata objects
       MetadataReferenceFinder finder = new MetadataReferenceFinder(hopGui.getMetadataProvider());
-      String projectHome = hopGui.getVariables().resolve("${PROJECT_HOME}");
+      String projectHome = hopGui.getVariables().resolve(Const.VAR_PROJECT_HOME);
       List<MetadataReferenceResult> fileRefs = Collections.emptyList();
       if (MetadataRefactorUtil.supportsGlobalReplace(hopGui.getMetadataProvider(), objectKey)) {
-        if (!Utils.isEmpty(projectHome) && !"${PROJECT_HOME}".equals(projectHome)) {
+        if (!Utils.isEmpty(projectHome) && !Const.VAR_PROJECT_HOME.equals(projectHome)) {
           fileRefs = finder.findReferences(objectKey, objectName, List.of(projectHome));
         }
       }
@@ -1440,7 +1434,7 @@ public class MetadataPerspective implements IHopPerspective, TabClosable, IMetad
   private static String toDisplayPath(String path, String projectHome) {
     if (!Utils.isEmpty(projectHome) && path.startsWith(projectHome)) {
       String rel = path.substring(projectHome.length());
-      return "${PROJECT_HOME}" + (rel.startsWith("/") ? rel : "/" + rel);
+      return Const.VAR_PROJECT_HOME + (rel.startsWith("/") ? rel : "/" + rel);
     }
     return path;
   }


### PR DESCRIPTION

- Replace Map.get() + null check with computeIfAbsent()
- Replace string concatenation with Java text blocks 