### PR TITLE
Fix GCS Folder deletion for both HNS Enabled and HNS Disabled buckets

### DIFF
--- a/plugins/tech/google/pom.xml
+++ b/plugins/tech/google/pom.xml
@@ -160,6 +160,20 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage-control</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.conscrypt</groupId>
+                    <artifactId>conscrypt-openjdk-uber</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.http-client</groupId>

--- a/plugins/tech/google/pom.xml
+++ b/plugins/tech/google/pom.xml
@@ -158,6 +158,10 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-storage-control</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.http-client</groupId>
             <artifactId>google-http-client</artifactId>
             <exclusions>

--- a/plugins/tech/google/src/main/java/org/apache/hop/vfs/gs/GoogleStorageFileObject.java
+++ b/plugins/tech/google/src/main/java/org/apache/hop/vfs/gs/GoogleStorageFileObject.java
@@ -26,6 +26,9 @@ import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BlobListOption;
+import com.google.storage.control.v2.DeleteFolderRequest;
+import com.google.storage.control.v2.FolderName;
+import com.google.storage.control.v2.StorageControlClient;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -232,7 +235,11 @@ public class GoogleStorageFileObject extends AbstractFileObject<GoogleStorageFil
   @Override
   protected void doDelete() throws Exception {
     if (hasObject()) {
+      boolean isDirectory = blob.isDirectory();
       blob.delete();
+      if (isDirectory && isHnsEnabled()) {
+        handleHnsDirectoryDeletion(stripLeadingSlash(bucketPath));
+      }
     } else if (bucketName != null
         && !bucketName.isEmpty()
         && bucketPath != null
@@ -243,6 +250,22 @@ public class GoogleStorageFileObject extends AbstractFileObject<GoogleStorageFil
       throw new IOException("Cannot delete: missing bucket/object path for '" + this + "'");
     }
     getAbstractFileSystem().invalidateListCacheForParentOf(bucketName, bucketPath);
+  }
+
+  private void handleHnsDirectoryDeletion(String path) throws IOException {
+    String folderName = FolderName.format("_", bucketName, stripTrailingSlash(path));
+    try (StorageControlClient controlClient = StorageControlClient.create()) {
+      DeleteFolderRequest folderRequest =
+          DeleteFolderRequest.newBuilder().setName(folderName).build();
+      controlClient.deleteFolder(folderRequest);
+    }
+  }
+
+  private boolean isHnsEnabled() {
+    if (bucket == null || bucket.getHierarchicalNamespace() == null) {
+      return false;
+    }
+    return bucket.getHierarchicalNamespace().getEnabled();
   }
 
   @Override
@@ -316,11 +339,7 @@ public class GoogleStorageFileObject extends AbstractFileObject<GoogleStorageFil
     if (!hasBucket()) {
       Page<Bucket> page = storage.list();
       for (Bucket b : page.iterateAll()) {
-        results.add(
-            new GoogleStorageFileObject(
-                scheme,
-                new GoogleStorageFileName(scheme, b.getName(), FileType.FOLDER),
-                getAbstractFileSystem()));
+        results.add(getAbstractFileSystem().resolveFile(b.getName()));
       }
     } else {
       String prefix;
@@ -351,15 +370,9 @@ public class GoogleStorageFileObject extends AbstractFileObject<GoogleStorageFil
         cacheEntries.put(
             b.getName(), new GoogleStorageListCache.ChildInfo(childType, childSize, childLastMod));
         results.add(
-            new GoogleStorageFileObject(
-                scheme,
-                new GoogleStorageFileName(
-                    scheme,
-                    getName().getPath() + "/" + lastPathElement(stripTrailingSlash(b.getName())),
-                    childType),
-                getAbstractFileSystem(),
-                this.bucket != null ? bucket : storage.get(bucketName),
-                b));
+            getAbstractFileSystem()
+                .resolveFile(
+                    getName().getPath() + "/" + lastPathElement(stripTrailingSlash(b.getName()))));
       }
       if (!cacheEntries.isEmpty()) {
         getAbstractFileSystem().putListCache(bucketName, prefix, cacheEntries);

--- a/plugins/tech/google/src/main/java/org/apache/hop/vfs/gs/GoogleStorageFileObject.java
+++ b/plugins/tech/google/src/main/java/org/apache/hop/vfs/gs/GoogleStorageFileObject.java
@@ -374,12 +374,8 @@ public class GoogleStorageFileObject extends AbstractFileObject<GoogleStorageFil
       } else {
         page = storage.list(bucketName, BlobListOption.currentDirectory());
       }
