### PR TITLE
Issue 6975

### DIFF
--- a/plugins/transforms/combinationlookup/src/main/java/org/apache/hop/pipeline/transforms/combinationlookup/CombinationLookupMeta.java
+++ b/plugins/transforms/combinationlookup/src/main/java/org/apache/hop/pipeline/transforms/combinationlookup/CombinationLookupMeta.java
@@ -736,5 +736,10 @@ public class CombinationLookupMeta
     if (StringUtils.isNotEmpty(sequenceName)) {
       this.fields.setSequenceFrom(sequenceName);
     }
+    Node lastUpdateFieldNode = XmlHandler.getSubNode(transformNode, "last_update_field");
+    String lastUpdateField = XmlHandler.getNodeValue(lastUpdateFieldNode);
+    if (StringUtils.isNotEmpty(lastUpdateField)) {
+      this.fields.getReturnFields().setLastUpdateField(lastUpdateField);
+    }
   }
 }

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/ExplorerPerspective.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/ExplorerPerspective.java
@@ -3478,6 +3478,18 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
     } else {
       sash.setMaximizedControl(tabFolderWrapper);
     }
+
+    // Shift the focus away from the perspective icon onto the active graph.
+    //
+    IHopFileTypeHandler activeHandler = getActiveFileTypeHandler();
+    if (activeHandler != null) {
+      if (activeHandler instanceof HopGuiPipelineGraph graph) {
+        graph.setFocus();
+      }
+      if (activeHandler instanceof HopGuiWorkflowGraph graph) {
+        graph.setFocus();
+      }
+    }
   }
 
   /** Split the editor to show two files side by side. If already split, this is a no-op. */


### PR DESCRIPTION
Small usability improvement for issue #6975.
When the explorer panel is collapsed or expanded make sure to shift the focus back onto the active pipeline/workflow canvas to make keyboard shortcuts go there.