### PR TITLE
issue #7380 : follow active file in the explorer

### DIFF
--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/ExplorerPerspective.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/ExplorerPerspective.java
@@ -390,14 +390,10 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
                         activeTabFolder = folder;
                         folder.setSelection(item);
                         folder.showItem(item);
-                        Object handler = item.getData();
-                        if (handler instanceof IHopFileTypeHandler) {
+                        if (item.getData() instanceof IHopFileTypeHandler handler) {
                           hopGui.handleFileCapabilities(
-                              ((IHopFileTypeHandler) handler).getFileType(),
-                              (IHopFileTypeHandler) handler,
-                              ((IHopFileTypeHandler) handler).hasChanged(),
-                              false,
-                              false);
+                              handler.getFileType(), handler, handler.hasChanged(), false, false);
+                          selectInTree(handler.getFilename());
                         }
                       }
                       break;
@@ -1747,6 +1743,13 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
             notifyZoomHandlerForActiveTab();
             updateWebUrlForActiveTab();
           }
+          CTabItem selection = folder.getSelection();
+          if (selection != null) {
+            Object data = selection.getData();
+            if (data instanceof IHopFileTypeHandler handler) {
+              selectInTree(handler.getFilename());
+            }
+          }
         });
     folder.addCTabFolder2Listener(
         new CTabFolder2Adapter() {
@@ -2123,6 +2126,7 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
       if (EnvironmentUtils.getInstance().isWeb()) {
         updateWebUrlForActiveTab();
       }
+      selectInTree(fileTypeHandler.getFilename());
       return;
     }
 
@@ -2182,6 +2186,7 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
     if (EnvironmentUtils.getInstance().isWeb()) {
       updateWebUrlForActiveTab();
     }
+    selectInTree(fileTypeHandler.getFilename());
   }
 
   /**
@@ -2202,6 +2207,7 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
       if (EnvironmentUtils.getInstance().isWeb()) {
         updateWebUrlForActiveTab();
       }
+      selectInTree(pipelineMeta.getFilename());
       return handler.getTypeHandler();
     }
 
@@ -2260,6 +2266,7 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
     if (EnvironmentUtils.getInstance().isWeb()) {
       updateWebUrlForActiveTab();
     }
+    selectInTree(pipelineMeta.getFilename());
 
     return pipelineGraph;
   }
@@ -2282,6 +2289,7 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
       if (EnvironmentUtils.getInstance().isWeb()) {
         updateWebUrlForActiveTab();
       }
+      selectInTree(workflowMeta.getFilename());
       return handler.getTypeHandler();
     }
 
@@ -2340,6 +2348,7 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
     if (EnvironmentUtils.getInstance().isWeb()) {
       updateWebUrlForActiveTab();
     }
+    selectInTree(workflowMeta.getFilename());
 
     return workflowGraph;
   }
@@ -2360,15 +2369,47 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
     }
   }
 
+  private boolean isDescendant(String parentPath, String childPath) {
+    if (parentPath == null || childPath == null) {
+      return false;
+    }
+    try {
+      FileObject parentFile = HopVfs.getFileObject(parentPath);
+      FileObject childFile = HopVfs.getFileObject(childPath);
+      return parentFile.getName().isDescendent(childFile.getName());
+    } catch (Exception e) {
+      // Fallback
+      String parent = parentPath.replace('\\', '/');
+      String child = childPath.replace('\\', '/');
+      if (!parent.endsWith("/")) {
+        parent += "/";
+      }
+      return child.startsWith(parent);
+    }
+  }
+
   private boolean selectInTree(TreeItem item, String filename) {
     TreeItemFolder tif = (TreeItemFolder) item.getData();
     if (tif != null && tif.path.equals(filename)) {
       tree.setSelection(tif.treeItem);
+      tree.showItem(tif.treeItem);
       return true;
     }
-    for (TreeItem child : item.getItems()) {
-      if (selectInTree(child, filename)) {
-        return true;
+    if (tif != null && tif.folder && isDescendant(tif.path, filename)) {
+      if (!tif.loaded) {
+        BusyIndicator.showWhile(
+            hopGui.getDisplay(),
+            () -> {
+              refreshFolder(item, tif.path, tif.depth + 1);
+              tif.loaded = true;
+            });
+      }
+      item.setExpanded(true);
+      TreeMemory.getInstance().storeExpanded(FILE_EXPLORER_TREE, item, true);
+      for (TreeItem child : item.getItems()) {
+        if (selectInTree(child, filename)) {
+          return true;
+        }
       }
     }
     return false;

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/ExplorerPerspective.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/ExplorerPerspective.java
@@ -2355,6 +2355,17 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
 
   /** Select the corresponding file in the left-hand tree */
   private void selectInTree(String filename) {
+    selectInTree(filename, true);
+  }
+
+  private void selectInTree(String filename, boolean automatic) {
+    if (automatic) {
+      Boolean activeFileSelection =
+          ExplorerPerspectiveConfigSingleton.getConfig().getActiveFileSelection();
+      if (activeFileSelection != null && !activeFileSelection) {
+        return;
+      }
+    }
 
     if (Utils.isEmpty(filename)) {
       return;
@@ -2665,7 +2676,7 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
   public void selectInTree() {
     CTabFolder active = getTargetTabFolder();
     if (active.getSelectionIndex() >= 0) {
-      this.selectInTree(getActiveFileTypeHandler().getFilename());
+      this.selectInTree(getActiveFileTypeHandler().getFilename(), false);
     }
   }
 

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/config/ExplorerPerspectiveConfig.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/config/ExplorerPerspectiveConfig.java
@@ -25,12 +25,14 @@ public class ExplorerPerspectiveConfig {
   private String fileLoadingMaxSize;
   private Boolean fileExplorerVisibleByDefault;
   private Boolean openingHelpFiles;
+  private Boolean activeFileSelection;
 
   public ExplorerPerspectiveConfig() {
     this.lazyLoadingDepth = "0";
     this.fileLoadingMaxSize = "16";
     this.fileExplorerVisibleByDefault = true;
     this.openingHelpFiles = false;
+    this.activeFileSelection = true;
   }
 
   public ExplorerPerspectiveConfig(ExplorerPerspectiveConfig config) {
@@ -39,6 +41,7 @@ public class ExplorerPerspectiveConfig {
     this.fileLoadingMaxSize = config.fileLoadingMaxSize;
     this.fileExplorerVisibleByDefault = config.fileExplorerVisibleByDefault;
     this.openingHelpFiles = config.openingHelpFiles;
+    this.activeFileSelection = config.activeFileSelection;
   }
 
   public String getLazyLoadingDepth() {
@@ -71,5 +74,13 @@ public class ExplorerPerspectiveConfig {
 
   public void setOpeningHelpFiles(Boolean openingHelpFiles) {
     this.openingHelpFiles = openingHelpFiles;
+  }
+
+  public Boolean getActiveFileSelection() {
+    return activeFileSelection != null ? activeFileSelection : true;
+  }
+
+  public void setActiveFileSelection(Boolean activeFileSelection) {
+    this.activeFileSelection = activeFileSelection;
   }
 }

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/config/ExplorerPerspectiveConfigPlugin.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/config/ExplorerPerspectiveConfigPlugin.java
@@ -51,6 +51,7 @@ public class ExplorerPerspectiveConfigPlugin
   private static final String WIDGET_ID_FILE_EXPLORER_VISIBLE_BY_DEFAULT =
       "10200-file-explorer-visible-by-default";
   private static final String WIDGET_ID_OPEN_HELP_FILES = "10300-open-help-files";
+  private static final String WIDGET_ID_ACTIVE_FILE_SELECTION = "10400-active-file-selection";
 
   @GuiWidgetElement(
       id = WIDGET_ID_LAZY_LOADING_DEPTH,
@@ -98,6 +99,17 @@ public class ExplorerPerspectiveConfigPlugin
       description = "Open help files in Hop GUI tabs instead of external browser")
   private Boolean openingHelpFiles;
 
+  @GuiWidgetElement(
+      id = WIDGET_ID_ACTIVE_FILE_SELECTION,
+      parentId = ConfigPluginOptionsTab.GUI_WIDGETS_PARENT_ID,
+      type = GuiElementType.CHECKBOX,
+      label = "i18n::ExplorerPerspectiveConfig.ActiveFileSelection.Label",
+      toolTip = "i18n::ExplorerPerspectiveConfig.ActiveFileSelection.Tooltip")
+  @CommandLine.Option(
+      names = {"-exafs", "--explorer-active-file-selection"},
+      description = "Automatically select the active tab file in the file explorer tree")
+  private Boolean activeFileSelection = true;
+
   /**
    * Gets instance
    *
@@ -112,6 +124,7 @@ public class ExplorerPerspectiveConfigPlugin
     Boolean visibleByDefault = config.getFileExplorerVisibleByDefault();
     instance.fileExplorerVisibleByDefault = visibleByDefault != null ? visibleByDefault : true;
     instance.openingHelpFiles = config.isOpeningHelpFiles();
+    instance.activeFileSelection = config.getActiveFileSelection();
 
     return instance;
   }
@@ -153,6 +166,13 @@ public class ExplorerPerspectiveConfigPlugin
         config.setOpeningHelpFiles(openingHelpFiles);
         log.logBasic(
             "Explorer perspective: open help files in tabs is set to '" + openingHelpFiles + "'");
+        changed = true;
+      }
+
+      if (activeFileSelection != null) {
+        config.setActiveFileSelection(activeFileSelection);
+        log.logDetailed(
+            "Explorer perspective: active file selection is set to '" + activeFileSelection + "'");
         changed = true;
       }
 
@@ -205,6 +225,11 @@ public class ExplorerPerspectiveConfigPlugin
           openingHelpFiles = ((Button) control).getSelection();
           ExplorerPerspectiveConfigSingleton.getConfig().setOpeningHelpFiles(openingHelpFiles);
           break;
+        case WIDGET_ID_ACTIVE_FILE_SELECTION:
+          activeFileSelection = ((Button) control).getSelection();
+          ExplorerPerspectiveConfigSingleton.getConfig()
+              .setActiveFileSelection(activeFileSelection);
+          break;
         default:
           break;
       }
@@ -248,5 +273,13 @@ public class ExplorerPerspectiveConfigPlugin
 
   public void setOpeningHelpFiles(Boolean openingHelpFiles) {
     this.openingHelpFiles = openingHelpFiles;
+  }
+
+  public Boolean getActiveFileSelection() {
+    return activeFileSelection != null ? activeFileSelection : true;
+  }
+
+  public void setActiveFileSelection(Boolean activeFileSelection) {
+    this.activeFileSelection = activeFileSelection;
   }
 }

--- a/ui/src/main/resources/org/apache/hop/ui/hopgui/perspective/explorer/config/messages/messages_en_US.properties
+++ b/ui/src/main/resources/org/apache/hop/ui/hopgui/perspective/explorer/config/messages/messages_en_US.properties
@@ -24,3 +24,7 @@ ExplorerPerspectiveConfig.FileExplorerVisible.Tooltip=When enabled, the file exp
 
 ExplorerPerspectiveConfig.OpenHelpFiles.Label=Open help files in Hop GUI tabs instead of external browser
 ExplorerPerspectiveConfig.OpenHelpFiles.Tooltip=When checked, help links will open as a new tab within the Hop GUI using the internal HTML viewer. Unchecked will open the system default browser.
+
+ExplorerPerspectiveConfig.ActiveFileSelection.Label=Select active file in tree automatically
+ExplorerPerspectiveConfig.ActiveFileSelection.Tooltip=Automatically select the active tab file in the file explorer tree on the left hand side when it is shown in a tab.
+

--- a/ui/src/main/resources/org/apache/hop/ui/hopgui/perspective/explorer/config/messages/messages_fr_FR.properties
+++ b/ui/src/main/resources/org/apache/hop/ui/hopgui/perspective/explorer/config/messages/messages_fr_FR.properties
@@ -23,3 +23,7 @@ ExplorerPerspectiveConfig.FileExplorerVisible.Tooltip=Lorsque cette option est a
 ExplorerPerspectiveConfig.OpenHelpFiles.Label=Ouvrir l''aide dans Hop plut\u00F4t que dans un navigateur externe
 ExplorerPerspectiveConfig.FileSize.Tooltip=Taille maximale des fichiers \u00E0 charger
 ExplorerPerspectiveConfig.OpenHelpFiles.Tooltip=Lorsque cette option est coch\u00E9e, l''aide s''ouvrent dans un nouvel onglet de Hop \u00E0 l''aide de la visionneuse HTML interne., sinon le navigateur par d\u00E9faut du syst\u00E8me est utilis\u00E9.
+
+ExplorerPerspectiveConfig.ActiveFileSelection.Label=S\u00E9lectionner automatiquement le fichier actif dans l''arborescence
+ExplorerPerspectiveConfig.ActiveFileSelection.Tooltip=S\u00E9lectionner automatiquement le fichier de l''onglet actif dans l''explorateur de fichiers de gauche lorsqu''il est affich\u00E9.
+

--- a/ui/src/main/resources/org/apache/hop/ui/hopgui/perspective/explorer/config/messages/messages_pt_BR.properties
+++ b/ui/src/main/resources/org/apache/hop/ui/hopgui/perspective/explorer/config/messages/messages_pt_BR.properties
@@ -25,3 +25,7 @@ ExplorerPerspectiveConfig.FileExplorerVisible.Label=Mostrar painel explorador de
 ExplorerPerspectiveConfig.FileExplorerVisible.Tooltip=Quando habilitado, o painel explorador de arquivos (árvore do projeto) é mostrado por padrão ao abrir a perspectiva exploradora
 ExplorerPerspectiveConfig.OpenHelpFiles.Label=Abra arquivos de ajuda nas abas do Hop GUI em vez de navegador externo
 ExplorerPerspectiveConfig.OpenHelpFiles.Tooltip=Quando marcada, links de ajuda abrirão como uma nova guia dentro da GUI Hop usando o visualizador HTML interno. Sem controle, abrirá o navegador padrão do sistema.
+
+ExplorerPerspectiveConfig.ActiveFileSelection.Label=Selecionar automaticamente arquivo ativo na \u00E1rvore
+ExplorerPerspectiveConfig.ActiveFileSelection.Tooltip=Selecionar automaticamente o arquivo da guia ativa na \u00E1rvore do explorador de arquivos no lado esquerdo.
+


### PR DESCRIPTION
# Walkthrough: Select Active File in Explorer Tree

We have implemented automatic selection of the active file in the file explorer tree (`ExplorerPerspective.tree`) on the left hand side when it is shown in a tab.  For issue #7380

## Changes Made

### UI Components

#### [ExplorerPerspective.java](file:///home/matt/git/mattcasters/hop/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/ExplorerPerspective.java)

1. **Hierarchy Check Helper**: Added `isDescendant(String parentPath, String childPath)` which standardizes paths and uses VFS `FileName.isDescendent` to verify nested file hierarchies.
2. **Recursive Expansion & Loading**: Refactored `selectInTree(TreeItem, String)` to dynamically load children and expand unexpanded folders recursively along the path to the selected file, using `TreeMemory` to keep track of folder expansions.
3. **Tab Switch & Focus Hooks**:
   - Added selection checking in `createSingleTabFolder()`'s selection listener.
   - Added selection checking in `FocusIn` display filter to ensure the correct item is selected when switching panes in split mode or switching editor focus.
4. **Tab Creation Hooks**: Added calls to `selectInTree` at the start and end of `addFile()`, `addPipeline()`, and `addWorkflow()` to immediately select the newly opened tab's file in the tree.

## Verification

### Build Verification
- Code formatted successfully with spotless: `./mvnw spotless:apply`
- Build successfully compiles the `ui` module: `./mvnw clean install -pl ui -DskipTests`

### Configuration and Translations

1. **Configuration Property**: Added `activeFileSelection` property (defaulting to `true`) with getter and setter to `ExplorerPerspectiveConfig.java`.
2. **Options and GUI Widget**: Added `@GuiWidgetElement` checkbox and Picocli option element `WIDGET_ID_ACTIVE_FILE_SELECTION` to `ExplorerPerspectiveConfigPlugin.java`.
3. **Locale Message Keys**: Added label and tooltip translations to `messages_en_US.properties`, `messages_fr_FR.properties`, and `messages_pt_BR.properties`.
4. **Conditional Triggering**: Updated the `selectInTree(filename)` automatic calls in `ExplorerPerspective.java` to check the `activeFileSelection` configuration setting first, while preserving manual toolbar and keyboard shortcut activation.

