### PR TITLE
Fix REST web service parameter docs

### DIFF
--- a/docs/hop-user-manual/modules/ROOT/pages/hop-rest/index.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/hop-rest/index.adoc
@@ -270,7 +270,7 @@ The 'Execution' services are deployed under sub-path `execution/`.
 
 The body to post can contain the following options (see also: the example above)
 
-* `execute`: the name of the Web Service metadata element to use
+* `service`: the name of the Web Service metadata element to use
 * `runConfig`: the name of the pipeline run configuration to use
 * `variables`: a map with variables (or parameters) with their names and values
 * `bodyContent`: this will be set as a variable using the body content variable option in the Web Service metadata.


### PR DESCRIPTION
﻿Fixes #3277.

This updates the Hop REST execution documentation so the request body option list matches the example directly above it.

The example uses:

```json
"service" : "test"
```

but the option list described the same field as `execute`. The Hop Server web service documentation also uses `service`, so this changes the REST option list to `service` for consistency.

Validation performed locally:

```text
git diff --check
# clean
```

```text
Select-String -Path docs\hop-user-manual\modules\ROOT\pages\hop-rest\index.adoc -Pattern '`service`','`execute`','"service" : "test"' -SimpleMatch
# line 254: example contains "service" : "test"
# line 273: option list now documents `service`
```

I could not run the full `mvn clean install apache-rat:check` locally because Maven/Java are not installed in this Windows/WSL environment. The change is limited to one AsciiDoc word in the user manual.

- [ ] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.
- [x] I hereby declare this contribution to be licensed under the Apache License Version 2.0, January 2004.
- [ ] In any other case, please file an Apache Individual Contributor License Agreement.