-      String selfName = bucketPath.isEmpty() ? "" : appendTrailingSlash(bucketPath);
       Map<String, GoogleStorageListCache.ChildInfo> cacheEntries = new LinkedHashMap<>();
       for (Blob b : page.iterateAll()) {
-        if (b.getName().equals(selfName)) {
-          continue;
-        }
         if (this.blob != null && b.getName().equals(this.blob.getName())) {
           continue;
         }

--- a/plugins/tech/google/src/main/java/org/apache/hop/vfs/gs/GoogleStorageFileObject.java
+++ b/plugins/tech/google/src/main/java/org/apache/hop/vfs/gs/GoogleStorageFileObject.java
@@ -19,6 +19,7 @@
 package org.apache.hop.vfs.gs;
 
 import com.google.api.gax.paging.Page;
+import com.google.api.gax.rpc.NotFoundException;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
@@ -235,9 +236,8 @@ public class GoogleStorageFileObject extends AbstractFileObject<GoogleStorageFil
   @Override
   protected void doDelete() throws Exception {
     if (hasObject()) {
-      boolean isDirectory = blob.isDirectory();
       blob.delete();
-      if (isDirectory && isHnsEnabled()) {
+      if (isHnsEnabled()) {
         handleHnsDirectoryDeletion(stripLeadingSlash(bucketPath));
       }
     } else if (bucketName != null
@@ -245,19 +245,37 @@ public class GoogleStorageFileObject extends AbstractFileObject<GoogleStorageFil
         && bucketPath != null
         && !bucketPath.isEmpty()) {
       Storage storage = getAbstractFileSystem().setupStorage();
-      storage.delete(BlobId.of(bucketName, stripLeadingSlash(bucketPath)));
+      String path = stripLeadingSlash(bucketPath);
+      Blob found = findBlob(storage, path);
+      if (found != null) {
+        found.delete();
+      }
+      if (isHnsEnabled()) {
+        handleHnsDirectoryDeletion(path);
+      }
     } else {
       throw new IOException("Cannot delete: missing bucket/object path for '" + this + "'");
     }
     getAbstractFileSystem().invalidateListCacheForParentOf(bucketName, bucketPath);
   }
 
+  private Blob findBlob(Storage storage, String path) {
+    Blob found = storage.get(BlobId.of(bucketName, path));
+    if (found == null) {
+      found = storage.get(BlobId.of(bucketName, path + "/"));
+    }
+    return found;
+  }
+
   private void handleHnsDirectoryDeletion(String path) throws IOException {
     String folderName = FolderName.format("_", bucketName, stripTrailingSlash(path));
-    try (StorageControlClient controlClient = StorageControlClient.create()) {
+    try {
+      StorageControlClient controlClient = getAbstractFileSystem().getStorageControlClient();
       DeleteFolderRequest folderRequest =
           DeleteFolderRequest.newBuilder().setName(folderName).build();
       controlClient.deleteFolder(folderRequest);
+    } catch (NotFoundException e) {
+      // Not an HNS folder, skip.
     }
   }
 
@@ -339,7 +357,7 @@ public class GoogleStorageFileObject extends AbstractFileObject<GoogleStorageFil
     if (!hasBucket()) {
       Page<Bucket> page = storage.list();
       for (Bucket b : page.iterateAll()) {
-        results.add(getAbstractFileSystem().resolveFile(b.getName()));
+        results.add(getAbstractFileSystem().resolveFile("/" + b.getName()));
       }
     } else {
       String prefix;
@@ -356,8 +374,12 @@ public class GoogleStorageFileObject extends AbstractFileObject<GoogleStorageFil
       } else {
         page = storage.list(bucketName, BlobListOption.currentDirectory());
       }
+      String selfName = bucketPath.isEmpty() ? "" : appendTrailingSlash(bucketPath);
       Map<String, GoogleStorageListCache.ChildInfo> cacheEntries = new LinkedHashMap<>();
       for (Blob b : page.iterateAll()) {
+        if (b.getName().equals(selfName)) {
+          continue;
+        }
         if (this.blob != null && b.getName().equals(this.blob.getName())) {
           continue;
         }
@@ -369,10 +391,7 @@ public class GoogleStorageFileObject extends AbstractFileObject<GoogleStorageFil
                 : Instant.EPOCH;
         cacheEntries.put(
             b.getName(), new GoogleStorageListCache.ChildInfo(childType, childSize, childLastMod));
-        results.add(
-            getAbstractFileSystem()
-                .resolveFile(
-                    getName().getPath() + "/" + lastPathElement(stripTrailingSlash(b.getName()))));
+        results.add(getAbstractFileSystem().resolveFile(bucketName + "/" + b.getName()));
       }
       if (!cacheEntries.isEmpty()) {
         getAbstractFileSystem().putListCache(bucketName, prefix, cacheEntries);

--- a/plugins/tech/google/src/main/java/org/apache/hop/vfs/gs/GoogleStorageFileObject.java
+++ b/plugins/tech/google/src/main/java/org/apache/hop/vfs/gs/GoogleStorageFileObject.java
@@ -204,6 +204,9 @@ public class GoogleStorageFileObject extends AbstractFileObject<GoogleStorageFil
       }
       Map<String, GoogleStorageListCache.ChildInfo> cacheEntries = new LinkedHashMap<>();
       for (Blob b : page.iterateAll()) {
+        if (stripTrailingSlash(b.getName()).equals(stripTrailingSlash(bucketPath))) {
+          continue;
+        }
         results.add(lastPathElement(stripTrailingSlash(b.getName())));
         FileType childType = b.isDirectory() ? FileType.FOLDER : FileType.FILE;
         long childSize = b.getSize() != null ? b.getSize() : 0L;
@@ -376,7 +379,7 @@ public class GoogleStorageFileObject extends AbstractFileObject<GoogleStorageFil
       }
       Map<String, GoogleStorageListCache.ChildInfo> cacheEntries = new LinkedHashMap<>();
       for (Blob b : page.iterateAll()) {
-        if (this.blob != null && b.getName().equals(this.blob.getName())) {
+        if (stripTrailingSlash(b.getName()).equals(stripTrailingSlash(bucketPath))) {
           continue;
         }
         FileType childType = b.isDirectory() ? FileType.FOLDER : FileType.FILE;
@@ -387,7 +390,9 @@ public class GoogleStorageFileObject extends AbstractFileObject<GoogleStorageFil
                 : Instant.EPOCH;
         cacheEntries.put(
             b.getName(), new GoogleStorageListCache.ChildInfo(childType, childSize, childLastMod));
-        results.add(getAbstractFileSystem().resolveFile(bucketName + "/" + b.getName()));
+        results.add(
+            getAbstractFileSystem()
+                .resolveFile("/" + bucketName + "/" + stripTrailingSlash(b.getName())));
       }
       if (!cacheEntries.isEmpty()) {
         getAbstractFileSystem().putListCache(bucketName, prefix, cacheEntries);

--- a/plugins/tech/google/src/main/java/org/apache/hop/vfs/gs/GoogleStorageFileSystem.java
+++ b/plugins/tech/google/src/main/java/org/apache/hop/vfs/gs/GoogleStorageFileSystem.java
@@ -18,10 +18,14 @@
 
 package org.apache.hop.vfs.gs;
 
+import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.cloud.http.HttpTransportOptions;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
+import com.google.storage.control.v2.StorageControlClient;
+import com.google.storage.control.v2.StorageControlSettings;
+import java.io.IOException;
 import java.util.Collection;
 import org.apache.commons.vfs2.Capability;
 import org.apache.commons.vfs2.FileName;
@@ -38,6 +42,7 @@ import org.threeten.bp.Duration;
 public class GoogleStorageFileSystem extends AbstractFileSystem {
 
   Storage storage = null;
+  StorageControlClient storageControlClient = null;
   FileSystemOptions fileSystemOptions;
 
   private GoogleStorageListCache listCache;
@@ -149,5 +154,20 @@ public class GoogleStorageFileSystem extends AbstractFileSystem {
     } else {
       return "";
     }
+  }
+
+  StorageControlClient getStorageControlClient() throws IOException {
+    if (storageControlClient != null) {
+      return storageControlClient;
+    }
+    StorageControlSettings settings =
+        StorageControlSettings.newBuilder()
+            .setCredentialsProvider(
+                FixedCredentialsProvider.create(
+                    GoogleStorageFileSystemConfigBuilder.getInstance()
+                        .getGoogleCredentials(fileSystemOptions)))
+            .build();
+    storageControlClient = StorageControlClient.create(settings);
+    return storageControlClient;
   }
 }


### PR DESCRIPTION
fixes #7212

Fix for HNS Enabled Buckets - Requires the GCS Storage Control Client. Blob.delete deletes the folder marker, then the control client makes a request to delete the hns folder.

Fix for both HNS Disabled Buckets / HNS Enabled - doDelete was never called for folders, required the listchildrenresolved method to use AbstractFileSystem's resolveFile method instead of instantiating new FileObjects.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
