### PR TITLE
Fix#7401  JSON Input dialog not persisting file flags and include subfolders

### DIFF
--- a/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsoninput/JsonInputDialog.java
+++ b/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsoninput/JsonInputDialog.java
@@ -397,7 +397,7 @@ public class JsonInputDialog extends BaseTransformDialog {
               ColumnInfo.COLUMN_TYPE_CCOMBO,
               new String[] {
                 BaseMessages.getString(PKG, CONST_SYSTEM_COMBO_YES),
-                BaseMessages.getString(PKG, "System.Combo.No")
+                BaseMessages.getString(PKG, CONST_SYSTEM_COMBO_NO)
               },
               true),
         };
@@ -1244,7 +1244,7 @@ public class JsonInputDialog extends BaseTransformDialog {
       String rep =
           field.isRepeated()
               ? BaseMessages.getString(PKG, CONST_SYSTEM_COMBO_YES)
-              : BaseMessages.getString(PKG, "System.Combo.No");
+              : BaseMessages.getString(PKG, CONST_SYSTEM_COMBO_NO);
 
       item.setText(1, Const.NVL(name, ""));
       item.setText(2, Const.NVL(xpath, ""));

--- a/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsoninput/JsonInputDialog.java
+++ b/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsoninput/JsonInputDialog.java
@@ -81,7 +81,12 @@ import org.eclipse.swt.widgets.Text;
 
 public class JsonInputDialog extends BaseTransformDialog {
   private static final Class<?> PKG = JsonInputMeta.class;
+  public static final String CONST_SYSTEM_COMBO_NO = "System.Combo.No";
   public static final String CONST_SYSTEM_COMBO_YES = "System.Combo.Yes";
+  private static final String[] YES_NO_COMBO = {
+    BaseMessages.getString(PKG, CONST_SYSTEM_COMBO_NO),
+    BaseMessages.getString(PKG, CONST_SYSTEM_COMBO_YES)
+  };
 
   private CTabFolder wTabFolder;
 
@@ -1310,8 +1315,8 @@ public class JsonInputDialog extends BaseTransformDialog {
       inputFile.setFileName(item.getText(1));
       inputFile.setFileMask(item.getText(2));
       inputFile.setExcludeFileMask(item.getText(3));
-      inputFile.setFileRequired(CONST_SYSTEM_COMBO_YES.equalsIgnoreCase(item.getText(4)));
-      inputFile.setIncludeSubFolders(CONST_SYSTEM_COMBO_YES.equalsIgnoreCase(item.getText(5)));
+      inputFile.setFileRequired(YES_NO_COMBO[1].equalsIgnoreCase(item.getText(4)));
+      inputFile.setIncludeSubFolders(YES_NO_COMBO[1].equalsIgnoreCase(item.getText(5)));
       in.getFileInput().getInputFiles().add(inputFile);
     }
 
@@ -1329,7 +1334,7 @@ public class JsonInputDialog extends BaseTransformDialog {
       field.setDecimalSymbol(item.getText(8));
       field.setGroupSymbol(item.getText(9));
       field.setTrimType(ValueMetaBase.getTrimTypeByDesc(item.getText(10)));
-      field.setRepeated(CONST_SYSTEM_COMBO_YES.equalsIgnoreCase(item.getText(11)));
+      field.setRepeated(YES_NO_COMBO[1].equalsIgnoreCase(item.getText(11)));
 
       in.getInputFields().add(field);
     }

--- a/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsonnormalize/JsonNormalizeInputDialog.java
+++ b/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsonnormalize/JsonNormalizeInputDialog.java
@@ -77,7 +77,12 @@ import org.eclipse.swt.widgets.Text;
 
 public class JsonNormalizeInputDialog extends BaseTransformDialog {
   private static final Class<?> PKG = JsonNormalizeInputMeta.class;
+  public static final String CONST_SYSTEM_COMBO_NO = "System.Combo.No";
   public static final String CONST_SYSTEM_COMBO_YES = "System.Combo.Yes";
+  private static final String[] YES_NO_COMBO = {
+    BaseMessages.getString(PKG, CONST_SYSTEM_COMBO_NO),
+    BaseMessages.getString(PKG, CONST_SYSTEM_COMBO_YES)
+  };
 
   private CTabFolder wTabFolder;
 
@@ -412,7 +417,7 @@ public class JsonNormalizeInputDialog extends BaseTransformDialog {
               ColumnInfo.COLUMN_TYPE_CCOMBO,
               new String[] {
                 BaseMessages.getString(PKG, CONST_SYSTEM_COMBO_YES),
-                BaseMessages.getString(PKG, "System.Combo.No")
+                BaseMessages.getString(PKG, CONST_SYSTEM_COMBO_NO)
               },
               true),
         };
@@ -1365,7 +1370,7 @@ public class JsonNormalizeInputDialog extends BaseTransformDialog {
       String rep =
           field.isRepeated()
               ? BaseMessages.getString(PKG, CONST_SYSTEM_COMBO_YES)
-              : BaseMessages.getString(PKG, "System.Combo.No");
+              : BaseMessages.getString(PKG, CONST_SYSTEM_COMBO_NO);
 
       item.setText(1, Const.NVL(name, ""));
       item.setText(2, Const.NVL(xpath, ""));
@@ -1440,8 +1445,8 @@ public class JsonNormalizeInputDialog extends BaseTransformDialog {
       inputFile.setFileName(item.getText(1));
       inputFile.setFileMask(item.getText(2));
       inputFile.setExcludeFileMask(item.getText(3));
-      inputFile.setFileRequired(CONST_SYSTEM_COMBO_YES.equalsIgnoreCase(item.getText(4)));
-      inputFile.setIncludeSubFolders(CONST_SYSTEM_COMBO_YES.equalsIgnoreCase(item.getText(5)));
+      inputFile.setFileRequired(YES_NO_COMBO[1].equalsIgnoreCase(item.getText(4)));
+      inputFile.setIncludeSubFolders(YES_NO_COMBO[1].equalsIgnoreCase(item.getText(5)));
       in.getFileInput().getInputFiles().add(inputFile);
     }
 
@@ -1459,7 +1464,7 @@ public class JsonNormalizeInputDialog extends BaseTransformDialog {
       field.setDecimalSymbol(item.getText(8));
       field.setGroupSymbol(item.getText(9));
       field.setTrimType(ValueMetaBase.getTrimTypeByDesc(item.getText(10)));
-      field.setRepeated(CONST_SYSTEM_COMBO_YES.equalsIgnoreCase(item.getText(11)));
+      field.setRepeated(YES_NO_COMBO[1].equalsIgnoreCase(item.getText(11)));
 
       in.getInputFields().add(field);
     }


### PR DESCRIPTION
Fix https://github.com/apache/hop/issues/7401

- Fix a save bug in `JsonInputDialog` where  **Include subfolders** were never persisted when saving a transform from the GUI.

