### PR TITLE
Fix weekly day-of-week combo in Start workflow action dialog

### DIFF
--- a/ui/src/main/java/org/apache/hop/ui/workflow/actions/start/ActionStartDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/workflow/actions/start/ActionStartDialog.java
@@ -204,7 +204,11 @@ public class ActionStartDialog extends ActionDialog {
     wIntervalMinutes.setText(Const.NVL(action.getIntervalMinutes(), ""));
     wHour.setText(Const.NVL(action.getHour(), ""));
     wMinutes.setText(Const.NVL(action.getMinutes(), ""));
-    wDayOfWeek.setText(Const.NVL(action.getWeekDay(), ""));
+    int dayOfWeekIndex = Const.toInt(Const.NVL(action.getWeekDay(), "0"), 0);
+    if (dayOfWeekIndex < 0 || dayOfWeekIndex >= wDayOfWeek.getItemCount()) {
+      dayOfWeekIndex = 0;
+    }
+    wDayOfWeek.select(dayOfWeekIndex);
     wDayOfMonth.setText(Const.NVL(action.getDayOfMonth(), ""));
     wDoNotWaitOnFirstExecution.setSelection(action.isDoNotWaitOnFirstExecution());
   }
@@ -222,7 +226,11 @@ public class ActionStartDialog extends ActionDialog {
     action.setIntervalMinutes(wIntervalMinutes.getText());
     action.setHour(wHour.getText());
     action.setMinutes(wMinutes.getText());
-    action.setWeekDay(wDayOfWeek.getText());
+    int weekDayIdx = wDayOfWeek.getSelectionIndex();
+    if (weekDayIdx < 0) {
+      weekDayIdx = 0;
+    }
+    action.setWeekDay(Integer.toString(weekDayIdx));
     action.setDayOfMonth(wDayOfMonth.getText());
     action.setDoNotWaitOnFirstExecution(wDoNotWaitOnFirstExecution.getSelection());
 


### PR DESCRIPTION
- Load `weekDay` (`"0"`–`"6"`, Sunday–Saturday) into the weekly repeat combo using `select(index)` so the control shows the localized weekday labels instead of a raw numeric string (e.g. `1`).
- Persist `weekDay` from `getSelectionIndex()` on OK so the engine keeps receiving numeric indices; previously `getText()` could save localized day names that `Const.toInt` in `ActionStart` could not parse.
