### PR TITLE
Fix duplicate context menu when clicking transform/action description info icon

### DIFF
--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/HopGuiPipelineGraph.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/HopGuiPipelineGraph.java
@@ -28,7 +28,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Random;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -730,6 +729,9 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
           // Click on the transform info icon means: Edit transformation description
           //
           this.editDescription((TransformMeta) areaOwner.getOwner());
+          avoidContextDialog = true;
+          currentTransform = null;
+          iconDragStartScreen = null;
           done = true;
           break;
 
@@ -1087,6 +1089,9 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
           // Release after a drag may land on another transform's name; fall through to complete
           // drag
           break;
+        case TRANSFORM_INFO_ICON:
+          // Description edit was handled in mouseDown; do not open the transform context menu
+          return;
         default:
           break;
       }
@@ -1151,7 +1156,7 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
             also = !Utils.isEmpty(selectedTransforms);
             hopGui.undoDelegate.addUndoPosition(
                 pipelineMeta,
-                selectedNotes.toArray(new NotePadMeta[selectedNotes.size()]),
+                selectedNotes.toArray(new NotePadMeta[0]),
                 indexes,
                 previousNoteLocations,
                 pipelineMeta.getSelectedNoteLocations(),
@@ -1161,7 +1166,7 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
             int[] indexes = pipelineMeta.getTransformIndexes(selectedTransforms);
             hopGui.undoDelegate.addUndoPosition(
                 pipelineMeta,
-                selectedTransforms.toArray(new TransformMeta[selectedTransforms.size()]),
+                selectedTransforms.toArray(new TransformMeta[0]),
                 indexes,
                 previousTransformLocations,
                 pipelineMeta.getSelectedTransformLocations(),
@@ -2284,29 +2289,7 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
 
   @Override
   public boolean setFocus() {
-    return (canvas != null && !canvas.isDisposed()) ? canvas.setFocus() : false;
-  }
-
-  public void renameTransform(TransformMeta transformMeta, String transformName) {
-    String newname = transformName;
-
-    TransformMeta smeta = pipelineMeta.findTransform(newname, transformMeta);
-    int nr = 2;
-    while (smeta != null) {
-      newname = transformName + " " + nr;
-      smeta = pipelineMeta.findTransform(newname);
-      nr++;
-    }
-    if (nr > 2) {
-      transformName = newname;
-      modalMessageDialog(
-          BaseMessages.getString(PKG, "HopGui.Dialog.TransformnameExists.Title"),
-          BaseMessages.getString(PKG, "HopGui.Dialog.TransformnameExists.Message", transformName),
-          SWT.OK | SWT.ICON_INFORMATION);
-    }
-    transformMeta.setName(transformName);
-    transformMeta.setChanged();
-    redraw();
+    return canvas != null && !canvas.isDisposed() && canvas.setFocus();
   }
 
   public void clearSettings() {
@@ -2675,7 +2658,7 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
     if (trimmed.matches("\\d+")) {
       return true;
     }
-    // Variable pattern: ${VARIABLE}
+    // Variable pattern: '${VARIABLE}'
     return trimmed.matches("\\$\\{[^}]+\\}");
   }
 
@@ -3245,7 +3228,7 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
       category = "i18n::HopGuiPipelineGraph.ContextualAction.Category.Basic.Text",
       categoryOrder = "1")
   public void editPipelineProperties(HopGuiPipelineContext context) {
-    editProperties(pipelineMeta, hopGui, true);
+    editProperties(pipelineMeta, hopGui);
   }
 
   @GuiToolbarElement(
@@ -3257,7 +3240,7 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
   @GuiKeyboardShortcut(control = true, key = 't')
   @GuiOsxKeyboardShortcut(command = true, key = 't')
   public void editPipelineProperties() {
-    editProperties(pipelineMeta, hopGui, true);
+    editProperties(pipelineMeta, hopGui);
   }
 
   public void newTransform(String description) {
@@ -4011,8 +3994,7 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
     return pipelineMeta.hasChanged();
   }
 
-  public boolean editProperties(
-      PipelineMeta pipelineMeta, HopGui hopGui, boolean allowDirectoryChange) {
+  public boolean editProperties(PipelineMeta pipelineMeta, HopGui hopGui) {
     return editProperties(pipelineMeta, hopGui, null);
   }
 
@@ -4770,18 +4752,6 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
             });
   }
 
-  private String[] convertArguments(Map<String, String> arguments) {
-    String[] argumentNames = arguments.keySet().toArray(new String[arguments.size()]);
-    Arrays.sort(argumentNames);
-
-    String[] args = new String[argumentNames.length];
-    for (int i = 0; i < args.length; i++) {
-      String argumentName = argumentNames[i];
-      args[i] = arguments.get(argumentName);
-    }
-    return args;
-  }
-
   @GuiToolbarElement(
       root = GUI_PLUGIN_TOOLBAR_PARENT_ID,
       id = TOOLBAR_ITEM_STOP,
@@ -4867,7 +4837,7 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
       // If the pipeline is done, we want to do the end processing, etc.
       //
       pipeline.addExecutionFinishedListener(
-          pipeline -> {
+          p -> {
             checkPipelineEnded();
             checkErrorVisuals();
             stopRedrawTimer();

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/HopGuiWorkflowGraph.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/HopGuiWorkflowGraph.java
@@ -347,6 +347,7 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
   private Point[] previousNoteLocations;
   private ActionMeta currentAction;
   private boolean ignoreNextClick;
+  private boolean avoidContextDialog;
   private boolean doubleClick;
   private Runnable pendingShowContextDialogRunnable;
   private boolean dragSelection;
@@ -673,6 +674,9 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
           // Click on the info icon means: Edit action description
           //
           editActionDescription((ActionMeta) areaOwner.getOwner());
+          avoidContextDialog = true;
+          currentAction = null;
+          actionDragStartScreen = null;
           done = true;
           break;
 
@@ -947,6 +951,9 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
             return;
           }
           break;
+        case ACTION_INFO_ICON:
+          // Description edit was handled in mouseDown; do not open the action context menu
+          return;
         default:
           break;
       }
@@ -1143,6 +1150,12 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
       singleClickHop = clickedWorkflowHop;
     }
     clickedWorkflowHop = null;
+
+    if (avoidContextDialog) {
+      avoidContextDialog = false;
+      selectionRegion = null;
+      return;
+    }
 
     // Only do this "mouseUp()" if this is not part of a double click...
     //


### PR DESCRIPTION
Fixes a duplicate-dialog issue when clicking the description info icon (top-left i) on pipeline transforms and workflow actions. A single click now opens only the description editor; the transform/action context menu no longer appears on top of it.

