### PR TITLE
issue #7394 : Dimension Lookup - add lots of checks

### DIFF
--- a/plugins/transforms/dimensionlookup/src/main/java/org/apache/hop/pipeline/transforms/dimensionlookup/DimensionLookup.java
+++ b/plugins/transforms/dimensionlookup/src/main/java/org/apache/hop/pipeline/transforms/dimensionlookup/DimensionLookup.java
@@ -95,121 +95,133 @@ public class DimensionLookup extends BaseTransform<DimensionLookupMeta, Dimensio
 
     if (first) {
       first = false;
+      try {
+        data.schemaTable =
+            data.databaseMeta.getQuotedSchemaTableCombination(
+                this, data.realSchemaName, data.realTableName);
 
-      data.schemaTable =
-          data.databaseMeta.getQuotedSchemaTableCombination(
-              this, data.realSchemaName, data.realTableName);
+        data.inputRowMeta = getInputRowMeta().clone();
+        data.outputRowMeta = getInputRowMeta().clone();
+        meta.getFields(data.outputRowMeta, getTransformName(), null, null, this, metadataProvider);
 
-      data.inputRowMeta = getInputRowMeta().clone();
-      data.outputRowMeta = getInputRowMeta().clone();
-      meta.getFields(data.outputRowMeta, getTransformName(), null, null, this, metadataProvider);
+        DLFields f = meta.getFields();
 
-      // Get the fields that need conversion to normal storage...
-      // Modify the storage type of the input data...
-      //
-      data.lazyList = new ArrayList<>();
-      for (int i = 0; i < data.inputRowMeta.size(); i++) {
-        IValueMeta valueMeta = data.inputRowMeta.getValueMeta(i);
-        if (valueMeta.isStorageBinaryString()) {
-          data.lazyList.add(i);
-          valueMeta.setStorageType(IValueMeta.STORAGE_TYPE_NORMAL);
+        validateFieldsAndMetadata(f);
+
+        // Get the fields that need conversion to normal storage...
+        // Modify the storage type of the input data...
+        //
+        data.lazyList = new ArrayList<>();
+        for (int i = 0; i < data.inputRowMeta.size(); i++) {
+          IValueMeta valueMeta = data.inputRowMeta.getValueMeta(i);
+          if (valueMeta.isStorageBinaryString()) {
+            data.lazyList.add(i);
+            valueMeta.setStorageType(IValueMeta.STORAGE_TYPE_NORMAL);
+          }
         }
-      }
 
-      // The start date value column (if applicable)
-      //
-      data.startDateFieldIndex = -1;
-      if (data.startDateAlternative == COLUMN_VALUE) {
-        data.startDateFieldIndex = data.inputRowMeta.indexOfValue(meta.getStartDateFieldName());
-        if (data.startDateFieldIndex < 0) {
-          throw new HopTransformException(
-              BaseMessages.getString(
-                  PKG,
-                  "DimensionLookup.Exception.StartDateValueColumnNotFound",
-                  meta.getStartDateFieldName()));
-        }
-      }
-      DLFields f = meta.getFields();
-
-      // Lookup values
-      data.keynrs = new int[f.getKeys().size()];
-      for (int i = 0; i < data.keynrs.length; i++) {
-        DLKey key = f.getKeys().get(i);
-
-        data.keynrs[i] = data.inputRowMeta.indexOfValue(key.getName());
-        if (data.keynrs[i] < 0) { // couldn't find field!
-          throw new HopTransformException(
-              BaseMessages.getString(
-                  PKG, CONST_DIMENSION_LOOKUP_EXCEPTION_KEY_FIELD_NOT_FOUND, key.getName()));
-        }
-      }
-
-      // Return values
-      data.fieldnrs = new int[f.getFields().size()];
-      for (int i = 0; i < data.fieldnrs.length; i++) {
-        DLField field = f.getFields().get(i);
-        if (isLookupOrUpdateTypeWithArgument(meta.isUpdate(), field)) {
-          data.fieldnrs[i] = data.outputRowMeta.indexOfValue(field.getName());
-          if (data.fieldnrs[i] < 0) {
+        // The start date value column (if applicable)
+        //
+        data.startDateFieldIndex = -1;
+        if (data.startDateAlternative == COLUMN_VALUE) {
+          data.startDateFieldIndex = data.inputRowMeta.indexOfValue(meta.getStartDateFieldName());
+          if (data.startDateFieldIndex < 0) {
             throw new HopTransformException(
                 BaseMessages.getString(
-                    PKG, CONST_DIMENSION_LOOKUP_EXCEPTION_KEY_FIELD_NOT_FOUND, field.getName()));
+                    PKG,
+                    "DimensionLookup.Exception.StartDateValueColumnNotFound",
+                    meta.getStartDateFieldName()));
           }
+        }
+
+        // Lookup values
+        data.keynrs = new int[f.getKeys().size()];
+        for (int i = 0; i < data.keynrs.length; i++) {
+          DLKey key = f.getKeys().get(i);
+
+          data.keynrs[i] = data.inputRowMeta.indexOfValue(key.getName());
+          if (data.keynrs[i] < 0) { // couldn't find field!
+            throw new HopTransformException(
+                BaseMessages.getString(
+                    PKG, CONST_DIMENSION_LOOKUP_EXCEPTION_KEY_FIELD_NOT_FOUND, key.getName()));
+          }
+        }
+
+        // Return values
+        data.fieldnrs = new int[f.getFields().size()];
+        for (int i = 0; i < data.fieldnrs.length; i++) {
+          DLField field = f.getFields().get(i);
+          if (isLookupOrUpdateTypeWithArgument(meta.isUpdate(), field)) {
+            data.fieldnrs[i] = data.outputRowMeta.indexOfValue(field.getName());
+            if (data.fieldnrs[i] < 0) {
+              throw new HopTransformException(
+                  BaseMessages.getString(
+                      PKG, CONST_DIMENSION_LOOKUP_EXCEPTION_KEY_FIELD_NOT_FOUND, field.getName()));
+            }
+          } else {
+            data.fieldnrs[i] = -1;
+          }
+        }
+
+        if (!meta.isUpdate() && meta.isPreloadingCache()) {
+          preloadCache();
         } else {
-          data.fieldnrs[i] = -1;
-        }
-      }
-
-      if (!meta.isUpdate() && meta.isPreloadingCache()) {
-        preloadCache();
-      } else {
-        // Caching...
-        //
-        if (data.cacheKeyRowMeta == null) {
-          // KEY : the natural key(s)
+          // Caching...
           //
-          data.cacheKeyRowMeta = new RowMeta();
-          for (int i = 0; i < data.keynrs.length; i++) {
-            IValueMeta key = data.inputRowMeta.getValueMeta(data.keynrs[i]);
-            data.cacheKeyRowMeta.addValueMeta(key.clone());
+          if (data.cacheKeyRowMeta == null) {
+            // KEY : the natural key(s)
+            //
+            data.cacheKeyRowMeta = new RowMeta();
+            for (int i = 0; i < data.keynrs.length; i++) {
+              IValueMeta key = data.inputRowMeta.getValueMeta(data.keynrs[i]);
+              data.cacheKeyRowMeta.addValueMeta(key.clone());
+            }
+
+            data.cache =
+                new ByteArrayHashMap(
+                    meta.getCacheSize() > 0 ? meta.getCacheSize() : 5000, data.cacheKeyRowMeta);
           }
-
-          data.cache =
-              new ByteArrayHashMap(
-                  meta.getCacheSize() > 0 ? meta.getCacheSize() : 5000, data.cacheKeyRowMeta);
         }
+
+        if (StringUtils.isNotEmpty(f.getDate().getName())) {
+          data.datefieldnr = data.inputRowMeta.indexOfValue(f.getDate().getName());
+        } else {
+          data.datefieldnr = -1;
+        }
+
+        // Initialize the start date value in case we don't have one in the input rows
+        //
+        data.valueDateNow = determineDimensionUpdatedDate(r);
+
+        if (meta.getFields().getReturns().getCreationMethod() == TechnicalKeyCreationMethod.FIELD) {
+          String tkSourceField = resolve(meta.getTkSourceField());
+          data.tkFieldIndex = getInputRowMeta().indexOfValue(tkSourceField);
+        }
+
+        data.tkFieldType =
+            meta.buildTkValueMeta(
+                getInputRowMeta(), meta.getFields().getReturns().getKeyField(), this);
+
+        data.notFoundTk =
+            determineNotFoundTk(
+                data.tkFieldType,
+                meta.getFields().getReturns().getCreationMethod(),
+                data.databaseMeta);
+
+        if (getCopy() == 0) {
+          checkDimZero();
+        }
+
+        setDimLookup(data.outputRowMeta);
+      } catch (HopException e) {
+        logError(
+            BaseMessages.getString(
+                PKG, "DimensionLookup.Log.TransformCanNotContinueForErrors", e.getMessage()));
+        setErrors(1);
+        stopAll();
+        setOutputDone();
+        return false;
       }
-
-      if (StringUtils.isNotEmpty(f.getDate().getName())) {
-        data.datefieldnr = data.inputRowMeta.indexOfValue(f.getDate().getName());
-      } else {
-        data.datefieldnr = -1;
-      }
-
-      // Initialize the start date value in case we don't have one in the input rows
-      //
-      data.valueDateNow = determineDimensionUpdatedDate(r);
-
-      if (meta.getFields().getReturns().getCreationMethod() == TechnicalKeyCreationMethod.FIELD) {
-        String tkSourceField = resolve(meta.getTkSourceField());
-        data.tkFieldIndex = getInputRowMeta().indexOfValue(tkSourceField);
-      }
-
-      data.tkFieldType =
-          meta.buildTkValueMeta(
-              getInputRowMeta(), meta.getFields().getReturns().getKeyField(), this);
-
-      data.notFoundTk =
-          determineNotFoundTk(
-              data.tkFieldType,
-              meta.getFields().getReturns().getCreationMethod(),
-              data.databaseMeta);
-
-      if (getCopy() == 0) {
-        checkDimZero();
-      }
-
-      setDimLookup(data.outputRowMeta);
     }
 
     // convert row to normal storage...
@@ -236,7 +248,9 @@ public class DimensionLookup extends BaseTransform<DimensionLookupMeta, Dimensio
         logError(
             BaseMessages.getString(
                 PKG, "DimensionLookup.Log.TransformCanNotContinueForErrors", e.getMessage()));
-        logError(Const.getStackTracker(e));
+        if (!(e instanceof HopTransformException)) {
+          logError(Const.getStackTracker(e));
+        }
         setErrors(1);
         stopAll();
         setOutputDone(); // signal end to receiver(s)
@@ -373,9 +387,33 @@ public class DimensionLookup extends BaseTransform<DimensionLookupMeta, Dimensio
         DLKey key = f.getKeys().get(i);
         // The field in the table:
         data.preloadKeyIndexes[i] = rowMeta.indexOfValue(key.getLookup());
+        if (data.preloadKeyIndexes[i] < 0) {
+          throw new HopTransformException(
+              BaseMessages.getString(
+                  PKG,
+                  "DimensionLookup.Exception.LookupKeyFieldNotFound",
+                  key.getLookup(),
+                  data.schemaTable));
+        }
       }
       data.preloadFromDateIndex = rowMeta.indexOfValue(f.getDate().getFrom());
+      if (data.preloadFromDateIndex < 0) {
+        throw new HopTransformException(
+            BaseMessages.getString(
+                PKG,
+                "DimensionLookup.Exception.StartDateFromFieldNotFound",
+                f.getDate().getFrom(),
+                data.schemaTable));
+      }
       data.preloadToDateIndex = rowMeta.indexOfValue(f.getDate().getTo());
+      if (data.preloadToDateIndex < 0) {
+        throw new HopTransformException(
+            BaseMessages.getString(
+                PKG,
+                "DimensionLookup.Exception.StartDateToFieldNotFound",
+                f.getDate().getTo(),
+                data.schemaTable));
+      }
 
       data.preloadCache =
           new DimensionCache(
@@ -1895,6 +1933,160 @@ public class DimensionLookup extends BaseTransform<DimensionLookupMeta, Dimensio
         throw new HopDatabaseException(
             "Error inserting 'unknown' row in dimension [" + data.schemaTable + "] : " + insertSql,
             e);
+      }
+    }
+  }
+
+  private void validateFieldsAndMetadata(DLFields f) throws HopException {
+    // 1. Retrieve target database table fields
+    IRowMeta tableFields;
+    try {
+      tableFields = data.db.getTableFieldsMeta(data.realSchemaName, data.realTableName);
+    } catch (Exception e) {
+      throw new HopTransformException(
+          BaseMessages.getString(
+              PKG, "DimensionLookup.Exception.UnableToReadTableMetadata", data.schemaTable),
+          e);
+    }
+    if (tableFields == null) {
+      throw new HopTransformException(
+          BaseMessages.getString(
+              PKG, "DimensionLookup.Exception.UnableToReadTableMetadata", data.schemaTable));
+    }
+
+    // 2. Validate core database columns exist
+    String tkField = f.getReturns().getKeyField();
+    if (StringUtils.isNotEmpty(tkField)) {
+      if (tableFields.indexOfValue(tkField) < 0) {
+        throw new HopTransformException(
+            BaseMessages.getString(
+                PKG,
+                "DimensionLookup.Exception.TechnicalKeyFieldNotFound",
+                tkField,
+                data.schemaTable));
+      }
+    } else {
+      throw new HopTransformException(
+          BaseMessages.getString(PKG, "DimensionLookupMeta.Error.NoTechnicalKeySpecified"));
+    }
+
+    String versionField = f.getReturns().getVersionField();
+    if (StringUtils.isNotEmpty(versionField)) {
+      if (tableFields.indexOfValue(versionField) < 0) {
+        throw new HopTransformException(
+            BaseMessages.getString(
+                PKG,
+                "DimensionLookup.Exception.VersionFieldNotFound",
+                versionField,
+                data.schemaTable));
+      }
+    } else {
+      throw new HopTransformException(
+          BaseMessages.getString(PKG, "DimensionLookupMeta.CheckResult.VersionKeyRequired"));
+    }
+
+    String fromField = f.getDate().getFrom();
+    if (StringUtils.isNotEmpty(fromField)) {
+      if (tableFields.indexOfValue(fromField) < 0) {
+        throw new HopTransformException(
+            BaseMessages.getString(
+                PKG,
+                "DimensionLookup.Exception.StartDateFromFieldNotFound",
+                fromField,
+                data.schemaTable));
+      }
+    } else {
+      throw new HopTransformException(
+          BaseMessages.getString(PKG, "DimensionLookupMeta.CheckResult.StartKeyRequired"));
+    }
+
+    String toField = f.getDate().getTo();
+    if (StringUtils.isNotEmpty(toField)) {
+      if (tableFields.indexOfValue(toField) < 0) {
+        throw new HopTransformException(
+            BaseMessages.getString(
+                PKG,
+                "DimensionLookup.Exception.StartDateToFieldNotFound",
+                toField,
+                data.schemaTable));
+      }
+    } else {
+      throw new HopTransformException(
+          BaseMessages.getString(PKG, "DimensionLookupMeta.CheckResult.EndKeyRequired"));
+    }
+
+    // 3. Validate key lookup columns in database table
+    for (DLKey key : f.getKeys()) {
+      String keyLookup = key.getLookup();
+      if (StringUtils.isNotEmpty(keyLookup)) {
+        if (tableFields.indexOfValue(keyLookup) < 0) {
+          throw new HopTransformException(
+              BaseMessages.getString(
+                  PKG,
+                  "DimensionLookup.Exception.LookupKeyFieldNotFound",
+                  keyLookup,
+                  data.schemaTable));
+        }
+      }
+    }
+
+    // 4. Validate output/update lookup columns in database table
+    for (DLField field : f.getFields()) {
+      if (isLookupOrUpdateTypeWithArgument(meta.isUpdate(), field)) {
+        String fieldLookup = field.getLookup();
+        if (StringUtils.isNotEmpty(fieldLookup)) {
+          if (tableFields.indexOfValue(fieldLookup) < 0) {
+            throw new HopTransformException(
+                BaseMessages.getString(
+                    PKG,
+                    "DimensionLookup.Exception.LookupOrUpdateFieldNotFound",
+                    fieldLookup,
+                    data.schemaTable));
+          }
+        }
+      }
+    }
+
+    // 5. Validate input stream fields
+    // Date Field
+    String dateName = f.getDate().getName();
+    if (StringUtils.isNotEmpty(dateName)) {
+      if (data.inputRowMeta.indexOfValue(dateName) < 0) {
+        throw new HopTransformException(
+            BaseMessages.getString(
+                PKG, "DimensionLookup.Exception.DateFieldNameNotFound", dateName));
+      }
+    }
+
+    // Technical Key Source Field
+    if (f.getReturns().getCreationMethod() == TechnicalKeyCreationMethod.FIELD) {
+      String tkSourceField = resolve(meta.getTkSourceField());
+      if (StringUtils.isEmpty(tkSourceField) || data.inputRowMeta.indexOfValue(tkSourceField) < 0) {
+        throw new HopTransformException(
+            BaseMessages.getString(
+                PKG, "DimensionLookup.Exception.TkSourceFieldNotFound", tkSourceField));
+      }
+    }
+
+    // Keys in stream
+    for (DLKey key : f.getKeys()) {
+      if (data.inputRowMeta.indexOfValue(key.getName()) < 0) {
+        throw new HopTransformException(
+            BaseMessages.getString(
+                PKG, CONST_DIMENSION_LOOKUP_EXCEPTION_KEY_FIELD_NOT_FOUND, key.getName()));
+      }
+    }
+
+    // Update source fields in stream (only if update is true)
+    if (meta.isUpdate()) {
+      for (DLField field : f.getFields()) {
+        if (isLookupOrUpdateTypeWithArgument(meta.isUpdate(), field)) {
+          if (data.outputRowMeta.indexOfValue(field.getName()) < 0) {
+            throw new HopTransformException(
+                BaseMessages.getString(
+                    PKG, "DimensionLookup.Exception.UpdateSourceFieldNotFound", field.getName()));
+          }
+        }
       }
     }
   }

