### PR TITLE
Fix MetaInject template path when exporting resources

### DIFF
--- a/plugins/transforms/metainject/src/main/java/org/apache/hop/pipeline/transforms/metainject/MetaInjectMeta.java
+++ b/plugins/transforms/metainject/src/main/java/org/apache/hop/pipeline/transforms/metainject/MetaInjectMeta.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.annotations.ActionTransformType;
 import org.apache.hop.core.annotations.Transform;
 import org.apache.hop.core.exception.HopException;
@@ -264,13 +265,19 @@ public class MetaInjectMeta extends BaseTransformMeta<MetaInject, MetaInjectData
           executorPipelineMeta.exportResources(
               variables, definitions, resourceNamingInterface, metadataProvider);
 
+      // To get a relative path to it, we inject
+      // ${Internal.Entry.Current.Directory}
+      //
+      String newFilename =
+          "${" + Const.INTERNAL_VARIABLE_ENTRY_CURRENT_FOLDER + "}/" + proposedNewFilename;
+
       // Set the correct filename inside the XML.
       //
-      executorPipelineMeta.setFilename(proposedNewFilename);
+      executorPipelineMeta.setFilename(newFilename);
 
       // change it in the entry
       //
-      templateFileName = proposedNewFilename;
+      templateFileName = newFilename;
 
       return proposedNewFilename;
     } catch (Exception e) {

--- a/plugins/transforms/metainject/src/test/java/org/apache/hop/pipeline/transforms/metainject/MetaInjectMetaTest.java
+++ b/plugins/transforms/metainject/src/test/java/org/apache/hop/pipeline/transforms/metainject/MetaInjectMetaTest.java
@@ -21,9 +21,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import org.apache.hop.core.Const;
+import org.apache.hop.core.exception.HopException;
 import org.apache.hop.core.plugins.PluginRegistry;
 import org.apache.hop.core.row.IValueMeta;
 import org.apache.hop.core.row.value.ValueMetaDate;
@@ -33,12 +40,24 @@ import org.apache.hop.core.row.value.ValueMetaNumber;
 import org.apache.hop.core.row.value.ValueMetaPlugin;
 import org.apache.hop.core.row.value.ValueMetaPluginType;
 import org.apache.hop.core.row.value.ValueMetaString;
+import org.apache.hop.core.variables.IVariables;
+import org.apache.hop.metadata.api.IHopMetadataProvider;
 import org.apache.hop.metadata.inject.HopMetadataInjector;
+import org.apache.hop.pipeline.PipelineMeta;
 import org.apache.hop.pipeline.transform.TransformSerializationTestUtil;
+import org.apache.hop.resource.IResourceNaming;
+import org.apache.hop.resource.ResourceDefinition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class MetaInjectMetaTest {
+
+  private static final String TEST_FILE_NAME = "TEST_FILE_NAME";
+
+  private static final String EXPORTED_FILE_NAME =
+      "${" + Const.INTERNAL_VARIABLE_ENTRY_CURRENT_FOLDER + "}/" + TEST_FILE_NAME;
+
+  private static MetaInjectMeta metaInjectMeta;
 
   @BeforeEach
   void beforeEach() throws Exception {
@@ -53,6 +72,7 @@ class MetaInjectMetaTest {
     for (String className : classNames) {
       registry.registerPluginClass(className, ValueMetaPluginType.class, ValueMetaPlugin.class);
     }
+    metaInjectMeta = new MetaInjectMeta();
   }
 
   @Test
@@ -120,7 +140,7 @@ class MetaInjectMetaTest {
         injectMetaSpy.exportResources(
             variables, definitions, resourceNamingInterface, metadataProvider);
     assertEquals(TEST_FILE_NAME, actualExportedFileName);
-    assertEquals(EXPORTED_FILE_NAME, injectMetaSpy.getFileName());
+    assertEquals(EXPORTED_FILE_NAME, injectMetaSpy.getTemplateFileName());
     verify(pipelineMeta)
         .exportResources(variables, definitions, resourceNamingInterface, metadataProvider);
     verify(pipelineMeta).setFilename(EXPORTED_FILE_NAME);

--- a/plugins/transforms/metainject/src/test/java/org/apache/hop/pipeline/transforms/metainject/MetaInjectMetaTest.java
+++ b/plugins/transforms/metainject/src/test/java/org/apache/hop/pipeline/transforms/metainject/MetaInjectMetaTest.java
@@ -103,6 +103,30 @@ class MetaInjectMetaTest {
   }
 
   @Test
+  void exportResources() throws HopException {
+    IVariables variables = mock(IVariables.class);
+    IResourceNaming resourceNamingInterface = mock(IResourceNaming.class);
+    IHopMetadataProvider metadataProvider = mock(IHopMetadataProvider.class);
+
+    MetaInjectMeta injectMetaSpy = spy(metaInjectMeta);
+    PipelineMeta pipelineMeta = mock(PipelineMeta.class);
+    Map<String, ResourceDefinition> definitions = Collections.emptyMap();
+    doReturn(TEST_FILE_NAME)
+        .when(pipelineMeta)
+        .exportResources(variables, definitions, resourceNamingInterface, metadataProvider);
+    doReturn(pipelineMeta).when(injectMetaSpy).loadPipelineMeta(metadataProvider, variables);
+
+    String actualExportedFileName =
+        injectMetaSpy.exportResources(
+            variables, definitions, resourceNamingInterface, metadataProvider);
+    assertEquals(TEST_FILE_NAME, actualExportedFileName);
+    assertEquals(EXPORTED_FILE_NAME, injectMetaSpy.getFileName());
+    verify(pipelineMeta)
+        .exportResources(variables, definitions, resourceNamingInterface, metadataProvider);
+    verify(pipelineMeta).setFilename(EXPORTED_FILE_NAME);
+  }
+
+  @Test
   void testSampleMetaMapping() throws Exception {
     Map<String, Set<String>> map = HopMetadataInjector.findInjectionGroupKeys(MetaInjectMeta.class);
     assertNotNull(map);

--- a/plugins/transforms/metainject/src/test/java/org/apache/hop/pipeline/transforms/metainject/MetaInjectTest.java
+++ b/plugins/transforms/metainject/src/test/java/org/apache/hop/pipeline/transforms/metainject/MetaInjectTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.hop.core.RowMetaAndData;
+import org.apache.hop.core.exception.HopException;
 import org.apache.hop.core.injection.Injection;
 import org.apache.hop.core.injection.InjectionSupported;
 import org.apache.hop.core.logging.LogChannel;
@@ -57,53 +58,30 @@ import org.mockito.Mockito;
 class MetaInjectTest {
 
   private static final String INJECTOR_TRANSFORM_NAME = "TEST_TRANSFORM_FOR_INJECTION";
-
   private static final String TEST_VALUE = "TEST_VALUE";
-
-  private static final String TEST_VARIABLE = "TEST_VARIABLE";
-
-  private static final String TEST_PARAMETER = "TEST_PARAMETER";
-
   private static final String TEST_TARGET_TRANSFORM_NAME = "TEST_TARGET_TRANSFORM_NAME";
-
   private static final String TEST_SOURCE_TRANSFORM_NAME = "TEST_SOURCE_TRANSFORM_NAME";
-
-  private static final String TEST_ATTR_VALUE = "TEST_ATTR_VALUE";
-
   private static final String TEST_FIELD = "TEST_FIELD";
-
-  private static final String UNAVAILABLE_TRANSFORM = "UNAVAILABLE_TRANSFORM";
-
   private MetaInject metaInject;
-
-  private MetaInjectMeta meta;
-
-  private MetaInjectData data;
-
   private PipelineMeta pipelineMeta;
-
-  private Pipeline pipeline;
-
-  private IHopMetadataProvider metadataProvider;
 
   @BeforeEach
   void before() throws Exception {
     pipelineMeta = Mockito.spy(new PipelineMeta());
-    meta = new MetaInjectMeta();
-    data = new MetaInjectData();
+    MetaInjectData data = new MetaInjectData();
     data.pipelineMeta = pipelineMeta;
     metaInject =
         TransformMockUtil.getTransform(
             MetaInject.class, MetaInjectMeta.class, MetaInjectData.class, "MetaInjectTest");
     metaInject = Mockito.spy(metaInject);
     metaInject.init();
-    metadataProvider = mock(IHopMetadataProvider.class);
+    IHopMetadataProvider metadataProvider = mock(IHopMetadataProvider.class);
     metaInject.setMetadataProvider(metadataProvider);
     doReturn(pipelineMeta).when(metaInject).getPipelineMeta();
 
     PipelineMeta internalPipelineMeta = mock(PipelineMeta.class);
     TransformMeta transformMeta = mock(TransformMeta.class);
-    pipeline = new LocalPipelineEngine();
+    Pipeline pipeline = new LocalPipelineEngine();
     pipeline.setLogChannel(LogChannel.GENERAL);
     pipeline = Mockito.spy(pipeline);
     doReturn(pipeline).when(metaInject).getPipeline();
@@ -134,7 +112,7 @@ class MetaInjectTest {
   }
 
   @Test
-  void testTransformChangeListener() throws Exception {
+  void testTransformChangeListener() {
     MetaInjectMeta mim = new MetaInjectMeta();
     TransformMeta sm = new TransformMeta("testTransform", mim);
     try {
@@ -150,7 +128,7 @@ class MetaInjectTest {
    * {@code @InjectionSupported} template transform.
    */
   @Test
-  void newInjectionConstants_injectsConstantWithoutSourceTransform() throws Exception {
+  void newInjectionConstants_injectsConstantWithoutSourceTransform() throws HopException {
     InjectableTestTransformMeta targetMeta = new InjectableTestTransformMeta();
 
     // A "constant" mapping has no source transform; the literal value to inject is held in the
@@ -384,16 +362,6 @@ class MetaInjectTest {
     assertEquals("renamed1", groupBuffer.getBuffer().get(0)[1]);
     assertEquals("field2", groupBuffer.getBuffer().get(1)[0]);
     assertEquals("renamed2", groupBuffer.getBuffer().get(1)[1]);
-  }
-
-  private PipelineMeta mockSingleTransformPipelineMeta(
-      final String targetTransformName, ITransformMeta smi) {
-    TransformMeta transformMeta = mock(TransformMeta.class);
-    when(transformMeta.getTransform()).thenReturn(smi);
-    when(transformMeta.getName()).thenReturn(targetTransformName);
-    PipelineMeta pipelineMeta = mock(PipelineMeta.class);
-    when(pipelineMeta.getUsedTransforms()).thenReturn(Collections.singletonList(transformMeta));
-    return pipelineMeta;
   }
 
   @InjectionSupported(localizationPrefix = "", groups = "groups")


### PR DESCRIPTION
ETL Metadata Injection exported its template pipeline as a bare filename.
When executed remotely from an exported package, Hop Server could not resolve
that template inside the package ZIP.

This aligns MetaInject with other nested pipeline/workflow exporters by using
${Internal.Entry.Current.Folder}/<exported-file>.

**Issues**
Fixes https://github.com/apache/hop/issues/4267