### PR TITLE
issue #7412 : Dialog size not remembered in data preview window

### DIFF
--- a/ui/src/main/java/org/apache/hop/ui/core/PropsUi.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/PropsUi.java
@@ -509,7 +509,7 @@ public class PropsUi extends Props {
    * @return true if dialog positions should reset on restart, false otherwise
    */
   public boolean getResetDialogPositionsOnRestart() {
-    return YES.equalsIgnoreCase(getProperty(RESET_DIALOG_POSITIONS_ON_RESTART, YES));
+    return YES.equalsIgnoreCase(getProperty(RESET_DIALOG_POSITIONS_ON_RESTART, NO));
   }
 
   /**


### PR DESCRIPTION
issue #7412

It's a combination of having `PropsUi.getResetDialogPositionsOnRestart()` being set to true by default and then simply ignoring all stored shell positions when this is enabled.

Needs another ticket to fundamentally change this behavior.  This option is fine if it would ACTUALLY reset the dialog positions on restart, e.g. empty out `${HOP_AUDIT_FOLDER}/hop-gui/shells-state.json` when Hop GUI starts.
 