### PR TITLE
Fix MongoDB transform dialogs: align controls and sync label enablement

### DIFF
--- a/plugins/transforms/mongodb/src/main/java/org/apache/hop/pipeline/transforms/mongodbdelete/MongoDbDeleteDialog.java
+++ b/plugins/transforms/mongodb/src/main/java/org/apache/hop/pipeline/transforms/mongodbdelete/MongoDbDeleteDialog.java
@@ -175,7 +175,7 @@ public class MongoDbDeleteDialog extends BaseTransformDialog {
         BaseMessages.getString(PKG, "MongoDbDeleteDialog.GetCollections.Button")); // $NON-NLS-1$
     fd = new FormData();
     fd.right = new FormAttachment(100, 0);
-    fd.top = new FormAttachment(lastControl, 0);
+    fd.top = new FormAttachment(wlCollection, 0, SWT.CENTER);
     wbGetCollections.setLayoutData(fd);
     wbGetCollections.addListener(SWT.Selection, e -> getCollectionNames());
 
@@ -189,7 +189,7 @@ public class MongoDbDeleteDialog extends BaseTransformDialog {
         });
     fd = new FormData();
     fd.left = new FormAttachment(middle, 0);
-    fd.top = new FormAttachment(lastControl, margin);
+    fd.top = new FormAttachment(wlCollection, 0, SWT.CENTER);
     fd.right = new FormAttachment(wbGetCollections, -margin);
     wCollection.setLayoutData(fd);
 
@@ -289,9 +289,9 @@ public class MongoDbDeleteDialog extends BaseTransformDialog {
           }
         });
     fd = new FormData();
-    fd.right = new FormAttachment(100, -margin);
-    fd.top = new FormAttachment(0, margin * 3);
     fd.left = new FormAttachment(middle, 0);
+    fd.right = new FormAttachment(100, -margin);
+    fd.top = new FormAttachment(useDefinedQueryLab, 0, SWT.CENTER);
     wbUseJsonQuery.setLayoutData(fd);
 
     colInf =

--- a/plugins/transforms/mongodb/src/main/java/org/apache/hop/pipeline/transforms/mongodbinput/MongoDbInputDialog.java
+++ b/plugins/transforms/mongodb/src/main/java/org/apache/hop/pipeline/transforms/mongodbinput/MongoDbInputDialog.java
@@ -166,7 +166,7 @@ public class MongoDbInputDialog extends BaseTransformDialog {
         BaseMessages.getString(PKG, "MongoDbInputDialog.GetCollections.Button"));
     FormData fd = new FormData();
     fd.right = new FormAttachment(100, 0);
-    fd.top = new FormAttachment(lastControl, 0);
+    fd.top = new FormAttachment(wlCollection, 0, SWT.CENTER);
     wbGetCollections.setLayoutData(fd);
     wbGetCollections.addListener(SWT.Selection, e -> getCollectionNames());
 
