### PR TITLE
issue #7266 : Conversion from PDI - In UDJE the "Java expression" column is emptied

### DIFF
--- a/plugins/transforms/janino/src/main/java/org/apache/hop/pipeline/transforms/janino/JaninoMeta.java
+++ b/plugins/transforms/janino/src/main/java/org/apache/hop/pipeline/transforms/janino/JaninoMeta.java
@@ -23,18 +23,21 @@ import lombok.Setter;
 import org.apache.hop.core.CheckResult;
 import org.apache.hop.core.ICheckResult;
 import org.apache.hop.core.annotations.Transform;
+import org.apache.hop.core.exception.HopException;
 import org.apache.hop.core.exception.HopTransformException;
 import org.apache.hop.core.row.IRowMeta;
 import org.apache.hop.core.row.IValueMeta;
 import org.apache.hop.core.row.value.ValueMetaFactory;
 import org.apache.hop.core.util.Utils;
 import org.apache.hop.core.variables.IVariables;
+import org.apache.hop.core.xml.XmlHandler;
 import org.apache.hop.i18n.BaseMessages;
 import org.apache.hop.metadata.api.HopMetadataProperty;
 import org.apache.hop.metadata.api.IHopMetadataProvider;
 import org.apache.hop.pipeline.PipelineMeta;
 import org.apache.hop.pipeline.transform.BaseTransformMeta;
 import org.apache.hop.pipeline.transform.TransformMeta;
+import org.w3c.dom.Node;
 
 @Transform(
     id = "Janino",
@@ -202,5 +205,22 @@ public class JaninoMeta extends BaseTransformMeta<Janino, JaninoData> {
   @Override
   public boolean supportsErrorHandling() {
     return true;
+  }
+
+  @Override
+  public void convertLegacyXml(Node node) throws HopException {
+    int nrCalcs = XmlHandler.countNodes(node, "formula");
+    for (int i = 0; i < nrCalcs; i++) {
+      Node calcnode = XmlHandler.getSubNodeByNr(node, "formula", i);
+      if (calcnode != null) {
+        String expression = XmlHandler.getTagValue(calcnode, "formula");
+        if (expression != null && i < functions.size()) {
+          JaninoMetaFunction fn = functions.get(i);
+          if (Utils.isEmpty(fn.getFormula())) {
+            fn.setFormula(expression);
+          }
+        }
+      }
+    }
   }
 }

--- a/plugins/transforms/janino/src/test/java/org/apache/hop/pipeline/transforms/janino/JaninoMetaTest.java
+++ b/plugins/transforms/janino/src/test/java/org/apache/hop/pipeline/transforms/janino/JaninoMetaTest.java
@@ -340,4 +340,42 @@ class JaninoMetaTest {
   void supportsErrorHandling_returnsTrue() {
     assertTrue(new JaninoMeta().supportsErrorHandling());
   }
+
+  // ------------------------------------------------------------------ convertLegacyXml
+
+  @Test
+  void testConvertLegacyXml() throws Exception {
+    String xml =
+        "<transform>"
+            + "    <formula>"
+            + "        <field_name>f1</field_name>"
+            + "        <formula>expression1</formula>"
+            + "        <value_type>String</value_type>"
+            + "        <value_length>100</value_length>"
+            + "        <value_precision>-1</value_precision>"
+            + "        <replace_field>replace1</replace_field>"
+            + "    </formula>"
+            + "    <formula>"
+            + "        <field_name>f2</field_name>"
+            + "        <formula>expression2</formula>"
+            + "        <value_type>Integer</value_type>"
+            + "        <value_length>7</value_length>"
+            + "        <value_precision>-1</value_precision>"
+            + "        <replace_field>replace2</replace_field>"
+            + "    </formula>"
+            + "</transform>";
+
+    JaninoMeta meta = new JaninoMeta();
+    XmlMetadataUtil.deSerializeFromXml(
+        XmlHandler.loadXmlString(xml, TransformMeta.XML_TAG),
+        JaninoMeta.class,
+        meta,
+        new MemoryMetadataProvider());
+
+    assertEquals(2, meta.getFunctions().size());
+    assertEquals("f1", meta.getFunctions().get(0).getFieldName());
+    assertEquals("expression1", meta.getFunctions().get(0).getFormula());
+    assertEquals("f2", meta.getFunctions().get(1).getFieldName());
+    assertEquals("expression2", meta.getFunctions().get(1).getFormula());
+  }
 }


### PR DESCRIPTION
Here is a recap of the changes, ready for code reviewers:

### **Problem & Root Cause**
* **Issue:** When importing Kettle (PDI) transformations into Apache Hop, the "Java expression" column in the User Defined Java Expression (UDJE / Janino) transform is cleared.
* **Root Cause:** During the PDI-to-Hop conversion process, `KettleConst.kettleElementReplacements` globally maps the `<formula_string>` tag to `<formula>` (which is required by the standard `Formula` transform). However, in Hop's `JaninoMetaFunction`, the property tag is still expected to be `<formula_string>`. Consequently, the XML deserializer fails to locate `<formula_string>` because it was renamed to `<formula>`, leaving the java expression blank.

---

### **Proposed Solution & Changes**
To handle this legacy migration mismatch locally without breaking the `Formula` transform, we added legacy XML conversion handling inside `JaninoMeta`.

#### 1. **[JaninoMeta.java](file:///home/matt/git/mattcasters/hop/plugins/transforms/janino/src/main/java/org/apache/hop/pipeline/transforms/janino/JaninoMeta.java)**
* Added `import org.apache.hop.core.xml.XmlHandler;`.
* Overrode `convertLegacyXml(Node node)` to read the legacy `<formula>` child node from each `<formula>` item block (after the global replacement) and set it as the formula expression of the corresponding `JaninoMetaFunction` when the standard deserialized field is empty/null.

```java
  @Override
  public void convertLegacyXml(Node node) throws HopException {
    int nrCalcs = XmlHandler.countNodes(node, "formula");
    for (int i = 0; i < nrCalcs; i++) {
      Node calcnode = XmlHandler.getSubNodeByNr(node, "formula", i);
      if (calcnode != null) {
        String expression = XmlHandler.getTagValue(calcnode, "formula");
        if (expression != null && i < functions.size()) {
          JaninoMetaFunction fn = functions.get(i);
          if (Utils.isEmpty(fn.getFormula())) {
            fn.setFormula(expression);
          }
        }
      }
    }
  }
```

#### 2. **[JaninoMetaTest.java](file:///home/matt/git/mattcasters/hop/plugins/transforms/janino/src/test/java/org/apache/hop/pipeline/transforms/janino/JaninoMetaTest.java)**
* Added `testConvertLegacyXml` unit test to verify that Kettle-converted UDJE XML (using `<formula>` as the child node tag instead of `<formula_string>`) successfully deserializes the Java expressions correctly.

---

### **Verification & Tests**
* **Code Formatting:** Formatted all modified files using:
  ```bash
  ./mvnw spotless:apply
  ```
* **Unit Tests:** Ran and verified all 208 unit tests in the Janino plugin module with:
  ```bash
  ./mvnw test -pl plugins/transforms/janino
  ```
  **Results:** All tests passed successfully.