--- a/plugins/transforms/dimensionlookup/src/main/java/org/apache/hop/pipeline/transforms/dimensionlookup/DimensionLookupMeta.java
+++ b/plugins/transforms/dimensionlookup/src/main/java/org/apache/hop/pipeline/transforms/dimensionlookup/DimensionLookupMeta.java
@@ -311,6 +311,13 @@ public class DimensionLookupMeta extends BaseTransformMeta<DimensionLookup, Dime
     try {
       // Get the rows from the table...
       IRowMeta extraFields = getTableFields(variables);
+      if (extraFields == null) {
+        String message =
+            BaseMessages.getString(
+                PKG, "DimensionLookupMeta.Exception.UnableToRetrieveDataTypeOfReturnField");
+        logError(message);
+        throw new HopTransformException(message);
+      }
 
       for (DLField field : fields.fields) {
         IValueMeta lookupValueMeta = extraFields.searchValueMeta(field.getLookup());

--- a/plugins/transforms/dimensionlookup/src/main/resources/org/apache/hop/pipeline/transforms/dimensionlookup/messages/messages_en_US.properties
+++ b/plugins/transforms/dimensionlookup/src/main/resources/org/apache/hop/pipeline/transforms/dimensionlookup/messages/messages_en_US.properties
@@ -226,3 +226,14 @@ DimensionLookupDialog.UuidButton.Tooltip=Generate a new UUID as technical/surrog
 DimensionLookupDialog.TkField.Label = Input field
 DimensionLookupDialog.TkField.Tooltip = Specify the name of the field in the input to use as a technical/surrogate key.
 DimensionLookupDialog.ShowUnknownTk.Label = Display selected unknown value
+
+DimensionLookup.Exception.UnableToReadTableMetadata=Could not read fields for target table [{0}]. Make sure the table exists.
+DimensionLookup.Exception.TechnicalKeyFieldNotFound=Technical key field [{0}] not found in table [{1}].
+DimensionLookup.Exception.VersionFieldNotFound=Version field [{0}] not found in table [{1}].
+DimensionLookup.Exception.StartDateFromFieldNotFound=Date-From field [{0}] not found in table [{1}].
+DimensionLookup.Exception.StartDateToFieldNotFound=Date-To field [{0}] not found in table [{1}].
+DimensionLookup.Exception.LookupKeyFieldNotFound=Lookup key column [{0}] not found in table [{1}].
+DimensionLookup.Exception.LookupOrUpdateFieldNotFound=Lookup/update column [{0}] not found in table [{1}].
+DimensionLookup.Exception.DateFieldNameNotFound=Date field [{0}] could not be found in the input stream.
+DimensionLookup.Exception.TkSourceFieldNotFound=Technical key source field [{0}] could not be found in the input stream.
+DimensionLookup.Exception.UpdateSourceFieldNotFound=Update source field [{0}] could not be found in the input stream.


### PR DESCRIPTION
# Walkthrough - Hardening the Dimension Lookup/Update Transform

For issue #7394

All code hardening and safety suggestions have been successfully implemented, formatted, and validated.

## Changes Made

### 1. Localization Resource Bundle
*   **File:** [messages_en_US.properties](file:///home/matt/git/mattcasters/hop/plugins/transforms/dimensionlookup/src/main/resources/org/apache/hop/pipeline/transforms/dimensionlookup/messages/messages_en_US.properties)
    *   Added 10 new translation keys specifically tailored to describe validation errors for input row fields and database table metadata.

### 2. DimensionLookupMeta
*   **File:** [DimensionLookupMeta.java](file:///home/matt/git/mattcasters/hop/plugins/transforms/dimensionlookup/src/main/java/org/apache/hop/pipeline/transforms/dimensionlookup/DimensionLookupMeta.java)
    *   Added a safety null-check on the database table fields returned by `getTableFields(variables)` in `getFields()`. This prevents an unhandled `NullPointerException` (which generates stack traces) from bubbling up when the database is offline or the target table is missing during design/metadata retrieval.

### 3. DimensionLookup
*   **File:** [DimensionLookup.java](file:///home/matt/git/mattcasters/hop/plugins/transforms/dimensionlookup/src/main/java/org/apache/hop/pipeline/transforms/dimensionlookup/DimensionLookup.java)
    *   **Metadata Validation:** Added a comprehensive private method `validateFieldsAndMetadata(DLFields f)` that validates all core metadata.
        *   Checks if the target database table exists and retrieves metadata.
        *   Checks if the core columns exist: technical key, version field, date range from/to.
        *   Checks if all lookup keys and update fields exist in the target database table.
        *   Checks if all lookup keys, update source fields, and date fields exist in the input row metadata.
        *   Checks if the technical key source field exists (when using creation method `FIELD`).
    *   **Fail-Fast Initialization:** Wrapped the `first` block inside `processRow()` in a try-catch block to run `validateFieldsAndMetadata(...)` at startup. If a validation error is detected, the transform fails cleanly immediately, logs a clear and specific error message, and stops execution.
    *   **Defensive Cache Preloading:** Added index validation checks inside `preloadCache()` for returned lookup key and date range indices to avoid array index out of bounds exceptions at runtime.
    *   **Clean Logs & Suppressed Stack Traces:** Modified exception handling inside `processRow()` to avoid outputting java stack traces via `logError(Const.getStackTracker(e))` for expected configuration/validation errors (represented by `HopTransformException`).

---

## Verification and Testing

### Automated Test Runs
The plugin codebase was compiled and unit tests were executed successfully.

*   **Command:** `./mvnw clean test -pl plugins/transforms/dimensionlookup`
*   **Result:**
    ```
    [INFO] -------------------------------------------------------
    [INFO]  T E S T S
    [INFO] -------------------------------------------------------
    [INFO] Running org.apache.hop.pipeline.transforms.dimensionlookup.DimensionLookupMetaTest
    [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.844 s
    [INFO] Running org.apache.hop.pipeline.transforms.dimensionlookup.DimensionCacheTest
    [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.047 s
    [INFO] 
    [INFO] Results:
    [INFO] 
    [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
    [INFO] 
    [INFO] ------------------------------**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [ ] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [ ] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
------------------------------------------
    [INFO] BUILD SUCCESS
    ```

### Code Formatting
Spotless was run successfully to ensure code styling compliance.

*   **Command:** `./mvnw spotless:apply`
*   **Result:** All files are clean and formatted correctly.

### Docker Integration Tests
We successfully executed the full database integration test suite in a Docker container to verify the `DimensionLookup` runtime behaviour:

*   **Command:** `./integration-tests/scripts/run-tests-docker.sh PROJECT_NAME=database`
*   **Result:** All database integration tests for `DimensionLookup` (insert, update, punch-through, tk-field, tk-uuid) passed:
    *   `0012-1-dimension-lookup-update-insert.hwf` --> `result=[true]`
    *   `0012-2-dimension-lookup-update-punch-through.hwf` --> `result=[true]`
    *   `0012-3-dimension-lookup-update-update.hwf` --> `result=[true]`
    *   `0012-4-dimension-lookup-tk-field.hwf` --> `result=[true]`
    *   `0012-5-dimension-lookup-tk-uuid.hwf` --> `result=[true]`
    *   `main-0012-dimension-lookup-update.hwf` (Main Workflow) --> Completed successfully (result=[true])

