### PR TITLE
issue #7273 : Merge Rows edge case

### DIFF
--- a/plugins/transforms/mergerows/src/main/java/org/apache/hop/pipeline/transforms/mergerows/MergeRows.java
+++ b/plugins/transforms/mergerows/src/main/java/org/apache/hop/pipeline/transforms/mergerows/MergeRows.java
@@ -123,13 +123,11 @@ public class MergeRows extends BaseTransform<MergeRowsMeta, MergeRowsData> {
       data.passThroughIndexes = new ArrayList<>();
       data.oneRowMeta = data.oneRowSet.getRowMeta();
       if (data.oneRowMeta == null) {
-        data.oneRowMeta =
-            getPipelineMeta().getPrevTransformFields(this, meta.getReferenceTransform());
+        data.oneRowMeta = getPipelineMeta().getTransformFields(this, meta.getReferenceTransform());
       }
       data.twoRowMeta = data.twoRowSet.getRowMeta();
       if (data.twoRowMeta == null) {
-        data.twoRowMeta =
-            getPipelineMeta().getPrevTransformFields(this, meta.getCompareTransform());
+        data.twoRowMeta = getPipelineMeta().getTransformFields(this, meta.getCompareTransform());
       }
       for (PassThroughField field : meta.getPassThroughFields()) {
         int index;


### PR DESCRIPTION
Fix for an annoying bug issue #7273

No idea how long this has been happening but in case there are no rows yet in the input buffers the Pipeline is asked to deliver the row composition of the reference and compare inputs.
Unfortunately it asks the input of these transforms, (PrevTransformFields) NOT the output.  It's the output that enters the Merge Rows transform.   For some reason it evaded our integration tests.
