### PR TITLE
Fix pipeline log view mixing logs from other open tabs in Hop GUI

### DIFF
--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/HopGuiLogBrowser.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/HopGuiLogBrowser.java
@@ -64,6 +64,8 @@ public class HopGuiLogBrowser {
   private List<String> childIds = new ArrayList<>();
   private Date lastLogRegistryChange;
   private AtomicBoolean paused;
+  private final AtomicInteger lastLogId = new AtomicInteger(-1);
+  private final AtomicBoolean busy = new AtomicBoolean(false);
 
   public HopGuiLogBrowser(final TextComposite text, final ILogParentProvided logProvider) {
     this.text = text;
@@ -75,8 +77,6 @@ public class HopGuiLogBrowser {
 
     // Create a new buffer appender to the log and capture that directly...
     //
-    final AtomicInteger lastLogId = new AtomicInteger(-1);
-    final AtomicBoolean busy = new AtomicBoolean(false);
     final FixedWidthLogLayout logLayout = new FixedWidthLogLayout(true);
 
     // Refresh the log every second or so
@@ -95,7 +95,11 @@ public class HopGuiLogBrowser {
                     () -> {
                       IHasLogChannel provider = logProvider.getLogChannelProvider();
 
-                      if (provider != null && !text.isDisposed() && !busy.get() && !paused.get()) {
+                      if (provider != null
+                          && !text.isDisposed()
+                          && text.isVisible()
+                          && !busy.get()
+                          && !paused.get()) {
                         busy.set(true);
 
                         ILogChannel logChannel = provider.getLogChannel();
@@ -120,9 +124,11 @@ public class HopGuiLogBrowser {
                           //
                           int lastNr = HopLogStore.getLastBufferLineNr();
                           if (lastNr > lastLogId.get()) {
+                            // Only show logs for this pipeline/workflow and its children, not the
+                            // shared Hop GUI log channel (which would mix logs from other tabs).
                             List<HopLoggingEvent> logLines =
                                 HopLogStore.getLogBufferFromTo(
-                                    childIds, true, lastLogId.get(), lastNr);
+                                    childIds, false, lastLogId.get(), lastNr);
 
                             // The maximum size of the log buffer
                             //
@@ -282,5 +288,10 @@ public class HopGuiLogBrowser {
   public void resetLogChannels() {
     childIds = new ArrayList<>();
     lastLogRegistryChange = null;
+  }
+
+  /** Skip log lines already in the central buffer (e.g. after the user clears the log view). */
+  public void resetLogPosition() {
+    lastLogId.set(HopLogStore.getLastBufferLineNr());
   }
 }

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/HopGuiPipelineGraph.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/HopGuiPipelineGraph.java
@@ -5139,8 +5139,11 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
 
             initialized = true;
           } catch (HopException e) {
-            log.logError(
-                pipeline.getPipelineMeta().getName() + ": preparing pipeline execution failed", e);
+            pipeline
+                .getLogChannel()
+                .logError(
+                    pipeline.getPipelineMeta().getName() + ": preparing pipeline execution failed",
+                    e);
             checkErrorVisuals();
           }
 
@@ -5184,7 +5187,9 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
                               pipeline.startThreads();
                               pipeline.waitUntilFinished();
                             } catch (Exception e) {
-                              log.logError("Error starting transform threads", e);
+                              pipeline
+                                  .getLogChannel()
+                                  .logError("Error starting transform threads", e);
                               checkErrorVisuals();
                               stopRedrawTimer();
                             }
@@ -5195,7 +5200,11 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
 
       updateGui();
     } catch (Exception e) {
-      log.logError("Error starting transform threads", e);
+      if (pipeline != null) {
+        pipeline.getLogChannel().logError("Error starting transform threads", e);
+      } else {
+        log.logError("Error starting transform threads", e);
+      }
       checkErrorVisuals();
       stopRedrawTimer();
     }

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/delegates/HopGuiPipelineLogDelegate.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/delegates/HopGuiPipelineLogDelegate.java
@@ -221,6 +221,9 @@ public class HopGuiPipelineLogDelegate {
       String textToSet = OsHelper.isMac() ? Const.CR : "";
       pipelineLogText.setText(textToSet);
     }
+    if (logBrowser != null) {
+      logBrowser.resetLogPosition();
+    }
     Map<String, String> transformLogMap = pipelineGraph.getTransformLogMap();
     if (transformLogMap != null) {
       transformLogMap.clear();

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/delegates/HopGuiWorkflowLogDelegate.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/delegates/HopGuiWorkflowLogDelegate.java
@@ -212,6 +212,9 @@ public class HopGuiWorkflowLogDelegate {
       String textToSet = OsHelper.isMac() ? Const.CR : "";
       workflowLogText.setText(textToSet);
     }
+    if (logBrowser != null) {
+      logBrowser.resetLogPosition();
+    }
   }
 
   @GuiToolbarElement(


### PR DESCRIPTION
## Problem

When multiple HPL files are open in Hop GUI and executed on separate tabs, switching back to an earlier tab shows logs from later executions mixed in.

**Reproduction:**
1. Open `demo_1.hpl` and run it — log looks correct.
2. Switch to `demo_2.hpl` and run it — log looks correct on that tab.
3. Switch back to `demo_1.hpl` — log now contains both `demo_1` and `demo_2` entries.
