### PR TITLE
issue #7338 : Pipeline fails to open error-handling hop

### DIFF
--- a/core/src/main/java/org/apache/hop/metadata/serializer/xml/XmlMetadataUtil.java
+++ b/core/src/main/java/org/apache/hop/metadata/serializer/xml/XmlMetadataUtil.java
@@ -863,9 +863,6 @@ public class XmlMetadataUtil {
         break;
       }
     }
-    if (value == null) {
-      throw new HopXmlException("Unable to find object with name " + name + " in list " + listName);
-    }
     return value;
   }
 

--- a/engine/src/test/java/org/apache/hop/pipeline/PipelineMetaTest.java
+++ b/engine/src/test/java/org/apache/hop/pipeline/PipelineMetaTest.java
@@ -729,4 +729,31 @@ class PipelineMetaTest {
     ModPartitioner copyModPart = (ModPartitioner) copyPartMeta.getPartitioner();
     assertEquals("field-name", copyModPart.getFieldName());
   }
+
+  @Test
+  void testIssue7338() throws Exception {
+    String xml =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            + "<pipeline>\n"
+            + "  <transform>\n"
+            + "    <type>RowGenerator</type>\n"
+            + "    <name>100</name>\n"
+            + "  </transform>\n"
+            + "  <transform_error_handling>\n"
+            + "    <error>\n"
+            + "      <source_transform>100</source_transform>\n"
+            + "      <target_transform>NonExistentTransform</target_transform>\n"
+            + "      <is_enabled>Y</is_enabled>\n"
+            + "    </error>\n"
+            + "  </transform_error_handling>\n"
+            + "</pipeline>";
+    Node node = XmlHandler.loadXmlString(xml, PipelineMeta.XML_TAG);
+    PipelineMeta copy =
+        XmlMetadataUtil.deSerializeFromXml(node, PipelineMeta.class, metadataProvider);
+    assertNotNull(copy);
+    assertEquals(1, copy.getTransformErrorMetas().size());
+    assertNotNull(copy.getTransformErrorMetas().get(0).getSourceTransform());
+    assertEquals("100", copy.getTransformErrorMetas().get(0).getSourceTransform().getName());
+    assertNull(copy.getTransformErrorMetas().get(0).getTargetTransform());
+  }
 }


### PR DESCRIPTION
# Walkthrough - XML Deserialization Lookup Graceful Failure (Issue 7338)

We fixed an issue where loading a pipeline XML file failed with a fatal exception if an error-handling configuration referenced a target transform name that no longer exists in the pipeline (or was deleted). We changed the deserialization process to handle missing references gracefully.

## Changes Made

### Core Metadata Serialization

- Modified [XmlMetadataUtil.java](file:///home/matt/git/mattcasters/hop/core/src/main/java/org/apache/hop/metadata/serializer/xml/XmlMetadataUtil.java):
  - In `deSerializeXmlUsingNamedList(...)`, removed the throwing of `HopXmlException` when a referenced object name (e.g., in a named list such as `transforms` or `workflowActions`) cannot be found.
  - Instead, the method now returns `null`, allowing the deserialization of the parent object to finish successfully, setting the missing reference field to `null`.

### Core Engine Tests

- Added a new unit test `testIssue7338()` to [PipelineMetaTest.java](file:///home/matt/git/mattcasters/hop/engine/src/test/java/org/apache/hop/pipeline/PipelineMetaTest.java):
  - Defines an XML pipeline with an error handling block that points to a non-existent transform `NonExistentTransform`.
  - Asserts that parsing this XML completes successfully, the pipeline is loaded, and the target transform field resolves to `null` without throwing a fatal deserialization error.

## Verification & Testing

### Compilation & Tests
- Successfully ran Spotless formatting check:
  ```bash
  ./mvnw spotless:check -pl core,engine
  ```
- Executed unit tests for `core` and `engine` modules, with all 584 tests passing successfully:
  ```bash
  ./mvnw test -pl core,engine
  ```
- Executed transform integration tests successfully (exit code 0):
  ```bash
  integration-tests/scripts/run-tests.sh transforms
  ```