@@ -175,8 +175,8 @@ public class MongoDbInputDialog extends BaseTransformDialog {
     wCollection.addModifyListener(lsMod);
     FormData fdCollection = new FormData();
     fdCollection.left = new FormAttachment(middle, 0);
-    fdCollection.top = new FormAttachment(lastControl, margin);
-    fdCollection.right = new FormAttachment(wbGetCollections, 0);
+    fdCollection.top = new FormAttachment(wlCollection, 0, SWT.CENTER);
+    fdCollection.right = new FormAttachment(wbGetCollections, -margin);
     wCollection.setLayoutData(fdCollection);
     lastControl = wCollection;
     wCollection.addListener(SWT.Selection, e -> updateQueryTitleInfo());

--- a/plugins/transforms/mongodb/src/main/java/org/apache/hop/pipeline/transforms/mongodboutput/MongoDbOutputDialog.java
+++ b/plugins/transforms/mongodb/src/main/java/org/apache/hop/pipeline/transforms/mongodboutput/MongoDbOutputDialog.java
@@ -697,6 +697,10 @@ public class MongoDbOutputDialog extends BaseTransformDialog {
     return null;
   }
 
+  /**
+   * Enables or disables Upsert, Modifier update, and Multi-update labels and checkboxes based on
+   * Update and Modifier update.
+   */
   private void setUpdateOptionControlsEnabled() {
     boolean updateSelected = wbUpdate.getSelection();
     upsertLab.setEnabled(updateSelected);

--- a/plugins/transforms/mongodb/src/main/java/org/apache/hop/pipeline/transforms/mongodboutput/MongoDbOutputDialog.java
+++ b/plugins/transforms/mongodb/src/main/java/org/apache/hop/pipeline/transforms/mongodboutput/MongoDbOutputDialog.java
@@ -81,8 +81,11 @@ public class MongoDbOutputDialog extends BaseTransformDialog {
 
   private Button wbTruncate;
   private Button wbUpdate;
+  private Label upsertLab;
   private Button wbUpsert;
+  private Label multiLab;
   private Button wbMulti;
+  private Label modifierLab;
   private Button wbModifierUpdate;
 
   private TextVar wWriteRetries;
@@ -267,22 +270,16 @@ public class MongoDbOutputDialog extends BaseTransformDialog {
         SWT.Selection,
         e -> {
           currentMeta.setChanged();
-          wbUpsert.setEnabled(wbUpdate.getSelection());
-          wbModifierUpdate.setEnabled(wbUpdate.getSelection());
-          wbMulti.setEnabled(wbUpdate.getSelection());
           if (!wbUpdate.getSelection()) {
             wbModifierUpdate.setSelection(false);
             wbMulti.setSelection(false);
             wbUpsert.setSelection(false);
           }
-          wbMulti.setEnabled(wbModifierUpdate.getSelection());
-          if (!wbMulti.getEnabled()) {
-            wbMulti.setSelection(false);
-          }
+          setUpdateOptionControlsEnabled();
         });
 
     // upsert line
-    Label upsertLab = new Label(wOutputComp, SWT.RIGHT);
+    upsertLab = new Label(wOutputComp, SWT.RIGHT);
     upsertLab.setText(BaseMessages.getString(PKG, "MongoDbOutputDialog.Upsert.Label"));
     PropsUi.setLook(upsertLab);
     upsertLab.setToolTipText(BaseMessages.getString(PKG, "MongoDbOutputDialog.Upsert.TipText"));
@@ -302,7 +299,7 @@ public class MongoDbOutputDialog extends BaseTransformDialog {
     lastControl = upsertLab;
 
     // multi line
-    Label multiLab = new Label(wOutputComp, SWT.RIGHT);
+    multiLab = new Label(wOutputComp, SWT.RIGHT);
     multiLab.setText(BaseMessages.getString(PKG, "MongoDbOutputDialog.Multi.Label"));
     PropsUi.setLook(multiLab);
     multiLab.setToolTipText(BaseMessages.getString(PKG, "MongoDbOutputDialog.Multi.TipText"));
@@ -323,7 +320,7 @@ public class MongoDbOutputDialog extends BaseTransformDialog {
     lastControl = multiLab;
 
     // modifier update
-    Label modifierLab = new Label(wOutputComp, SWT.RIGHT);
+    modifierLab = new Label(wOutputComp, SWT.RIGHT);
     modifierLab.setText(BaseMessages.getString(PKG, "MongoDbOutputDialog.Modifier.Label"));
     PropsUi.setLook(modifierLab);
     modifierLab.setToolTipText(BaseMessages.getString(PKG, "MongoDbOutputDialog.Modifier.TipText"));
@@ -346,12 +343,13 @@ public class MongoDbOutputDialog extends BaseTransformDialog {
         SWT.Selection,
         e -> {
           currentMeta.setChanged();
-          wbMulti.setEnabled(wbModifierUpdate.getSelection());
           if (!wbModifierUpdate.getSelection()) {
             wbMulti.setSelection(false);
           }
+          setUpdateOptionControlsEnabled();
         });
     lastControl = modifierLab;
+    setUpdateOptionControlsEnabled();
 
     // retries stuff
     Label retriesLab = new Label(wOutputComp, SWT.RIGHT);
@@ -699,6 +697,17 @@ public class MongoDbOutputDialog extends BaseTransformDialog {
     return null;
   }
 
+  private void setUpdateOptionControlsEnabled() {
+    boolean updateSelected = wbUpdate.getSelection();
+    upsertLab.setEnabled(updateSelected);
+    wbUpsert.setEnabled(updateSelected);
+    modifierLab.setEnabled(updateSelected);
+    wbModifierUpdate.setEnabled(updateSelected);
+    boolean multiEnabled = updateSelected && wbModifierUpdate.getSelection();
+    multiLab.setEnabled(multiEnabled);
+    wbMulti.setEnabled(multiEnabled);
+  }
+
   private void getData() {
     wConnection.setText(Const.NVL(currentMeta.getConnectionName(), "")); //
     wCollectionField.setText(Const.NVL(currentMeta.getCollection(), "")); //
@@ -709,14 +718,11 @@ public class MongoDbOutputDialog extends BaseTransformDialog {
     wbTruncate.setSelection(currentMeta.isTruncate());
     wbModifierUpdate.setSelection(currentMeta.isModifierUpdate());
 
-    wbUpsert.setEnabled(wbUpdate.getSelection());
-    wbModifierUpdate.setEnabled(wbUpdate.getSelection());
-    wbMulti.setEnabled(wbUpdate.getSelection());
     if (!wbUpdate.getSelection()) {
       wbModifierUpdate.setSelection(false);
       wbMulti.setSelection(false);
     }
-    wbMulti.setEnabled(wbModifierUpdate.getSelection());
+    setUpdateOptionControlsEnabled();
     if (!wbMulti.getEnabled()) {
       wbMulti.setSelection(false);
     }


### PR DESCRIPTION
Improves layout and enable/disable behavior in MongoDB pipeline transform configuration dialogs:
- **MongoDB Input** (`MongoDbInputDialog`): Align the Collection combo and **Get collections** button vertically with the Collection label (same pattern as MongoDB Output).
- **MongoDB Delete** (`MongoDbDeleteDialog`): Same alignment fix for Collection + **Get collections**; align **Use JSON query** label and checkbox on one row (checkbox was offset with `margin * 3`).
- **MongoDB Output** (`MongoDbOutputDialog`): When Update / Modifier update toggles enable or disable Upsert, Multi-update, and Modifier options, apply the same state to their labels—not only the checkboxes—via a shared `setUpdateOptionControlsEnabled()` helper used on load and on selection.
