### PR TITLE
issue #7442 : markdown tables not rendered

### DIFF
--- a/plugins/transforms/textfile/pom.xml
+++ b/plugins/transforms/textfile/pom.xml
@@ -46,6 +46,24 @@
             <version>${commonmark.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.commonmark</groupId>
+            <artifactId>commonmark-ext-footnotes</artifactId>
+            <version>${commonmark.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.commonmark</groupId>
+            <artifactId>commonmark-ext-gfm-tables</artifactId>
+            <version>${commonmark.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.commonmark</groupId>
+            <artifactId>commonmark-ext-task-list-items</artifactId>
+            <version>${commonmark.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/types/MarkDownExplorerFileTypeHandler.java
+++ b/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/types/MarkDownExplorerFileTypeHandler.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import org.apache.hop.core.Props;
 import org.apache.hop.core.gui.plugin.GuiPlugin;
 import org.apache.hop.core.gui.plugin.toolbar.GuiToolbarElement;
@@ -37,6 +38,10 @@ import org.apache.hop.ui.hopgui.perspective.explorer.ExplorerFile;
 import org.apache.hop.ui.hopgui.perspective.explorer.ExplorerPerspective;
 import org.apache.hop.ui.hopgui.perspective.explorer.file.types.text.BaseTextExplorerFileTypeHandler;
 import org.apache.hop.ui.util.EnvironmentUtils;
+import org.commonmark.Extension;
+import org.commonmark.ext.footnotes.FootnotesExtension;
+import org.commonmark.ext.gfm.tables.TablesExtension;
+import org.commonmark.ext.task.list.items.TaskListItemsExtension;
 import org.commonmark.node.Node;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
@@ -55,6 +60,10 @@ public class MarkDownExplorerFileTypeHandler extends BaseTextExplorerFileTypeHan
   public static final String TOOLBAR_PARENT_ID = "MarkDownExplorerFileTypeHandler-Toolbar";
   public static final String TOOLBAR_ITEM_PREVIEW =
       "MarkDownExplorerFileTypeHandler-ToolBar-Preview";
+
+  private static final List<Extension> MARKDOWN_EXTENSIONS =
+      List.of(
+          TablesExtension.create(), TaskListItemsExtension.create(), FootnotesExtension.create());
 
   public MarkDownExplorerFileTypeHandler(
       HopGui hopGui, ExplorerPerspective perspective, ExplorerFile explorerFile) {
@@ -125,8 +134,8 @@ public class MarkDownExplorerFileTypeHandler extends BaseTextExplorerFileTypeHan
       String markdown = editorWidget.getText();
 
       // Parse markdown to HTML body content
-      Parser parser = Parser.builder().build();
-      HtmlRenderer renderer = HtmlRenderer.builder().build();
+      Parser parser = Parser.builder().extensions(MARKDOWN_EXTENSIONS).build();
+      HtmlRenderer renderer = HtmlRenderer.builder().extensions(MARKDOWN_EXTENSIONS).build();
       Node document = parser.parse(markdown);
       String htmlContent = renderer.render(document);
 
@@ -186,6 +195,22 @@ public class MarkDownExplorerFileTypeHandler extends BaseTextExplorerFileTypeHan
       html.append("  border-left-width: 4px;\n");
       html.append("  border-left-style: solid;\n");
       html.append("}\n");
+      html.append("table {\n");
+      html.append("  width: 100%;\n");
+      html.append("  margin: 1.5em 0;\n");
+      html.append("  border-collapse: collapse;\n");
+      html.append("  border-radius: 6px;\n");
+      html.append("  overflow: hidden;\n");
+      html.append("  font-size: 0.95em;\n");
+      html.append("}\n");
+      html.append("th, td {\n");
+      html.append("  padding: 0.6em 0.85em;\n");
+      html.append("  border: 1px solid;\n");
+      html.append("  text-align: left;\n");
+      html.append("}\n");
+      html.append("th {\n");
+      html.append("  font-weight: 600;\n");
+      html.append("}\n");
 
       if (PropsUi.getInstance().isDarkMode()) {
         html.append("body {\n");
@@ -211,6 +236,19 @@ public class MarkDownExplorerFileTypeHandler extends BaseTextExplorerFileTypeHan
         html.append("  color: #94a3b8;\n");
         html.append("  background-color: #0f172a;\n");
         html.append("}\n");
+        html.append("table {\n");
+        html.append("  background-color: #0f172a;\n");
+        html.append("}\n");
+        html.append("th, td {\n");
+        html.append("  border-color: #334155;\n");
+        html.append("}\n");
+        html.append("th {\n");
+        html.append("  background-color: #1e293b;\n");
+        html.append("  color: #f8fafc;\n");
+        html.append("}\n");
+        html.append("tbody tr:nth-child(even) {\n");
+        html.append("  background-color: #111827;\n");
+        html.append("}\n");
       } else {
         html.append("body {\n");
         html.append("  background-color: #f8fafc;\n");
@@ -233,6 +271,19 @@ public class MarkDownExplorerFileTypeHandler extends BaseTextExplorerFileTypeHan
         html.append("blockquote {\n");
         html.append("  border-left-color: #cbd5e1;\n");
         html.append("  color: #64748b;\n");
+        html.append("  background-color: #f8fafc;\n");
+        html.append("}\n");
+        html.append("table {\n");
+        html.append("  background-color: #ffffff;\n");
+        html.append("}\n");
+        html.append("th, td {\n");
+        html.append("  border-color: #e2e8f0;\n");
+        html.append("}\n");
+        html.append("th {\n");
+        html.append("  background-color: #f1f5f9;\n");
+        html.append("  color: #0f172a;\n");
+        html.append("}\n");
+        html.append("tbody tr:nth-child(even) {\n");
         html.append("  background-color: #f8fafc;\n");
         html.append("}\n");
       }


### PR DESCRIPTION
# Issue #7442 — Markdown preview: GFM table rendering

Recap for code reviewers.

## Summary

The Markdown file preview in the Hop file explorer (`MarkDownExplorerFileTypeHandler.previewMarkdown()`) did not render GFM pipe tables correctly. Tables appeared as plain paragraphs with literal `|` characters instead of HTML `<table>` elements.

This change adds the required CommonMark extensions, registers them on the parser and renderer, and adds table-specific CSS for both light and dark mode previews.

## Problem

`previewMarkdown()` used the base CommonMark parser with no extensions:

```java
Parser parser = Parser.builder().build();
HtmlRenderer renderer = HtmlRenderer.builder().build();
```

CommonMark core does not support GFM tables. A report such as `retail-dv-initial-report.md` (pipe tables with alignment markers like `---:`) was parsed into eight `<p>| ... |</p>` blocks and zero `<table>` elements.

Headings, bold text, inline code, and lists rendered correctly; only GFM-specific syntax was broken.

## Solution

### 1. Dependencies (`plugins/transforms/textfile/pom.xml`)

Three CommonMark extensions were added (all `provided` scope, version `${commonmark.version}` = `0.29.0`):

| Artifact | Purpose |
|---|---|
| `commonmark-ext-gfm-tables` | Pipe tables and column alignment |
| `commonmark-ext-task-list-items` | `- [x]` / `- [ ]` task lists |
| `commonmark-ext-footnotes` | `[^1]` footnotes |

These match the existing pattern for `commonmark` core in the textfile plugin.

### 2. Extension registration (`MarkDownExplorerFileTypeHandler.java`)

Extensions are configured once in a static list and passed to both builder instances:

```java
private static final List<Extension> MARKDOWN_EXTENSIONS =
    List.of(
        TablesExtension.create(),
        TaskListItemsExtension.create(),
        FootnotesExtension.create());

Parser parser = Parser.builder().extensions(MARKDOWN_EXTENSIONS).build();
HtmlRenderer renderer = HtmlRenderer.builder().extensions(MARKDOWN_EXTENSIONS).build();
```

Parser and HtmlRenderer are thread-safe when built this way, so the static list is appropriate.

### 3. Table CSS in preview HTML

The inline preview stylesheet had no `table` rules. Shared layout rules were added (full width, collapsed borders, padding, rounded corners), plus mode-specific colors:

**Light mode**
- Table background: `#ffffff`
- Header background: `#f1f5f9`
- Borders: `#e2e8f0`
- Alternating rows: `#f8fafc`

**Dark mode**
- Table background: `#0f172a`
- Header background: `#1e293b`
- Borders: `#334155`
- Alternating rows: `#111827`

Colors follow the existing slate palette already used for body, code blocks, and blockquotes.

## Files changed

| File | Change |
|---|---|
| `plugins/transforms/textfile/pom.xml` | +3 CommonMark extension dependencies |
| `plugins/transforms/textfile/src/main/java/.../MarkDownExplorerFileTypeHandler.java` | Extension registration + table CSS |

**Diff size:** 2 files, +71 / −2 lines.

## Review focus

1. **Classpath / assembly** — Extension JARs use `provided` scope like `commonmark` core. Confirm they are bundled into the Hop client distribution at runtime (same mechanism as the existing `commonmark` dependency via the textfile plugin).
2. **LICENSE** — If ASF release policy requires it, the static `LICENSE` file may need entries for the three new extension artifacts (currently only `commonmark` core is listed).
3. **Scope** — Only the explorer Markdown preview is updated. `DocBuilder.markdownToHtml()` in `plugins/misc/documentation` still uses the bare parser and would have the same table limitation if HTML doc generation is expected to handle GFM tables.
4. **No new tests** — Existing `MarkDownExplorerFileTypeTest` covers file-type metadata only, not preview rendering. Consider whether a small unit test asserting `<table>` output for a pipe-table snippet is worth adding in a follow-up.

## Manual verification

1. Build and start Hop GUI.
2. Open a `.md` file with GFM tables (e.g. a data-vault load report).
3. Click the preview toolbar button.
4. Confirm:
   - Tables render as bordered HTML tables, not pipe-separated paragraphs.
   - Header row has a distinct background.
   - Alternating row shading is visible.
   - Appearance is correct in both light and dark mode.

## Out of scope / known limitations

- No syntax highlighting for fenced code blocks (would need a separate JS/CSS library).
- No `commonmark-ext-autolink` or `commonmark-ext-gfm-strikethrough` — bare URLs and `~~strikethrough~~` still render as literal text.
- No `ul`/`ol` list styling added (lists were already readable).
- Documentation plugin HTML generation unchanged.