### PR TITLE
issue #7421 : keyboard unresponsive during startup/shutdown of Hop GUI

### DIFF
--- a/assemblies/static/src/main/resources/hop
+++ b/assemblies/static/src/main/resources/hop
@@ -79,6 +79,16 @@ HOP_OPTIONS="${HOP_OPTIONS} --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED --
 
 case $(uname -s) in
 Linux)
+  # Workaround for temporary keyboard input stall on Hop GUI startup/shutdown
+  # (common on Ubuntu/GNOME/X11 with heavy SWT plugins).
+  # Bypasses AT-SPI accessibility bridge and IBus which can block the X11 event loop.
+  # Users who need full accessibility/IME can override by setting HOP_KEEP_A11Y=1
+  if [ -z "$HOP_KEEP_A11Y" ]; then
+    export NO_AT_BRIDGE=1
+    export GTK_IM_MODULE=xim
+    export IBUS_DISABLE=1
+  fi
+
   # Workaround for https://github.com/apache/hop/issues/4252
   # Related to https://github.com/eclipse-platform/eclipse.platform.swt/issues/639
   # And to some extent also https://github.com/eclipse-platform/eclipse.platform.swt/issues/790

--- a/assemblies/static/src/main/resources/hop-gui.sh
+++ b/assemblies/static/src/main/resources/hop-gui.sh
@@ -73,6 +73,16 @@ os_arch="$(${_HOP_JAVA} -XshowSettings:properties -version 2>&1 | grep "os.arch"
 arch_path="$(echo "$os_arch" | sed 's/aarch/arm/g' | sed 's/amd/x86_/g')"
 case $(uname -s) in
 Linux)
+  # Workaround for temporary keyboard input stall on Hop GUI startup/shutdown
+  # (common on Ubuntu/GNOME/X11 with heavy SWT plugins).
+  # Bypasses AT-SPI accessibility bridge and IBus which can block the X11 event loop.
+  # Users who need full accessibility/IME can override by setting HOP_KEEP_A11Y=1
+  if [ -z "$HOP_KEEP_A11Y" ]; then
+    export NO_AT_BRIDGE=1
+    export GTK_IM_MODULE=xim
+    export IBUS_DISABLE=1
+  fi
+
   # Workaround for https://github.com/apache/hop/issues/4252
   # Related to https://github.com/eclipse-platform/eclipse.platform.swt/issues/639
   # And to some extent also https://github.com/eclipse-platform/eclipse.platform.swt/issues/790

--- a/docs/hop-user-manual/modules/ROOT/nav.adoc
+++ b/docs/hop-user-manual/modules/ROOT/nav.adoc
@@ -32,6 +32,7 @@ under the License.
 ** xref:hop-gui/perspectives.adoc[Perspectives]
 ** xref:hop-gui/hop-gui-git.adoc[Working with git]
 ** xref:hop-gui/shortcuts.adoc[Keyboard Shortcuts]
+** xref:hop-gui/linux-desktop.adoc[Linux Desktop]
 ** xref:hop-gui/hop-web.adoc[Hop Web]
 * xref:projects/index.adoc[Projects]
 ** xref:projects/projects-environments.adoc[Projects & Environments]

--- a/docs/hop-user-manual/modules/ROOT/pages/hop-gui/index.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/hop-gui/index.adoc
@@ -35,4 +35,5 @@ Covered here are:
 * xref:hop-gui/perspectives.adoc[Perspectives]: the various perspectives in the Hop Gui
 * xref:hop-gui/hop-gui-git.adoc[Working with git]: Manage files in the git version control system
 * xref:hop-gui/shortcuts.adoc[Keyboard Shortcuts]: a list of the keyboard shortcuts that are available in Hop Gui.
+* xref:hop-gui/linux-desktop.adoc[Linux Desktop]: accessibility, input methods, and desktop session workarounds for Hop Gui on Linux.
 * xref:hop-gui/hop-web.adoc[Hop Web]: a web version of Hop Gui that provides the exact same functionality and user experience as the desktop version

--- a/docs/hop-user-manual/modules/ROOT/pages/hop-gui/linux-desktop.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/hop-gui/linux-desktop.adoc
@@ -1,0 +1,59 @@
+////
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+////
+[[LinuxDesktop]]
+:description: Linux desktop configuration for Hop Gui, including accessibility, input methods, and Wayland session workarounds.
+
+= Linux Desktop Configuration
+
+Hop Gui runs on Linux using SWT and GTK.
+A few desktop-session settings are applied automatically when you start Hop through `hop-gui.sh` or the `hop` launcher script.
+
+== Keyboard input stall at startup or shutdown
+
+On Linux, especially Ubuntu and GNOME on X11, Hop Gui can temporarily stop accepting keyboard input while the application starts up or shuts down.
+This is most noticeable on systems with many SWT-based plugins loaded.
+
+To prevent that stall, Hop applies a workaround automatically in `hop-gui.sh` and the `hop` launcher.
+The scripts set the following environment variables unless you override them:
+
+* `NO_AT_BRIDGE=1` — bypasses the AT-SPI accessibility bridge
+* `GTK_IM_MODULE=xim` — switches the GTK input method module away from IBus
+* `IBUS_DISABLE=1` — disables IBus
+
+This behavior was introduced for https://github.com/apache/hop/issues/7421[issue #7421].
+
+== Restoring accessibility and IME support
+
+If you use a screen reader, other assistive technology, or an IBus-based input method editor (for example for CJK languages), set `HOP_KEEP_A11Y` before starting Hop Gui:
+
+[source,bash]
+----
+export HOP_KEEP_A11Y=1
+./hop-gui.sh
+----
+
+When `HOP_KEEP_A11Y` is set to any non-empty value, Hop leaves your existing accessibility and input-method environment unchanged.
+
+TIP: To make this permanent, add `export HOP_KEEP_A11Y=1` to your shell profile (for example `~/.bashrc` or `~/.profile`) or define the variable in your desktop session environment.
+
+== Wayland sessions
+
+When Hop detects a Wayland session (`XDG_SESSION_TYPE=wayland`), it sets `GDK_BACKEND=x11` so SWT uses the X11 backend.
+This workaround addresses rendering and input issues with Hop Gui on Wayland.
+See https://github.com/apache/hop/issues/4252[issue #4252] for background.
+
+This setting is independent of `HOP_KEEP_A11Y` and applies regardless of whether you enable full accessibility support.

