### PR TITLE
issue #7409 : When input data sets is set the transform is still doing field layout

### DIFF
--- a/engine/src/main/java/org/apache/hop/pipeline/PipelineMeta.java
+++ b/engine/src/main/java/org/apache/hop/pipeline/PipelineMeta.java
@@ -1325,10 +1325,30 @@ public class PipelineMeta extends AbstractMeta
     IRowMeta before = row.clone();
     IRowMeta[] clonedInfo = cloneRowMetaInterfaces(infoRowMeta);
     if (!isSomethingDifferentInRow(before, row)) {
-      iTransformMeta.getFields(
-          this, before, name, clonedInfo, nextTransform, variables, metadataProvider);
-      // pass the clone object to prevent from spoiling data by other transforms
-      row = before;
+      GetFieldsExtension extension =
+          new GetFieldsExtension(
+              this,
+              transformMeta,
+              before,
+              name,
+              clonedInfo,
+              nextTransform,
+              variables,
+              metadataProvider);
+      try {
+        ExtensionPointHandler.callExtensionPoint(
+            LogChannel.GENERAL, variables, HopExtensionPoint.GetFieldsExtension.id, extension);
+      } catch (Exception e) {
+        LogChannel.GENERAL.logError("Error calling extension point 'GetFieldsExtension'", e);
+      }
+      if (extension.isHandled()) {
+        row = before;
+      } else {
+        iTransformMeta.getFields(
+            this, before, name, clonedInfo, nextTransform, variables, metadataProvider);
+        // pass the clone object to prevent from spoiling data by other transforms
+        row = before;
+      }
     }
 
     return row;
@@ -3527,6 +3547,110 @@ public class PipelineMeta extends AbstractMeta
       if (transformMeta != null) {
         transformMeta.setTransformErrorMeta(errorMeta);
       }
+    }
+  }
+
+  public static class GetFieldsExtension {
+    private PipelineMeta pipelineMeta;
+    private TransformMeta transformMeta;
+    private IRowMeta row;
+    private String name;
+    private IRowMeta[] info;
+    private TransformMeta nextTransform;
+    private IVariables variables;
+    private IHopMetadataProvider metadataProvider;
+    private boolean handled;
+
+    public GetFieldsExtension(
+        PipelineMeta pipelineMeta,
+        TransformMeta transformMeta,
+        IRowMeta row,
+        String name,
+        IRowMeta[] info,
+        TransformMeta nextTransform,
+        IVariables variables,
+        IHopMetadataProvider metadataProvider) {
+      this.pipelineMeta = pipelineMeta;
+      this.transformMeta = transformMeta;
+      this.row = row;
+      this.name = name;
+      this.info = info;
+      this.nextTransform = nextTransform;
+      this.variables = variables;
+      this.metadataProvider = metadataProvider;
+      this.handled = false;
+    }
+
+    public PipelineMeta getPipelineMeta() {
+      return pipelineMeta;
+    }
+
+    public void setPipelineMeta(PipelineMeta pipelineMeta) {
+      this.pipelineMeta = pipelineMeta;
+    }
+
+    public TransformMeta getTransformMeta() {
+      return transformMeta;
+    }
+
+    public void setTransformMeta(TransformMeta transformMeta) {
+      this.transformMeta = transformMeta;
+    }
+
+    public IRowMeta getRow() {
+      return row;
+    }
+
+    public void setRow(IRowMeta row) {
+      this.row = row;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public IRowMeta[] getInfo() {
+      return info;
+    }
+
+    public void setInfo(IRowMeta[] info) {
+      this.info = info;
+    }
+
+    public TransformMeta getNextTransform() {
+      return nextTransform;
+    }
+
+    public void setNextTransform(TransformMeta nextTransform) {
+      this.nextTransform = nextTransform;
+    }
+
+    public IVariables getVariables() {
+      return variables;
+    }
+
+    public void setVariables(IVariables variables) {
+      this.variables = variables;
+    }
+
+    public IHopMetadataProvider getMetadataProvider() {
+      return metadataProvider;
+    }
+
+    public void setMetadataProvider(IHopMetadataProvider metadataProvider) {
+      this.metadataProvider = metadataProvider;
+    }
+
+    public boolean isHandled() {
+      return handled;
+    }
+
+    public void setHandled(boolean handled) {
+      this.handled = handled;
     }
   }
 }

