### PR TITLE
issue #7296 : MessageBox doesn't equate ESC to Cancel

### DIFF
--- a/ui/src/main/java/org/apache/hop/ui/core/dialog/MessageBox.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/dialog/MessageBox.java
@@ -173,6 +173,15 @@ public class MessageBox extends Dialog {
 
     shell.addListener(SWT.Close, e -> cancel());
 
+    shell.addListener(
+        SWT.Traverse,
+        e -> {
+          if (e.detail == SWT.TRAVERSE_ESCAPE) {
+            e.doit = false;
+            cancel();
+          }
+        });
+
     BaseTransformDialog.setSize(shell);
 
     // If minimum size is set, use it directly instead of packing


### PR DESCRIPTION
I have successfully applied a fix to resolve issue #7296.

### Summary of Changes
1. **Added Traverse Listener:** Added a listener to the shell in [MessageBox.java](file:///home/matt/git/mattcasters/hop/ui/src/main/java/org/apache/hop/ui/core/dialog/MessageBox.java#L175-L184) to handle the `SWT.TRAVERSE_ESCAPE` event when the Escape key is pressed. This listener triggers `cancel()`, setting the return value to `SWT.CANCEL` and disposing the shell.
2. **Formatting & Compilation:** Formatted the codebase using `./mvnw spotless:apply` and verified that the `hop-ui` module compiles and passes all unit tests successfully.

# Walkthrough - Escape Key Support for Save Confirmation Dialog

To resolve the issue where the Escape key does not work when prompting to save changes on file/pipeline close, a key traversal handler has been added to the custom `MessageBox` dialog.

## Changes

### UI Dialogs

#### [MODIFY] [MessageBox.java](file:///home/matt/git/mattcasters/hop/ui/src/main/java/org/apache/hop/ui/core/dialog/MessageBox.java)

Added a `SWT.Traverse` listener on the dialog's shell to handle the `SWT.TRAVERSE_ESCAPE` event:
```java
    shell.addListener(
        SWT.Traverse,
        e -> {
          if (e.detail == SWT.TRAVERSE_ESCAPE) {
            e.doit = false;
            cancel();
          }
        });
```

* This aligns `MessageBox` with standard dialog behavior (like `BaseDialog`) so that pressing the Escape key acts as a cancel request.
* It sets `returnValue` to `SWT.CANCEL`, disposes the shell, and exits the dialog's event loop, which prevents the unsaved file/pipeline from being incorrectly closed.


