### PR TITLE
Fixes #7297: Silence MSSQL JDBC driver JUL INFO log spam in hop-run

### DIFF
--- a/engine/src/main/java/org/apache/hop/run/HopRun.java
+++ b/engine/src/main/java/org/apache/hop/run/HopRun.java
@@ -17,6 +17,8 @@
 
 package org.apache.hop.run;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
@@ -45,6 +47,12 @@ public class HopRun extends HopRunBase implements Runnable, IHasHopMetadataProvi
   }
 
   public static void main(String[] args) {
+
+    // Silence verbose JUL loggers from third-party JDBC drivers (e.g. Microsoft SQL Server)
+    // that write INFO messages to stderr via the default ConsoleHandler. Hop uses its own
+    // logging system (HopLogStore) so this JUL output is unwanted noise. (Fixes #7297)
+    //
+    silenceJulJdbcLoggers();
 
     HopRun hopRun = new HopRun();
 
@@ -143,5 +151,18 @@ public class HopRun extends HopRunBase implements Runnable, IHasHopMetadataProvi
     helpArgs[args.length] = "-h";
 
     cmd.parseArgs(helpArgs);
+  }
+
+  /**
+   * Suppress INFO-level JUL output from third-party JDBC drivers that would otherwise flood stderr
+   * via the default {@link java.util.logging.ConsoleHandler}. Hop uses its own logging subsystem
+   * ({@link HopLogStore}) so JUL console output is unwanted noise.
+   *
+   * <p>This must be called early in {@link #main(String[])} — before {@link HopEnvironment#init()}
+   * — so the loggers are silenced before any driver classes are loaded.
+   */
+  private static void silenceJulJdbcLoggers() {
+    // Microsoft SQL Server JDBC driver (com.microsoft.sqlserver.jdbc.TDSTokenHandler et al.)
+    Logger.getLogger("com.microsoft.sqlserver.jdbc").setLevel(Level.WARNING);
   }
 }


### PR DESCRIPTION
**Fixes #7297**

### Description
This PR resolves the issue where running pipelines via the CLI (`hop-run.bat` / `hop-run.sh`) results in standard error (`stderr`) being flooded with `INFO` messages from the Microsoft SQL Server JDBC driver (`com.microsoft.sqlserver.jdbc.TDSTokenHandler`). 

Because the MSSQL driver utilizes standard `java.util.logging` (JUL), its default `ConsoleHandler` routes `INFO` level logs directly to `System.err`. This creates significant noise when users attempt to redirect real errors to dedicated log files (e.g., `2> error.log`).

**What changed:**
* Added a `silenceJulJdbcLoggers()` method call as the very first execution step in `HopRun.main()`, immediately preceding `HopEnvironment.init()`.
* This sets the `com.microsoft.sqlserver.jdbc` JUL logger strictly to the `WARNING` level, effectively neutralizing the spam before any database driver classes are loaded.

**Architectural Rationale:**
While implementing the `jul-to-slf4j` bridge is a common workaround for JUL spam, it was intentionally avoided here. Apache Hop utilizes `slf4j-nop` (which discards SLF4J output natively) in favor of its custom `HopLogStore`. Additionally, the bridge is not a declared Maven dependency in the engine module. Directly targeting the noisy JUL logger level is a zero-dependency, surgical fix that avoids unnecessary abstraction overhead.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).