### PR TITLE
Upgrade to Apache pom parent 38

### DIFF
--- a/integration-tests/hopweb/pom.xml
+++ b/integration-tests/hopweb/pom.xml
@@ -24,13 +24,13 @@
 
     <groupId>org.apache.hop</groupId>
     <artifactId>hop-web-integration-tests</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.18.0-SNAPSHOT</version>
 
     <name>Hop Web Integration Tests</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>11</java.version>
+        <java.version>21</java.version>
         <selenium.version>4.8.1</selenium.version>
         <junit.version>5.8.2</junit.version>
         <surefire.version>2.22.2</surefire.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>35</version>
+        <version>38</version>
     </parent>
 
     <groupId>org.apache.hop</groupId>
@@ -110,6 +110,7 @@
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <jandex.version>3.5.3</jandex.version>
         <java-hamcrest.version>2.0.0.0</java-hamcrest.version>
+        <javaVersion>${target.jdk.version}</javaVersion>
         <javadoc.failOnWarnings>false</javadoc.failOnWarnings>
         <jetty.version>12.1.7</jetty.version>
         <junit.version>6.0.3</junit.version>
@@ -122,7 +123,7 @@
         <lombok.version>1.18.42</lombok.version>
         <maven-failsafe-plugin.forkCount>1</maven-failsafe-plugin.forkCount>
         <maven-failsafe-plugin.reuseForks>true</maven-failsafe-plugin.reuseForks>
-        <maven-javadoc-plugin.version>3.10.0</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <maven-surefire-plugin.argLine>-javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito-core.version}/mockito-core-${mockito-core.version}.jar
             -Xshare:off
             -Duser.timezone=UTC
@@ -272,9 +273,11 @@
         <repository>
             <releases>
                 <enabled>true</enabled>
+                <checksumPolicy>fail</checksumPolicy>
             </releases>
             <snapshots>
                 <enabled>false</enabled>
+                <checksumPolicy>fail</checksumPolicy>
             </snapshots>
             <id>central</id>
             <name>Maven Central</name>
@@ -285,9 +288,11 @@
         <pluginRepository>
             <releases>
                 <enabled>false</enabled>
+                <checksumPolicy>fail</checksumPolicy>
             </releases>
             <snapshots>
                 <enabled>true</enabled>
+                <checksumPolicy>fail</checksumPolicy>
             </snapshots>
             <id>apache.snapshots</id>
             <url>https://repository.apache.org/snapshots/</url>
@@ -541,7 +546,7 @@
                             <failOnError>true</failOnError>
                             <failOnWarnings>${javadoc.failOnWarnings}</failOnWarnings>
                             <doclint>all,-missing</doclint>
-                            <source>${maven.compiler.source}</source>
+                            <source>${target.jdk.version}</source>
                             <encoding>${project.build.sourceEncoding}</encoding>
                             <docencoding>${project.reporting.outputEncoding}</docencoding>
                             <maxmemory>512m</maxmemory>

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,7 @@
         <maven.build.timestamp.format>yyyy-MM-dd hh.mm.ss</maven.build.timestamp.format>
         <maven.compiler.source>${target.jdk.version}</maven.compiler.source>
         <maven.compiler.target>${target.jdk.version}</maven.compiler.target>
+        <minimalMavenBuildVersion>3.6.3</minimalMavenBuildVersion>
         <mockito-core.version>5.22.0</mockito-core.version>
         <netty.version>4.2.8.Final</netty.version>
         <objenesis.version>3.5</objenesis.version>

--- a/ui/src/test/java/org/apache/hop/ui/hopgui/terminal/TerminalShellDetectorTest.java
+++ b/ui/src/test/java/org/apache/hop/ui/hopgui/terminal/TerminalShellDetectorTest.java
@@ -42,7 +42,9 @@ class TerminalShellDetectorTest {
           "Windows should detect PowerShell or cmd");
     } else if (os.contains("mac") || os.contains("nix") || os.contains("nux")) {
       // Unix-like systems should return a shell in /bin
-      assertTrue(shell.startsWith("/bin/"), "Unix-like systems should return a shell in /bin");
+      assertTrue(
+          shell.startsWith("/bin/") || shell.startsWith("/usr/bin/"),
+          "Unix-like systems should return a shell in /bin or /usr/bin");
     }
   }
 


### PR DESCRIPTION
- Upgrade to Apache pom parent 38 (need to override javaVersion property)
- Upgrade javadoc maven plugin
- Set minimal maven build version to 3.6.3
- Activate checksum on maven repositories
- Fix terminal shell detector test