--- a/docs/hop-user-manual/modules/ROOT/pages/installation-configuration.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/installation-configuration.adoc
@@ -171,6 +171,8 @@ include::snippets/variables/hop-java-home.adoc[]
 
 include::snippets/variables/hop-options.adoc[]
 
+include::snippets/variables/hop-keep-a11y.adoc[]
+
 === JDBC Drivers, Jars, Libraries, and other plugin dependencies
 
 Hop comes with built-in support for tens of databases and a large number of other technologies.

--- a/docs/hop-user-manual/modules/ROOT/pages/snippets/variables/hop-keep-a11y.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/snippets/variables/hop-keep-a11y.adoc
@@ -1,0 +1,20 @@
+////
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+////
+HOP_KEEP_A11Y::
+Linux only. Set this variable to `1` before starting Hop Gui if you rely on assistive technology (for example a screen reader) or an IBus-based input method for complex scripts.
+By default, Hop disables the AT-SPI accessibility bridge and IBus in `hop-gui.sh` and the `hop` launcher to avoid a temporary keyboard input stall on startup and shutdown.
+See xref:hop-gui/linux-desktop.adoc[Linux Desktop Configuration] for details.

--- a/docs/hop-user-manual/modules/ROOT/pages/variables.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/variables.adoc
@@ -329,6 +329,8 @@ include::snippets/variables/hop-plugin-base-folders.adoc[]
 
 include::snippets/variables/hop-shared-jdbc-folder.adoc[]
 
+include::snippets/variables/hop-keep-a11y.adoc[]
+
 Additionally, the following environment variables can help you to add even more fine-grained configuration for your Apache Hop installation:
 
 [%header, width="90%", cols="3,1,5"]


### PR DESCRIPTION
issue #7421

A fix for a super annoying issue on Linux desktops when starting/stopping the Hop GUI.
Adds option system variable `HOP_KEEP_A11Y` and the documentation for it.


## Fix keyboard input stall on Linux Hop GUI startup/shutdown (#7421)

### Problem

On Linux (especially Ubuntu/GNOME on X11 with many SWT plugins), Hop GUI can temporarily stop accepting keyboard input while starting up or shutting down. The AT-SPI accessibility bridge and IBus can block the X11 event loop during that window.

### Solution

On Linux, `hop-gui.sh` and the main `hop` launcher now set these environment variables **by default**:

| Variable | Effect |
|----------|--------|
| `NO_AT_BRIDGE=1` | Bypasses the AT-SPI accessibility bridge |
| `GTK_IM_MODULE=xim` | Switches GTK input method away from IBus |
| `IBUS_DISABLE=1` | Disables IBus |

This runs in the existing Linux `case` block, before the Wayland workaround for #4252.

### Accessibility / IME opt-out

Users who need full accessibility or IBus-based input methods (e.g. screen readers, CJK IME) can opt out:

```bash
export HOP_KEEP_A11Y=1
./hop-gui.sh
```

When `HOP_KEEP_A11Y` is set to any non-empty value, none of the three variables above are exported.

### Files changed

**Launcher scripts (code fix)**

- `assemblies/static/src/main/resources/hop-gui.sh`
- `assemblies/static/src/main/resources/hop`

**User manual (documentation)**

| File | Change |
|------|--------|
| `docs/hop-user-manual/modules/ROOT/pages/hop-gui/linux-desktop.adoc` | **New** — full explanation of the workaround, opt-out, and Wayland note |
| `docs/hop-user-manual/modules/ROOT/pages/snippets/variables/hop-keep-a11y.adoc` | **New** — reusable env-var snippet |
| `docs/hop-user-manual/modules/ROOT/pages/hop-gui/index.adoc` | Link to Linux Desktop page |
| `docs/hop-user-manual/modules/ROOT/nav.adoc` | Nav entry under Hop Gui |
| `docs/hop-user-manual/modules/ROOT/pages/installation-configuration.adoc` | Include `HOP_KEEP_A11Y` snippet |
| `docs/hop-user-manual/modules/ROOT/pages/variables.adoc` | Include `HOP_KEEP_A11Y` snippet |

### Testing suggestions for reviewers

1. **Default (no env var)** — On Ubuntu/GNOME/X11, start and quit Hop GUI; keyboard should remain responsive during startup/shutdown.
2. **With `HOP_KEEP_A11Y=1`** — Confirm screen reader / IBus IME still works as before the change.
3. **Wayland** — Unchanged; `GDK_BACKEND=x11` still applies independently of `HOP_KEEP_A11Y`.

### Related issues

- Fixes https://github.com/apache/hop/issues/7421
- Sits alongside existing workaround for https://github.com/apache/hop/issues/4252 (Wayland → X11)