### PR TITLE
Update toolbar icons and keyboard shortcuts in execution viewers #7234

### DIFF
--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/execution/PipelineExecutionViewer.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/execution/PipelineExecutionViewer.java
@@ -828,9 +828,9 @@ public class PipelineExecutionViewer extends BaseExecutionViewer
       root = GUI_PLUGIN_TOOLBAR_PARENT_ID,
       id = TOOLBAR_ITEM_TO_EDITOR,
       toolTip = "i18n::PipelineExecutionViewer.ToolbarElement.NavigateToEditor.Tooltip",
-      image = "ui/images/data_orch.svg")
-  @GuiKeyboardShortcut(key = SWT.F5)
-  @GuiOsxKeyboardShortcut(key = SWT.F5)
+      image = "ui/images/edit.svg")
+  @GuiKeyboardShortcut(key = SWT.F3)
+  @GuiOsxKeyboardShortcut(key = SWT.F3)
   public void navigateToEditor() {
     try {
       // First try to see if this pipeline is running in Hop GUI...

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/execution/WorkflowExecutionViewer.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/execution/WorkflowExecutionViewer.java
@@ -144,7 +144,7 @@ public class WorkflowExecutionViewer extends BaseExecutionViewer
   private org.eclipse.swt.widgets.List dataList;
   private TableView dataView;
 
-  private Map<String, List<ExecutionData>> actionExecutions;
+  private final Map<String, List<ExecutionData>> actionExecutions;
 
   public WorkflowExecutionViewer(
       Composite parent,
@@ -649,7 +649,7 @@ public class WorkflowExecutionViewer extends BaseExecutionViewer
           if (!Utils.isEmpty(executionDataList)) {
             // Just consider the first
             //
-            ExecutionData executionData = executionDataList.get(0);
+            ExecutionData executionData = executionDataList.getFirst();
 
             RowBuffer rowBuffer = executionData.getDataSets().get(ExecutionDataBuilder.KEY_RESULT);
             if (rowBuffer != null) {
@@ -737,7 +737,9 @@ public class WorkflowExecutionViewer extends BaseExecutionViewer
       root = GUI_PLUGIN_TOOLBAR_PARENT_ID,
       id = TOOLBAR_ITEM_TO_EDITOR,
       toolTip = "i18n::WorkflowExecutionViewer.ToolbarElement.NavigateToEditor.Tooltip",
-      image = "ui/images/data_orch.svg")
+      image = "ui/images/edit.svg")
+  @GuiKeyboardShortcut(key = SWT.F3)
+  @GuiOsxKeyboardShortcut(key = SWT.F3)
   public void navigateToEditor() {
     try {
       // First try to see if this workflow is running in Hop GUI...
@@ -884,7 +886,7 @@ public class WorkflowExecutionViewer extends BaseExecutionViewer
 
       // Get any execution data for the selected action
       //
-      selectedExecutionData = executionDataList.get(0);
+      selectedExecutionData = executionDataList.getFirst();
 
       Map<String, ExecutionDataSetMeta> setMetaData = selectedExecutionData.getSetMetaData();
       List<String> items = new ArrayList<>();
@@ -960,7 +962,7 @@ public class WorkflowExecutionViewer extends BaseExecutionViewer
       Execution child;
 
       if (childExecutions.size() == 1) {
-        child = childExecutions.get(0);
+        child = childExecutions.getFirst();
       } else {
         // Select the execution...
         //


### PR DESCRIPTION
- Changed toolbar icon from `data_orch.svg` to `edit.svg` for both PipelineExecutionViewer and WorkflowExecutionViewer.
- Updated keyboard shortcut for navigating to the editor from `F5` to `F3`.
- Refactored code to use `getFirst()` instead of `get(0)` for cleaner and safer list access.
- Marked `actionExecutions` as `final` in WorkflowExecutionViewer.
