### PR TITLE
Fix MySQL database metadata JSON deserialization by restoring driverClassName accessors

### DIFF
--- a/plugins/databases/mysql/src/main/java/org/apache/hop/databases/mysql/MySqlDatabaseMeta.java
+++ b/plugins/databases/mysql/src/main/java/org/apache/hop/databases/mysql/MySqlDatabaseMeta.java
@@ -23,6 +23,8 @@ import java.sql.ResultSetMetaData;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.hop.core.Const;
 import org.apache.hop.core.database.BaseDatabaseMeta;
 import org.apache.hop.core.database.DatabaseMeta;
@@ -60,6 +62,8 @@ public class MySqlDatabaseMeta extends BaseDatabaseMeta implements IDatabase {
       label = "i18n:org.apache.hop.ui.core.database:DatabaseDialog.label.MySQLStreamResults")
   private boolean resultStreaming;
 
+  @Getter
+  @Setter
   @GuiWidgetElement(
       id = "mySqlDriverClass",
       order = "20",


### PR DESCRIPTION

 Restore `getDriverClassName()` / `setDriverClassName()` on `MySqlDatabaseMeta` so JSON metadata can deserialize the `driverClassName` field again


error:
```txt
org.apache.hop.core.exception.HopRuntimeException: Unable to load databases from the metadata
	at org.apache.hop.base.AbstractMeta.getDatabases(AbstractMeta.java:870)
	at org.apache.hop.pipeline.PipelineMeta.getStringList(PipelineMeta.java:2787)
	at org.apache.hop.pipeline.PipelineMeta.getUsedVariables(PipelineMeta.java:2893)
	at org.apache.hop.pipeline.PipelineExecutionConfiguration.getUsedVariables(PipelineExecutionConfiguration.java:173)
	at org.apache.hop.ui.hopgui.file.pipeline.delegates.HopGuiPipelineRunDelegate.executePipeline(HopGuiPipelineRunDelegate.java:147)
	at org.apache.hop.ui.hopgui.file.pipeline.HopGuiPipelineGraph.lambda$start$12(HopGuiPipelineGraph.java:4543)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:40)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:132)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4137)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3753)
	at org.apache.hop.ui.hopgui.HopGui.open(HopGui.java:595)
	at org.apache.hop.ui.hopgui.HopGui.main(HopGui.java:432)
Caused by: org.apache.hop.core.exception.HopException: 
Error loading metadata object '192.168.1.200' from file 'D:\tmp\hopspace\hop_demo/metadata\rdbms/192.168.1.200.json'

Unable to load JSON object

Error loading fields for object class org.apache.hop.core.database.DatabaseMeta

Error loading field with key 'rdbms' for field 'iDatabase in class org.apache.hop.core.database.DatabaseMeta

Error loading POJO field 'org.apache.hop.core.database.IDatabase'

Error loading fields for object class org.apache.hop.databases.mysql.MySqlDatabaseMeta

Error loading field with key 'driverClassName' for field 'driverClassName in class org.apache.hop.databases.mysql.MySqlDatabaseMeta

Error setting value on field 'driverClassName' using method 'setDriverClassName' in class 'org.apache.hop.databases.mysql.MySqlDatabaseMeta
org.apache.hop.databases.mysql.MySqlDatabaseMeta.setDriverClassName(java.lang.String)








	at org.apache.hop.metadata.serializer.json.JsonMetadataSerializer.load(JsonMetadataSerializer.java:119)
	at org.apache.hop.metadata.serializer.json.JsonMetadataSerializer.loadAll(JsonMetadataSerializer.java:85)
	at org.apache.hop.metadata.serializer.multi.MultiMetadataSerializer.loadAll(MultiMetadataSerializer.java:165)
	at org.apache.hop.base.AbstractMeta.getDatabases(AbstractMeta.java:868)
	... 11 more
Caused by: org.apache.hop.core.exception.HopException: 
Unable to load JSON object

Error loading fields for object class org.apache.hop.core.database.DatabaseMeta

Error loading field with key 'rdbms' for field 'iDatabase in class org.apache.hop.core.database.DatabaseMeta

Error loading POJO field 'org.apache.hop.core.database.IDatabase'

Error loading fields for object class org.apache.hop.databases.mysql.MySqlDatabaseMeta

Error loading field with key 'driverClassName' for field 'driverClassName in class org.apache.hop.databases.mysql.MySqlDatabaseMeta

Error setting value on field 'driverClassName' using method 'setDriverClassName' in class 'org.apache.hop.databases.mysql.MySqlDatabaseMeta
org.apache.hop.databases.mysql.MySqlDatabaseMeta.setDriverClassName(java.lang.String)







	at org.apache.hop.metadata.serializer.json.JsonMetadataParser.loadJsonObject(JsonMetadataParser.java:64)
	at org.apache.hop.metadata.serializer.json.JsonMetadataSerializer.load(JsonMetadataSerializer.java:112)
	... 14 more
Caused by: org.apache.hop.core.exception.HopException: 
Error loading fields for object class org.apache.hop.core.database.DatabaseMeta

Error loading field with key 'rdbms' for field 'iDatabase in class org.apache.hop.core.database.DatabaseMeta

Error loading POJO field 'org.apache.hop.core.database.IDatabase'

Error loading fields for object class org.apache.hop.databases.mysql.MySqlDatabaseMeta

Error loading field with key 'driverClassName' for field 'driverClassName in class org.apache.hop.databases.mysql.MySqlDatabaseMeta

Error setting value on field 'driverClassName' using method 'setDriverClassName' in class 'org.apache.hop.databases.mysql.MySqlDatabaseMeta
org.apache.hop.databases.mysql.MySqlDatabaseMeta.setDriverClassName(java.lang.String)






	at org.apache.hop.metadata.serializer.json.JsonMetadataParser.loadProperties(JsonMetadataParser.java:107)
	at org.apache.hop.metadata.serializer.json.JsonMetadataParser.loadJsonObject(JsonMetadataParser.java:61)
	... 15 more
Caused by: org.apache.hop.core.exception.HopException: 
Error loading field with key 'rdbms' for field 'iDatabase in class org.apache.hop.core.database.DatabaseMeta

Error loading POJO field 'org.apache.hop.core.database.IDatabase'

Error loading fields for object class org.apache.hop.databases.mysql.MySqlDatabaseMeta

Error loading field with key 'driverClassName' for field 'driverClassName in class org.apache.hop.databases.mysql.MySqlDatabaseMeta

Error setting value on field 'driverClassName' using method 'setDriverClassName' in class 'org.apache.hop.databases.mysql.MySqlDatabaseMeta
org.apache.hop.databases.mysql.MySqlDatabaseMeta.setDriverClassName(java.lang.String)





	at org.apache.hop.metadata.serializer.json.JsonMetadataParser.loadProperty(JsonMetadataParser.java:230)
	at org.apache.hop.metadata.serializer.json.JsonMetadataParser.loadProperties(JsonMetadataParser.java:103)
	... 16 more
Caused by: org.apache.hop.core.exception.HopException: 
Error loading POJO field 'org.apache.hop.core.database.IDatabase'

Error loading fields for object class org.apache.hop.databases.mysql.MySqlDatabaseMeta

Error loading field with key 'driverClassName' for field 'driverClassName in class org.apache.hop.databases.mysql.MySqlDatabaseMeta

Error setting value on field 'driverClassName' using method 'setDriverClassName' in class 'org.apache.hop.databases.mysql.MySqlDatabaseMeta
org.apache.hop.databases.mysql.MySqlDatabaseMeta.setDriverClassName(java.lang.String)




	at org.apache.hop.metadata.serializer.json.JsonMetadataParser.loadPojoProperties(JsonMetadataParser.java:254)
	at org.apache.hop.metadata.serializer.json.JsonMetadataParser.loadProperty(JsonMetadataParser.java:214)
	... 17 more
Caused by: org.apache.hop.core.exception.HopException: 
Error loading fields for object class org.apache.hop.databases.mysql.MySqlDatabaseMeta

Error loading field with key 'driverClassName' for field 'driverClassName in class org.apache.hop.databases.mysql.MySqlDatabaseMeta

Error setting value on field 'driverClassName' using method 'setDriverClassName' in class 'org.apache.hop.databases.mysql.MySqlDatabaseMeta
org.apache.hop.databases.mysql.MySqlDatabaseMeta.setDriverClassName(java.lang.String)



	at org.apache.hop.metadata.serializer.json.JsonMetadataParser.loadProperties(JsonMetadataParser.java:107)
	at org.apache.hop.metadata.serializer.json.JsonMetadataParser.loadPojoProperties(JsonMetadataParser.java:249)
	... 18 more
Caused by: org.apache.hop.core.exception.HopException: 
Error loading field with key 'driverClassName' for field 'driverClassName in class org.apache.hop.databases.mysql.MySqlDatabaseMeta

Error setting value on field 'driverClassName' using method 'setDriverClassName' in class 'org.apache.hop.databases.mysql.MySqlDatabaseMeta
org.apache.hop.databases.mysql.MySqlDatabaseMeta.setDriverClassName(java.lang.String)


	at org.apache.hop.metadata.serializer.json.JsonMetadataParser.loadProperty(JsonMetadataParser.java:230)
	at org.apache.hop.metadata.serializer.json.JsonMetadataParser.loadProperties(JsonMetadataParser.java:103)
	... 19 more
Caused by: org.apache.hop.core.exception.HopException: 
Error setting value on field 'driverClassName' using method 'setDriverClassName' in class 'org.apache.hop.databases.mysql.MySqlDatabaseMeta
org.apache.hop.databases.mysql.MySqlDatabaseMeta.setDriverClassName(java.lang.String)

	at org.apache.hop.metadata.util.ReflectionUtil.setFieldValue(ReflectionUtil.java:192)
	at org.apache.hop.metadata.serializer.json.JsonMetadataParser.loadProperty(JsonMetadataParser.java:221)
	... 20 more
Caused by: java.lang.NoSuchMethodException: org.apache.hop.databases.mysql.MySqlDatabaseMeta.setDriverClassName(java.lang.String)
	at java.base/java.lang.Class.getMethod(Class.java:2397)
	at org.apache.hop.metadata.util.ReflectionUtil.setFieldValue(ReflectionUtil.java:183)
	... 21 more
```