--- a/plugins/misc/testing/src/main/java/org/apache/hop/testing/gui/TestingGuiPlugin.java
+++ b/plugins/misc/testing/src/main/java/org/apache/hop/testing/gui/TestingGuiPlugin.java
@@ -237,7 +237,7 @@ public class TestingGuiPlugin {
     IRowMeta transformFields;
     try {
       transformFields = pipelineMeta.getTransformFields(variables, transformMeta);
-    } catch (HopTransformException e) {
+    } catch (Exception e) {
       // Driver or input problems...
       //
       transformFields = new RowMeta();

--- a/plugins/misc/testing/src/main/java/org/apache/hop/testing/xp/PipelineGetFieldsExtensionPoint.java
+++ b/plugins/misc/testing/src/main/java/org/apache/hop/testing/xp/PipelineGetFieldsExtensionPoint.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.testing.xp;
+
+import org.apache.hop.core.exception.HopException;
+import org.apache.hop.core.extension.ExtensionPoint;
+import org.apache.hop.core.extension.IExtensionPoint;
+import org.apache.hop.core.logging.ILogChannel;
+import org.apache.hop.core.row.IRowMeta;
+import org.apache.hop.core.row.IValueMeta;
+import org.apache.hop.core.variables.IVariables;
+import org.apache.hop.pipeline.PipelineMeta;
+import org.apache.hop.pipeline.transform.TransformMeta;
+import org.apache.hop.testing.DataSet;
+import org.apache.hop.testing.PipelineUnitTest;
+import org.apache.hop.testing.PipelineUnitTestSetLocation;
+import org.apache.hop.testing.gui.TestingGuiPlugin;
+import org.apache.hop.testing.util.DataSetConst;
+
+@ExtensionPoint(
+    extensionPointId = "GetFieldsExtension",
+    id = "PipelineGetFieldsExtensionPoint",
+    description =
+        "Intercept field determination for transforms that have a unit test input dataset mapped to them")
+public class PipelineGetFieldsExtensionPoint
+    implements IExtensionPoint<PipelineMeta.GetFieldsExtension> {
+
+  @Override
+  public void callExtensionPoint(
+      ILogChannel log, IVariables variables, PipelineMeta.GetFieldsExtension extension)
+      throws HopException {
+    PipelineMeta pipelineMeta = extension.getPipelineMeta();
+    TransformMeta transformMeta = extension.getTransformMeta();
+
+    if (pipelineMeta == null || transformMeta == null) {
+      return;
+    }
+
+    // Check if a unit test is active in Hop GUI
+    PipelineUnitTest unitTest = TestingGuiPlugin.getCurrentUnitTest(pipelineMeta);
+    if (unitTest == null) {
+      return;
+    }
+
+    // Check if this transform has an input location mapping
+    PipelineUnitTestSetLocation inputLocation = unitTest.findInputLocation(transformMeta.getName());
+    if (inputLocation == null) {
+      return;
+    }
+
+    String dataSetName = inputLocation.getDataSetName();
+    if (dataSetName == null) {
+      return;
+    }
+
+    // Load dataset and get its fields
+    DataSet dataSet;
+    try {
+      dataSet = extension.getMetadataProvider().getSerializer(DataSet.class).load(dataSetName);
+    } catch (HopException e) {
+      throw new HopException("Unable to load data set '" + dataSetName + "'");
+    }
+
+    if (dataSet != null) {
+      IRowMeta outputRowMeta = DataSetConst.getTransformOutputFields(dataSet, inputLocation);
+      if (outputRowMeta != null) {
+        IRowMeta row = extension.getRow();
+        for (int i = 0; i < outputRowMeta.size(); i++) {
+          IValueMeta v = outputRowMeta.getValueMeta(i);
+          v.setOrigin(extension.getName());
+        }
+        row.addRowMeta(outputRowMeta);
+        extension.setHandled(true);
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Walkthrough - Design-Time Unit Test Field Interception

For issue #7409 

We have implemented an extension-point based design to avoid Table Input (and other transforms) trying to connect to unavailable databases or resources when determining the output row layout at design time under an active unit test. Additionally, we fixed a `NullPointerException` (and general field query failure crashes) that occurred when trying to associate a unit test dataset on an unconfigured or database-inaccessible transform.

## Changes Made

### Core Engine
- Modified [PipelineMeta.java](file:///home/matt/git/mattcasters/hop/engine/src/main/java/org/apache/hop/pipeline/PipelineMeta.java) to define the `GetFieldsExtension` static nested class containing all metadata needed during field determination.
- Triggered the extension point `HopExtensionPoint.GetFieldsExtension.id` in `getThisTransformFields()` right before calling `ITransformMeta.getFields()`. If the extension marks the event as `handled`, the default `iTransformMeta.getFields()` call is bypassed, and the fields resolved by the extension are returned.

### Testing Plugin
- Created [PipelineGetFieldsExtensionPoint.java](file:///home/matt/git/mattcasters/hop/plugins/misc/testing/src/main/java/org/apache/hop/testing/xp/PipelineGetFieldsExtensionPoint.java) to listen for the `GetFieldsExtension` extension point.
  - The extension point checks if a unit test is active via `TestingGuiPlugin.getCurrentUnitTest(pipelineMeta)`. If so, it looks up whether the transform name is mapped to an input dataset.
  - If a dataset mapping is found, it loads the dataset, determines the output row layout using `DataSetConst.getTransformOutputFields()`, populates the row meta, and sets `extension.setHandled(true)`.
- Modified [TestingGuiPlugin.java](file:///home/matt/git/mattcasters/hop/plugins/misc/testing/src/main/java/org/apache/hop/testing/gui/TestingGuiPlugin.java) inside `setInputDataSetOnTransform()` to catch `Exception` instead of `HopTransformException`.
  - When setting a unit test dataset on a transform for the first time, no mapping is registered yet, so the extension point will not intercept the call. If the transform is not configured or fails to connect to the database (throwing a `NullPointerException`, database exception, etc.), the catch block handles the error and gracefully falls back to showing the dataset's own fields for mapping selection.

## Verification Results

### Automated Tests
- Ran Spotless check to ensure code cleanliness:
  ```bash
  ./mvnw spotless:check -pl engine,plugins/misc/testing
  ```
  Result: **SUCCESS**
- Compiled both modules successfully:
  ```bash
  ./mvnw clean install -DskipTests -pl engine,plugins/misc/testing
  ```
  Result: **SUCCESS**
- Ran all unit tests:
  ```bash
  ./mvnw test -pl engine,plugins/misc/testing
  ```
  Result: **SUCCESS**

### Manual Verification
- Created a new pipeline with an unconfigured "Table Input" transform.
- Created a unit test for the pipeline.
- Successfully set an input dataset on the transform.
- Confirmed that the output rows are successfully displayed without errors, despite no database or SQL being configured.
