### PR TITLE
Clean up core XML serializers

### DIFF
--- a/core/src/main/java/org/apache/hop/core/Result.java
+++ b/core/src/main/java/org/apache/hop/core/Result.java
@@ -343,24 +343,28 @@ public class Result implements Cloneable {
       // Export the result files
       //
       xml.append(XmlHandler.openTag(XML_FILES_TAG));
-      for (ResultFile resultFile : resultFiles.values()) {
-        xml.append(resultFile.getXml());
+      if (resultFiles != null) {
+        for (ResultFile resultFile : resultFiles.values()) {
+          xml.append(resultFile.getXml());
+        }
       }
       xml.append(XmlHandler.closeTag(XML_FILES_TAG));
 
       xml.append(XmlHandler.openTag(XML_ROWS_TAG));
-      boolean firstRow = true;
-      IRowMeta rowMeta = null;
-      for (RowMetaAndData row : rows) {
-        if (firstRow) {
-          firstRow = false;
-          rowMeta = row.getRowMeta();
-          if (rowMeta != null) {
-            xml.append(rowMeta.getMetaXml());
+      if (rows != null) {
+        boolean firstRow = true;
+        IRowMeta rowMeta = null;
+        for (RowMetaAndData row : rows) {
+          if (firstRow) {
+            firstRow = false;
+            rowMeta = row.getRowMeta();
+            if (rowMeta != null) {
+              xml.append(rowMeta.getMetaXml());
+            }
           }
-        }
-        if (rowMeta != null) {
-          xml.append(rowMeta.getDataXml(row.getData()));
+          if (rowMeta != null) {
+            xml.append(rowMeta.getDataXml(row.getData()));
+          }
         }
       }
       xml.append(XmlHandler.closeTag(XML_ROWS_TAG));

--- a/core/src/main/java/org/apache/hop/core/ResultFile.java
+++ b/core/src/main/java/org/apache/hop/core/ResultFile.java
@@ -271,14 +271,17 @@ public class ResultFile implements Cloneable {
   @JsonIgnore
   public String getXml() {
 
-    return XmlHandler.openTag(XML_TAG)
-        + XmlHandler.addTagValue("type", getTypeCode())
-        + XmlHandler.addTagValue("file", file.getName().toString())
-        + XmlHandler.addTagValue(CONST_PARENT_ORIGIN, originParent)
-        + XmlHandler.addTagValue(CONST_ORIGIN, origin)
-        + XmlHandler.addTagValue(CONST_COMMENT, comment)
-        + XmlHandler.addTagValue(CONST_TIMESTAMP, timestamp)
-        + XmlHandler.closeTag(XML_TAG);
+    StringBuilder xml = new StringBuilder(256);
+    xml.append(XmlHandler.openTag(XML_TAG));
+    xml.append(XmlHandler.addTagValue("type", getTypeCode()));
+    xml.append(XmlHandler.addTagValue("file", file.getName().toString()));
+    xml.append(XmlHandler.addTagValue(CONST_PARENT_ORIGIN, originParent));
+    xml.append(XmlHandler.addTagValue(CONST_ORIGIN, origin));
+    xml.append(XmlHandler.addTagValue(CONST_COMMENT, comment));
+    xml.append(XmlHandler.addTagValue(CONST_TIMESTAMP, timestamp));
+    xml.append(XmlHandler.closeTag(XML_TAG));
+
+    return xml.toString();
   }
 
   public ResultFile(Node node) throws HopFileException {

--- a/core/src/main/java/org/apache/hop/core/row/ValueMetaAndData.java
+++ b/core/src/main/java/org/apache/hop/core/row/ValueMetaAndData.java
@@ -119,24 +119,24 @@ public class ValueMetaAndData {
     meta.setGroupingSymbol(null);
     meta.setCurrencySymbol(null);
 
-    StringBuilder retval = new StringBuilder(128);
-    retval.append("<" + XML_TAG + ">");
-    retval.append(XmlHandler.addTagValue("name", meta.getName(), false));
-    retval.append(XmlHandler.addTagValue("type", meta.getTypeDesc(), false));
+    StringBuilder xml = new StringBuilder(128);
+    xml.append(XmlHandler.openTag(XML_TAG));
+    xml.append(XmlHandler.addTagValue("name", meta.getName(), false));
+    xml.append(XmlHandler.addTagValue("type", meta.getTypeDesc(), false));
 
-    retval.append(XmlHandler.addTagValue("length", meta.getLength(), false));
-    retval.append(XmlHandler.addTagValue("precision", meta.getPrecision(), false));
-    retval.append(XmlHandler.addTagValue("mask", meta.getConversionMask(), false));
+    xml.append(XmlHandler.addTagValue("length", meta.getLength(), false));
+    xml.append(XmlHandler.addTagValue("precision", meta.getPrecision(), false));
+    xml.append(XmlHandler.addTagValue("mask", meta.getConversionMask(), false));
 
     try {
-      retval.append(XmlHandler.addTagValue("text", meta.getCompatibleString(valueData), false));
+      xml.append(XmlHandler.addTagValue("text", meta.getCompatibleString(valueData), false));
     } catch (HopValueException e) {
-      retval.append(XmlHandler.addTagValue("text", "", false));
+      xml.append(XmlHandler.addTagValue("text", "", false));
     }
-    retval.append(XmlHandler.addTagValue("isnull", meta.isNull(valueData), false));
-    retval.append("</" + XML_TAG + ">");
+    xml.append(XmlHandler.addTagValue("isnull", meta.isNull(valueData), false));
+    xml.append(XmlHandler.closeTag(XML_TAG));
 
-    return retval.toString();
+    return xml.toString();
   }
 
   /**

--- a/core/src/test/java/org/apache/hop/core/ResultFileTest.java
+++ b/core/src/test/java/org/apache/hop/core/ResultFileTest.java
@@ -31,11 +31,13 @@ import org.apache.hop.core.exception.HopFileException;
 import org.apache.hop.core.row.IRowMeta;
 import org.apache.hop.core.row.IValueMeta;
 import org.apache.hop.core.vfs.HopVfs;
+import org.apache.hop.core.xml.XmlHandler;
 import org.apache.hop.junit.rules.RestoreHopEnvironmentExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Node;
 
 @ExtendWith(RestoreHopEnvironmentExtension.class)
 class ResultFileTest {
@@ -74,6 +76,28 @@ class ResultFileTest {
         timeBeforeFile.compareTo(resultFile.getTimestamp()) <= 0
             && timeAfterFile.compareTo(resultFile.getTimestamp()) >= 0,
         "ResultFile timestamp is created in the expected window");
+
+    tempFile.delete();
+  }
+
+  @Test
+  void testGetXmlRoundTrip() throws Exception {
+    File tempDir = tempDirPath.toFile();
+    FileObject tempFile = HopVfs.createTempFile("prefix", "suffix", tempDir.getAbsolutePath());
+    ResultFile resultFile =
+        new ResultFile(ResultFile.FILE_TYPE_WARNING, tempFile, "parent & one", "origin <two>");
+    resultFile.setComment("comment & <tag>");
+
+    String xml = resultFile.getXml();
+    Node node = XmlHandler.loadXmlString(xml, "result-file");
+    ResultFile copy = new ResultFile(node);
+
+    assertEquals(resultFile.getType(), copy.getType());
+    assertEquals(resultFile.getFile().getName().toString(), copy.getFile().getName().toString());
+    assertEquals(resultFile.getOriginParent(), copy.getOriginParent());
+    assertEquals(resultFile.getOrigin(), copy.getOrigin());
+    assertEquals(resultFile.getComment(), copy.getComment());
+    assertEquals(resultFile.getTimestamp(), copy.getTimestamp());
 
     tempFile.delete();
   }

--- a/core/src/test/java/org/apache/hop/core/ResultTest.java
+++ b/core/src/test/java/org/apache/hop/core/ResultTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.hop.core.xml.XmlHandler;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Node;
+
+class ResultTest {
+
+  @Test
+  void getXmlHandlesLightCloneWithoutRows() throws Exception {
+    Result result = new Result();
+    result.setNrErrors(2);
+    result.setLogText("log text");
+
+    String xml = result.lightClone().getXml();
+    Node node = XmlHandler.loadXmlString(xml, Result.XML_TAG);
+    Result copy = new Result(node);
+
+    assertEquals(2, copy.getNrErrors());
+    assertEquals("log text", copy.getLogText());
+    assertEquals(0, copy.getRows().size());
+    assertEquals(0, copy.getResultFiles().size());
+  }
+}

--- a/core/src/test/java/org/apache/hop/core/row/ValueMetaAndDataTests.java
+++ b/core/src/test/java/org/apache/hop/core/row/ValueMetaAndDataTests.java
@@ -23,6 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import java.math.BigDecimal;
 import java.util.Date;
+import org.apache.hop.core.HopClientEnvironment;
+import org.apache.hop.core.exception.HopException;
 import org.apache.hop.core.row.value.ValueMetaBigNumber;
 import org.apache.hop.core.row.value.ValueMetaBinary;
 import org.apache.hop.core.row.value.ValueMetaBoolean;
@@ -31,10 +33,18 @@ import org.apache.hop.core.row.value.ValueMetaInteger;
 import org.apache.hop.core.row.value.ValueMetaNumber;
 import org.apache.hop.core.row.value.ValueMetaSerializable;
 import org.apache.hop.core.row.value.ValueMetaString;
+import org.apache.hop.core.xml.XmlHandler;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.w3c.dom.Node;
 
 /** Unit test for {@link ValueMetaAndData} */
 class ValueMetaAndDataTests {
+
+  @BeforeAll
+  static void beforeClassSetUp() throws HopException {
+    HopClientEnvironment.init();
+  }
 
   @Test
   void testStringType() {
@@ -102,5 +112,18 @@ class ValueMetaAndDataTests {
 
     assertInstanceOf(ValueMetaSerializable.class, vm.getValueMeta());
     assertEquals(obj, vm.getValueData());
+  }
+
+  @Test
+  void testGetXmlRoundTrip() throws Exception {
+    ValueMetaAndData vm = new ValueMetaAndData(new ValueMetaString("field"), "value & <tag>");
+
+    String xml = vm.getXml();
+    Node node = XmlHandler.loadXmlString(xml, ValueMetaAndData.XML_TAG);
+    ValueMetaAndData copy = new ValueMetaAndData(node);
+
+    assertInstanceOf(ValueMetaString.class, copy.getValueMeta());
+    assertEquals("field", copy.getValueMeta().getName());
+    assertEquals("value & <tag>", copy.getValueData());
   }
 }


### PR DESCRIPTION
## Summary

This cleans up the XML serialization code for three core classes:

- `Result.getXml()`
- `ResultFile.getXml()`
- `ValueMetaAndData.getXml()`

The serializers now use `StringBuilder` and `XmlHandler.openTag(...)` / `XmlHandler.closeTag(...)` consistently instead of mixing helper calls with manual string concatenation.

While updating `Result.getXml()`, I also made it safe for `Result.lightClone()`. A light clone intentionally does not copy rows, so `getXml()` should still be able to emit an empty `<result-rows>` section instead of assuming the rows list is always present.

## Testing

Focused core tests:

```powershell
.\mvnw.cmd -pl core -Dtest=ResultTest,ResultFileTest,ValueMetaAndDataTests test
```

Result:

```text
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Whitespace check:

```powershell
git show --check --oneline --summary HEAD
```

Result:

```text
1c5d40db Clean up core XML serializers
```

## Issues

Fixes #6951
Fixes #6952
Fixes #6953

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [ ] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).