### PR TITLE
Fix MongoDB transform dialog layout, update-option enablement, and Input preview when not outputting JSON

### DIFF
--- a/plugins/tech/mongodb/src/main/java/org/apache/hop/pipeline/transforms/mongodbdelete/MongoDbDeleteDialog.java
+++ b/plugins/tech/mongodb/src/main/java/org/apache/hop/pipeline/transforms/mongodbdelete/MongoDbDeleteDialog.java
@@ -175,7 +175,7 @@ public class MongoDbDeleteDialog extends BaseTransformDialog {
         BaseMessages.getString(PKG, "MongoDbDeleteDialog.GetCollections.Button")); // $NON-NLS-1$
     fd = new FormData();
     fd.right = new FormAttachment(100, 0);
-    fd.top = new FormAttachment(lastControl, 0);
+    fd.top = new FormAttachment(wlCollection, 0, SWT.CENTER);
     wbGetCollections.setLayoutData(fd);
     wbGetCollections.addListener(SWT.Selection, e -> getCollectionNames());
 
@@ -189,7 +189,7 @@ public class MongoDbDeleteDialog extends BaseTransformDialog {
         });
     fd = new FormData();
     fd.left = new FormAttachment(middle, 0);
-    fd.top = new FormAttachment(lastControl, margin);
+    fd.top = new FormAttachment(wlCollection, 0, SWT.CENTER);
     fd.right = new FormAttachment(wbGetCollections, -margin);
     wCollection.setLayoutData(fd);
 
@@ -289,9 +289,9 @@ public class MongoDbDeleteDialog extends BaseTransformDialog {
           }
         });
     fd = new FormData();
-    fd.right = new FormAttachment(100, -margin);
-    fd.top = new FormAttachment(0, margin * 3);
     fd.left = new FormAttachment(middle, 0);
+    fd.right = new FormAttachment(100, -margin);
+    fd.top = new FormAttachment(useDefinedQueryLab, 0, SWT.CENTER);
     wbUseJsonQuery.setLayoutData(fd);
 
     colInf =

--- a/plugins/tech/mongodb/src/main/java/org/apache/hop/pipeline/transforms/mongodbinput/MongoDbInput.java
+++ b/plugins/tech/mongodb/src/main/java/org/apache/hop/pipeline/transforms/mongodbinput/MongoDbInput.java
@@ -266,6 +266,10 @@ public class MongoDbInput extends BaseTransform<MongoDbInputMeta, MongoDbInputDa
         data.collection = data.clientWrapper.getCollection(databaseName, collection);
 
         if (!meta.isOutputJson()) {
+          if (meta.getFields() == null || meta.getFields().isEmpty()) {
+            throw new HopException(
+                BaseMessages.getString(PKG, "MongoInput.ErrorMessage.NoFieldsSpecified"));
+          }
           data.setMongoFields(meta.getFields());
         }
 

