### PR TITLE
Fix missing label display in Build Documentation component

### DIFF
--- a/plugins/misc/documentation/src/main/java/org/apache/hop/documentation/ActionDoc.java
+++ b/plugins/misc/documentation/src/main/java/org/apache/hop/documentation/ActionDoc.java
@@ -97,7 +97,7 @@ public class ActionDoc extends ActionBase implements Cloneable, IAction {
       parentId = GUI_WIDGETS_PARENT_ID,
       type = GuiElementType.CHECKBOX,
       variables = false,
-      label = "i18n:ActionDoc.RemoveMarkdown.Label")
+      label = "i18n::ActionDoc.RemoveMarkdown.Label")
   @HopMetadataProperty
   private boolean removeMarkdown = false;
 


### PR DESCRIPTION
## Root Cause
The i18n key was incorrectly defined as:

i18n:ActionDoc.RemoveMarkdown.Label

It should use the correct syntax:

i18n::ActionDoc.RemoveMarkdown.Label