### PR TITLE
Fix vertical alignment of separator row in Text File Input dialog

### DIFF
--- a/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/fileinput/text/TextFileInputDialog.java
+++ b/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/fileinput/text/TextFileInputDialog.java
@@ -917,13 +917,13 @@ public class TextFileInputDialog extends BaseTransformDialog
     PropsUi.setLook(wbSeparator);
     FormData fdbSeparator = new FormData();
     fdbSeparator.right = new FormAttachment(100, 0);
-    fdbSeparator.top = new FormAttachment(wFiletype, 0);
+    fdbSeparator.top = new FormAttachment(wlSeparator, 0, SWT.CENTER);
     wbSeparator.setLayoutData(fdbSeparator);
     wSeparator = new TextVar(variables, wContentComp, SWT.SINGLE | SWT.LEFT | SWT.BORDER);
     PropsUi.setLook(wSeparator);
     wSeparator.addModifyListener(lsMod);
     FormData fdSeparator = new FormData();
-    fdSeparator.top = new FormAttachment(wFiletype, margin);
+    fdSeparator.top = new FormAttachment(wlSeparator, 0, SWT.CENTER);
     fdSeparator.left = new FormAttachment(middle, 0);
     fdSeparator.right = new FormAttachment(wbSeparator, -margin);
     wSeparator.setLayoutData(fdSeparator);


### PR DESCRIPTION
Fixes misaligned controls on the separator row in the Text File Input transform dialog (Content tab). The separator label, text field, and delimiter button were not vertically aligned because the button was anchored to the top of the file type combo without margin, while the label and `TextVar` field used a margin offset from the same control.
