### PR TITLE
[INFRA] Set up default rulesets for default and release branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,22 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
-# https://cwiki.apache.org/confluence/display/INFRA/.asf.yaml+features+for+git+repositories
----
 
 notifications:
   commits: commits@hop.apache.org
@@ -74,7 +55,20 @@ github:
     delete_comment_discussion: "Re: [D] {title} ({repository})"
 
   #remove ~ when enabling the protection
-  protected_branches: ~
+  protected_branches:
 #    master:
 #      required_pull_request_reviews:
 #        required_approving_review_count: 1
+  rulesets:
+    - name: "Default Branch Protection"
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
+          - "release/*"
+          - "rel/*"
+        excludes: []
+      bypass_teams:
+        - root
+      restrict_deletion: true
+      restrict_force_push: true

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -55,10 +55,11 @@ github:
     delete_comment_discussion: "Re: [D] {title} ({repository})"
 
   #remove ~ when enabling the protection
-  protected_branches:
+  protected_branches: ~
 #    master:
 #      required_pull_request_reviews:
 #        required_approving_review_count: 1
+
   rulesets:
     - name: "Default Branch Protection"
       type: branch

--- a/.github/workflows/pr_tagger.yml
+++ b/.github/workflows/pr_tagger.yml
@@ -18,7 +18,7 @@
 
 name: LabelPrs
 on: [pull_request_target]
-permissions: read-all
+permissions: read
 jobs:
   label:
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -472,6 +472,7 @@
                         <exclude>DISCLAIMER</exclude>
                         <exclude>LICENSE</exclude>
                         <exclude>NOTICE</exclude>
+                        <exclude>.asf.yaml</exclude>
                         <exclude>**/licenses/*</exclude>
                         <exclude>**/target/**</exclude>
                         <exclude>**/*.svg</exclude>


### PR DESCRIPTION
This Pull Request enables the repository to conform with the "sane default security settings" of the Apache Software Foundation by configuring a default branch ruleset that protects the default branch and any release branches.

Note that `~DEFAULT_BRANCH` is a GitHub symbolic link to the current default branch (HEAD) of the repository and does not need changing.
If the managing project does not wish to set up these defaults, please close this Pull Request. Alternatively, the project may merge this Pull Request to apply the changes immediately.

If no action is taken, this Pull Request will be automatically merged by the Apache Infrastructure team on **2026-06-14** (30 days from now).

For any further information, please reach us on Slack or at: users@infra.apache.org
