### PR TITLE
issue #7220 : dialogs are sized too large when a table view has many items

### DIFF
--- a/ui/src/main/java/org/apache/hop/ui/core/widget/TableView.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/widget/TableView.java
@@ -114,6 +114,9 @@ public class TableView extends Composite {
   /** Default minimum height hint in pixels for all TableView instances. */
   public static final int HEIGHT_HINT_PX = 200;
 
+  /** Default maximum height hint in pixels for all TableView instances. */
+  public static final int HEIGHT_HINT_MAX_PX = 350;
+
   /**
    * Default minimum width hint in pixels for all TableView instances (matches typical shell width).
    */
@@ -641,8 +644,16 @@ public class TableView extends Composite {
   @Override
   public Point computeSize(int wHint, int hHint, boolean changed) {
     Point size = super.computeSize(wHint, hHint, changed);
-    if (hHint == SWT.DEFAULT && size.y < HEIGHT_HINT_PX) {
-      size.y = HEIGHT_HINT_PX;
+    double zoomFactor = PropsUi.getNativeZoomFactor();
+    int minHeight = (int) Math.round(HEIGHT_HINT_PX * zoomFactor);
+    int maxHeight = (int) Math.round(HEIGHT_HINT_MAX_PX * zoomFactor);
+
+    if (hHint == SWT.DEFAULT) {
+      if (size.y < minHeight) {
+        size.y = minHeight;
+      } else if (size.y > maxHeight) {
+        size.y = maxHeight;
+      }
     }
     return size;
   }


### PR DESCRIPTION
### **PR Description / Recap**

issue: #7220 : run options window is too large

#### **Root Cause**
1. **Unbounded Table Height Calculation**: Both the **Parameters** and **Variables** sections in the **Run Options** configuration dialog use `TableView` instances. The preferred height of an SWT `Table` grows proportionally with the number of items (`num_rows * row_height`). If a workflow/pipeline has many parameters or variables, the table requests an excessively large vertical height (often 800px+).
2. **Initial Shell Packing**: When the dialog is opened for the first time (or when positions are reset), the codebase executes `shell.pack()`. This forces the window shell to match the absolute preferred height of its children, causing the dialog to extend off-screen and rendering the header and footer buttons (such as **Launch** and **Cancel**) inaccessible on typical displays and scaled screen setups.

---

#### **Implemented Solution**
We resolved this by capping the preferred height of the `TableView` widget at a sensible threshold and dynamically scaling it to adapt to different resolutions and zoom configurations:

1. **Declared `HEIGHT_HINT_MAX_PX`**: Added a default maximum height hint of `350` pixels to [TableView.java](file:///home/matt/git/mattcasters/hop/ui/src/main/java/org/apache/hop/ui/core/widget/TableView.java#L117-L119).
2. **Updated `computeSize`**: Constrained the computed preferred height within `[HEIGHT_HINT_PX, HEIGHT_HINT_MAX_PX]` when the height hint `hHint` is `SWT.DEFAULT`.
3. **High-DPI / Zoom Awareness**: Multiplied both the minimum and maximum height hints by `PropsUi.getNativeZoomFactor()`. This ensures the table height scales correctly on high-DPI monitors (e.g., 125%, 150%, 200% OS zoom) to remain readable, while preventing the layout from overflowing smaller screens.
4. **Auto-Scroll Behavior**: If the table contains more rows than fit within the maximum height, the native SWT Table automatically enables its vertical scrollbar. The overall dialog shell now packs to a clean, readable height, and the bottom buttons remain fixed, visible, and fully interactive.