### PR TITLE
HOP-7045 [Bug]: Default values overwrite empty fields in TextFileOutput

### DIFF
--- a/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/textfileoutput/TextFileOutputMeta.java
+++ b/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/textfileoutput/TextFileOutputMeta.java
@@ -350,8 +350,8 @@ public class TextFileOutputMeta extends BaseTransformMeta<TextFileOutput, TextFi
     fileSettings = new FileSettings();
     outputFields = new ArrayList<>();
     createParentFolder = true;
-    separator = ";";
-    enclosure = "\"";
+    separator = "";
+    enclosure = "";
     enclosureForced = false;
     enclosureFixDisabled = false;
     headerEnabled = true;
@@ -382,6 +382,12 @@ public class TextFileOutputMeta extends BaseTransformMeta<TextFileOutput, TextFi
         field -> {
           this.outputFields.add(new TextFileField(field));
         });
+  }
+
+  @Override
+  public void setDefault() {
+    separator = ";";
+    enclosure = "\"";
   }
 
   @Override


### PR DESCRIPTION
Moved setting of default values for separator and enclosure from constructor to setDefault
Empty values are now accepted instead of being overridden by defaults

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
