### PR TITLE
Show Apache Hop version in Hop GUI and Hop Web window titles

### DIFF
--- a/rap/src/main/java/org/apache/hop/ui/hopgui/HopWeb.java
+++ b/rap/src/main/java/org/apache/hop/ui/hopgui/HopWeb.java
@@ -35,6 +35,7 @@ import org.apache.batik.transcoder.image.PNGTranscoder;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hop.core.Const;
+import org.apache.hop.core.HopVersionProvider;
 import org.apache.hop.core.exception.HopRuntimeException;
 import org.apache.hop.core.gui.plugin.GuiRegistry;
 import org.apache.hop.core.gui.plugin.toolbar.GuiToolbarItem;
@@ -55,6 +56,24 @@ import org.eclipse.rap.rwt.service.ResourceLoader;
 public class HopWeb implements ApplicationConfiguration {
 
   public static final String CONST_LIGHT = "light";
+
+  private static final String WEB_PAGE_TITLE = "Apache Hop Web";
+
+  /**
+   * Returns the browser page title for Hop Web, including the Apache Hop version when it is
+   * available from the runtime manifest ({@link HopVersionProvider}). If no implementation version
+   * is present, only {@link #WEB_PAGE_TITLE} is returned.
+   *
+   * @return page title such as {@code Apache Hop Web - 2.19.0-SNAPSHOT}, or {@code Apache Hop Web}
+   *     when the version is unknown
+   */
+  private static String getWebPageTitle() {
+    String version = new HopVersionProvider().getVersion()[0];
+    if (StringUtils.isNotEmpty(version)) {
+      return WEB_PAGE_TITLE + " - " + version;
+    }
+    return WEB_PAGE_TITLE;
+  }
 
   @Override
   public void configure(Application application) {
@@ -149,14 +168,16 @@ public class HopWeb implements ApplicationConfiguration {
     application.addStyleSheet("dark", "org/apache/hop/ui/hopgui/dark-mode.css");
     application.addStyleSheet(CONST_LIGHT, "org/apache/hop/ui/hopgui/light-mode.css");
 
+    String webPageTitle = getWebPageTitle();
+
     Map<String, String> propertiesLight = new HashMap<>();
-    propertiesLight.put(WebClient.PAGE_TITLE, "Apache Hop Web");
+    propertiesLight.put(WebClient.PAGE_TITLE, webPageTitle);
     propertiesLight.put(WebClient.FAVICON, "ui/images/logo_icon.png");
     propertiesLight.put(WebClient.THEME_ID, CONST_LIGHT);
     propertiesLight.put(WebClient.HEAD_HTML, readTextFromResource("head.html"));
 
     Map<String, String> propertiesDark = new HashMap<>();
-    propertiesDark.put(WebClient.PAGE_TITLE, "Apache Hop Web");
+    propertiesDark.put(WebClient.PAGE_TITLE, webPageTitle);
     propertiesDark.put(WebClient.FAVICON, "ui/images/logo_icon.png");
     propertiesDark.put(WebClient.THEME_ID, "dark");
     propertiesDark.put(WebClient.HEAD_HTML, readTextFromResource("head.html"));

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/HopGui.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/HopGui.java
@@ -40,6 +40,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hop.core.Const;
 import org.apache.hop.core.DbCache;
 import org.apache.hop.core.HopEnvironment;
+import org.apache.hop.core.HopVersionProvider;
 import org.apache.hop.core.Props;
 import org.apache.hop.core.config.DescribedVariablesConfigFile;
 import org.apache.hop.core.config.HopConfig;
@@ -446,6 +447,23 @@ public class HopGui
     }
   }
 
+  /**
+   * Returns the main window title, including the Apache Hop version when it is available from the
+   * runtime manifest ({@link HopVersionProvider}). If no implementation version is present (for
+   * example when running from the IDE classpath), only the localized application name is returned.
+   *
+   * @return window title such as {@code Hop - 2.19.0}, or {@code Hop} when the version is unknown
+   */
+  protected String getApplicationWindowTitle() {
+    String appName = BaseMessages.getString(PKG, "HopGui.Application.Name");
+    String version = new HopVersionProvider().getVersion()[0];
+    if (StringUtils.isNotEmpty(version)) {
+      return appName + " - " + version;
+    }
+
+    return appName;
+  }
+
   /** Build the shell */
   protected void open() {
     // Hand Windows a multi-resolution icon set so it can pick the right size for each slot
@@ -475,7 +493,7 @@ public class HopGui
 
     PropsUi.setLook(shell);
 
-    shell.setText(BaseMessages.getString(PKG, "HopGui.Application.Name"));
+    shell.setText(getApplicationWindowTitle());
     addMainMenu();
     addMainToolbar();
     addStatusToolbar();


### PR DESCRIPTION
Fix https://github.com/apache/hop/issues/7223

- Add `getApplicationWindowTitle()` in `HopGui` so the desktop main window title includes the runtime version from `HopVersionProvider` (e.g. `Hop - 2.19.0-SNAPSHOT`).
- Add `getWebPageTitle()` in `HopWeb` so the browser tab title for both `/ui` and `/ui-dark` entry points includes the same version (e.g. `Apache Hop Web - 2.19.0-SNAPSHOT`).
- Reuse the existing `HopVersionProvider` used by the About dialog; when no implementation version is available (typical IDE classpath runs), titles fall back to the previous behavior without a version suffix.