--- a/plugins/tech/mongodb/src/main/java/org/apache/hop/pipeline/transforms/mongodbinput/MongoDbInputData.java
+++ b/plugins/tech/mongodb/src/main/java/org/apache/hop/pipeline/transforms/mongodbinput/MongoDbInputData.java
@@ -258,9 +258,10 @@ public class MongoDbInputData extends BaseTransformData implements ITransformDat
    * @param fields the field path specifications
    */
   public void setMongoFields(List<MongoField> fields) {
-    // copy this list
     userFields = new ArrayList<>();
-
+    if (fields == null) {
+      return;
+    }
     for (MongoField f : fields) {
       userFields.add(f.copy());
     }

--- a/plugins/tech/mongodb/src/main/java/org/apache/hop/pipeline/transforms/mongodbinput/MongoDbInputDialog.java
+++ b/plugins/tech/mongodb/src/main/java/org/apache/hop/pipeline/transforms/mongodbinput/MongoDbInputDialog.java
@@ -166,7 +166,7 @@ public class MongoDbInputDialog extends BaseTransformDialog {
         BaseMessages.getString(PKG, "MongoDbInputDialog.GetCollections.Button"));
     FormData fd = new FormData();
     fd.right = new FormAttachment(100, 0);
-    fd.top = new FormAttachment(lastControl, 0);
+    fd.top = new FormAttachment(wlCollection, 0, SWT.CENTER);
     wbGetCollections.setLayoutData(fd);
     wbGetCollections.addListener(SWT.Selection, e -> getCollectionNames());
 
@@ -175,8 +175,8 @@ public class MongoDbInputDialog extends BaseTransformDialog {
     wCollection.addModifyListener(lsMod);
     FormData fdCollection = new FormData();
     fdCollection.left = new FormAttachment(middle, 0);
-    fdCollection.top = new FormAttachment(lastControl, margin);
-    fdCollection.right = new FormAttachment(wbGetCollections, 0);
+    fdCollection.top = new FormAttachment(wlCollection, 0, SWT.CENTER);
+    fdCollection.right = new FormAttachment(wbGetCollections, -margin);
     wCollection.setLayoutData(fdCollection);
     lastControl = wCollection;
     wCollection.addListener(SWT.Selection, e -> updateQueryTitleInfo());
@@ -497,25 +497,22 @@ public class MongoDbInputDialog extends BaseTransformDialog {
     meta.setExecuteForEachIncomingRow(wbExecuteForEachRow.getSelection());
 
     int numNonEmpty = wFields.nrNonEmpty();
-    if (numNonEmpty > 0) {
-      List<MongoField> outputFields = new ArrayList<>();
-      for (int i = 0; i < numNonEmpty; i++) {
-        TableItem item = wFields.getNonEmpty(i);
-        MongoField newField = new MongoField();
+    List<MongoField> outputFields = new ArrayList<>();
+    for (int i = 0; i < numNonEmpty; i++) {
+      TableItem item = wFields.getNonEmpty(i);
+      MongoField newField = new MongoField();
 
-        newField.fieldName = item.getText(1).trim();
-        newField.fieldPath = item.getText(2).trim();
-        newField.hopType = item.getText(3).trim();
+      newField.fieldName = item.getText(1).trim();
+      newField.fieldPath = item.getText(2).trim();
+      newField.hopType = item.getText(3).trim();
 
-        if (!StringUtils.isEmpty(item.getText(4))) {
-          newField.indexedValues = MongoDbInputData.indexedValsList(item.getText(4).trim());
-        }
-
-        outputFields.add(newField);
+      if (!StringUtils.isEmpty(item.getText(4))) {
+        newField.indexedValues = MongoDbInputData.indexedValsList(item.getText(4).trim());
       }
 
-      meta.setFields(outputFields);
+      outputFields.add(newField);
     }
+    meta.setFields(outputFields);
   }
 
   private void ok() {
@@ -731,6 +728,19 @@ public class MongoDbInputDialog extends BaseTransformDialog {
         BaseMessages.getString(
             PKG,
             "MongoDbInputDialog.Warning.Message.MongoQueryContainsUnresolvedVarsFieldSubs.PreviewTitle"))) {
+      return;
+    }
+
+    if (!oneMeta.isOutputJson() && Utils.isEmpty(oneMeta.getFields())) {
+      ShowMessageDialog smd =
+          new ShowMessageDialog(
+              shell,
+              SWT.ICON_WARNING | SWT.OK,
+              BaseMessages.getString(
+                  PKG, "MongoDbInputDialog.ErrorMessage.NoFieldsForStructuredOutput.Title"),
+              BaseMessages.getString(
+                  PKG, "MongoDbInputDialog.ErrorMessage.NoFieldsForStructuredOutput"));
+      smd.open();
       return;
     }
 

--- a/plugins/tech/mongodb/src/main/java/org/apache/hop/pipeline/transforms/mongodboutput/MongoDbOutputDialog.java
+++ b/plugins/tech/mongodb/src/main/java/org/apache/hop/pipeline/transforms/mongodboutput/MongoDbOutputDialog.java
@@ -81,8 +81,11 @@ public class MongoDbOutputDialog extends BaseTransformDialog {
 
   private Button wbTruncate;
   private Button wbUpdate;
+  private Label upsertLab;
   private Button wbUpsert;
+  private Label multiLab;
   private Button wbMulti;
+  private Label modifierLab;
   private Button wbModifierUpdate;
 
   private TextVar wWriteRetries;
@@ -267,22 +270,16 @@ public class MongoDbOutputDialog extends BaseTransformDialog {
         SWT.Selection,
         e -> {
           currentMeta.setChanged();
-          wbUpsert.setEnabled(wbUpdate.getSelection());
-          wbModifierUpdate.setEnabled(wbUpdate.getSelection());
-          wbMulti.setEnabled(wbUpdate.getSelection());
           if (!wbUpdate.getSelection()) {
             wbModifierUpdate.setSelection(false);
             wbMulti.setSelection(false);
             wbUpsert.setSelection(false);
           }
-          wbMulti.setEnabled(wbModifierUpdate.getSelection());
-          if (!wbMulti.getEnabled()) {
-            wbMulti.setSelection(false);
-          }
+          setUpdateOptionControlsEnabled();
         });
 
     // upsert line
-    Label upsertLab = new Label(wOutputComp, SWT.RIGHT);
+    upsertLab = new Label(wOutputComp, SWT.RIGHT);
     upsertLab.setText(BaseMessages.getString(PKG, "MongoDbOutputDialog.Upsert.Label"));
     PropsUi.setLook(upsertLab);
     upsertLab.setToolTipText(BaseMessages.getString(PKG, "MongoDbOutputDialog.Upsert.TipText"));
@@ -302,7 +299,7 @@ public class MongoDbOutputDialog extends BaseTransformDialog {
     lastControl = upsertLab;
 
     // multi line
-    Label multiLab = new Label(wOutputComp, SWT.RIGHT);
+    multiLab = new Label(wOutputComp, SWT.RIGHT);
     multiLab.setText(BaseMessages.getString(PKG, "MongoDbOutputDialog.Multi.Label"));
     PropsUi.setLook(multiLab);
     multiLab.setToolTipText(BaseMessages.getString(PKG, "MongoDbOutputDialog.Multi.TipText"));
@@ -323,7 +320,7 @@ public class MongoDbOutputDialog extends BaseTransformDialog {
     lastControl = multiLab;
 
     // modifier update
-    Label modifierLab = new Label(wOutputComp, SWT.RIGHT);
+    modifierLab = new Label(wOutputComp, SWT.RIGHT);
     modifierLab.setText(BaseMessages.getString(PKG, "MongoDbOutputDialog.Modifier.Label"));
     PropsUi.setLook(modifierLab);
     modifierLab.setToolTipText(BaseMessages.getString(PKG, "MongoDbOutputDialog.Modifier.TipText"));
@@ -346,12 +343,13 @@ public class MongoDbOutputDialog extends BaseTransformDialog {
         SWT.Selection,
         e -> {
           currentMeta.setChanged();
-          wbMulti.setEnabled(wbModifierUpdate.getSelection());
           if (!wbModifierUpdate.getSelection()) {
             wbMulti.setSelection(false);
           }
+          setUpdateOptionControlsEnabled();
         });
     lastControl = modifierLab;
+    setUpdateOptionControlsEnabled();
 
     // retries stuff
     Label retriesLab = new Label(wOutputComp, SWT.RIGHT);
@@ -699,6 +697,21 @@ public class MongoDbOutputDialog extends BaseTransformDialog {
     return null;
   }
 
+  /**
+   * Enables or disables Upsert, Modifier update, and Multi-update labels and checkboxes based on
+   * Update and Modifier update.
+   */
+  private void setUpdateOptionControlsEnabled() {
+    boolean updateSelected = wbUpdate.getSelection();
+    upsertLab.setEnabled(updateSelected);
+    wbUpsert.setEnabled(updateSelected);
+    modifierLab.setEnabled(updateSelected);
+    wbModifierUpdate.setEnabled(updateSelected);
+    boolean multiEnabled = updateSelected && wbModifierUpdate.getSelection();
+    multiLab.setEnabled(multiEnabled);
+    wbMulti.setEnabled(multiEnabled);
+  }
+
   private void getData() {
     wConnection.setText(Const.NVL(currentMeta.getConnectionName(), "")); //
     wCollectionField.setText(Const.NVL(currentMeta.getCollection(), "")); //
@@ -709,14 +722,11 @@ public class MongoDbOutputDialog extends BaseTransformDialog {
     wbTruncate.setSelection(currentMeta.isTruncate());
     wbModifierUpdate.setSelection(currentMeta.isModifierUpdate());
 
-    wbUpsert.setEnabled(wbUpdate.getSelection());
-    wbModifierUpdate.setEnabled(wbUpdate.getSelection());
-    wbMulti.setEnabled(wbUpdate.getSelection());
     if (!wbUpdate.getSelection()) {
       wbModifierUpdate.setSelection(false);
       wbMulti.setSelection(false);
     }
-    wbMulti.setEnabled(wbModifierUpdate.getSelection());
+    setUpdateOptionControlsEnabled();
     if (!wbMulti.getEnabled()) {
       wbMulti.setSelection(false);
     }

--- a/plugins/tech/mongodb/src/main/resources/org/apache/hop/pipeline/transforms/mongodbinput/messages/messages_en_US.properties
+++ b/plugins/tech/mongodb/src/main/resources/org/apache/hop/pipeline/transforms/mongodbinput/messages/messages_en_US.properties
@@ -94,4 +94,7 @@ MongoInput.ErrorMessage.ErrorLoadingMongoDbConnection=Error loading MongoDB conn
 MongoInput.ErrorMessage.MongoDbConnection.NotFound=MongoDB connection {0} couldn''t be found
 MongoInput.ErrorMessage.NoCollectionSpecified=No collection specified
 MongoInput.ErrorMessage.NoDBSpecified=No database specified
+MongoInput.ErrorMessage.NoFieldsSpecified=No MongoDB document fields are defined for structured output
+MongoDbInputDialog.ErrorMessage.NoFieldsForStructuredOutput.Title=Missing fields
+MongoDbInputDialog.ErrorMessage.NoFieldsForStructuredOutput=When ''Output a single JSON field'' is not selected, define at least one field on the Fields tab (use Get Fields to sample the collection).
 MongoInput.ErrorMessage.PathContainsMultipleExpansions=Path contains multiple array expansions: {0}

--- a/plugins/tech/mongodb/src/main/resources/org/apache/hop/pipeline/transforms/mongodbinput/messages/messages_zh_CN.properties
+++ b/plugins/tech/mongodb/src/main/resources/org/apache/hop/pipeline/transforms/mongodbinput/messages/messages_zh_CN.properties
@@ -68,3 +68,6 @@ MongoInput.ErrorMessage.ErrorLoadingMongoDbConnection=\u4ECE MongoDB \u8FDE\u63A
 MongoInput.ErrorMessage.MongoDbConnection.NotFound=\u627E\u4E0D\u5230 MongoDB \u8FDE\u63A5 {0}
 MongoInput.ErrorMessage.NoCollectionSpecified=\u672A\u6307\u5B9A\u96C6\u5408
 MongoInput.ErrorMessage.NoDBSpecified=\u672A\u6307\u5B9A\u6570\u636E\u5E93
+MongoInput.ErrorMessage.NoFieldsSpecified=\u672A\u5B9A\u4E49\u7528\u4E8E\u7ED3\u6784\u5316\u8F93\u51FA\u7684 MongoDB \u5B57\u6BB5
+MongoDbInputDialog.ErrorMessage.NoFieldsForStructuredOutput.Title=\u7F3A\u5C11\u5B57\u6BB5
+MongoDbInputDialog.ErrorMessage.NoFieldsForStructuredOutput=\u672A\u52FE\u9009\u300C\u8F93\u51FA\u5355\u4E2A JSON \u5B57\u6BB5\u300D\u65F6\uFF0C\u8BF7\u5728\u300C\u5B57\u6BB5\u300D\u9875\u7B7E\u4E2D\u81F3\u5C11\u5B9A\u4E49\u4E00\u4E2A\u5B57\u6BB5\uFF08\u53EF\u4F7F\u7528\u300C\u83B7\u53D6\u5B57\u6BB5\u300D\u4ECE\u96C6\u5408\u4E2D\u91C7\u6837\uFF09\u3002

--- a/plugins/tech/mongodb/src/test/java/org/apache/hop/pipeline/transforms/mongodbinput/MongoDbInputDataTest.java
+++ b/plugins/tech/mongodb/src/test/java/org/apache/hop/pipeline/transforms/mongodbinput/MongoDbInputDataTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.hop.pipeline.transforms.mongodbinput;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -378,5 +379,14 @@ class MongoDbInputDataTest {
     assertEquals(
         "my.${oneparam}.with.${a_dot_param}.otherstuff",
         MongoDbInputData.cleansePath("my.${oneparam}.with.${a.dot.param}.otherstuff"));
+  }
+
+  @Test
+  void setMongoFieldsNullIsSafe() {
+    MongoDbInputData data = new MongoDbInputData();
+    data.outputRowMeta = new RowMeta();
+    data.setMongoFields(null);
+
+    assertDoesNotThrow(data::init);
   }
 }


### PR DESCRIPTION

### UI layout and enablement
- **MongoDB Input** (`MongoDbInputDialog`): Vertically align the Collection label, combo, and **Get collections** button on one row (`FormAttachment` + `SWT.CENTER`, matching MongoDB Output).
- **MongoDB Delete** (`MongoDbDeleteDialog`): Same Collection row alignment; align **Use JSON query** label and checkbox on one row (checkbox was offset with `margin * 3`).
- **MongoDB Output** (`MongoDbOutputDialog`): When **Update** / **Modifier update** toggles enable or disable Upsert, Multi-update, and Modifier options, apply the same state to their labels via `setUpdateOptionControlsEnabled()` (on load, on selection, and after dialog build).

### MongoDB Input preview / init fix
When **Output a single JSON field** is unchecked and no fields are defined on the Fields tab, preview failed with:
`NullPointerException: Cannot invoke "java.util.List.iterator()" because "fields" is null`  
at `MongoDbInputData.setMongoFields`.