### PR TITLE
issue #7245 : show unit test variables in pipeline run dialog

### DIFF
--- a/plugins/misc/testing/src/main/java/org/apache/hop/testing/xp/HopGuiUnitTestVariablesExtensionPoint.java
+++ b/plugins/misc/testing/src/main/java/org/apache/hop/testing/xp/HopGuiUnitTestVariablesExtensionPoint.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.testing.xp;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hop.core.Const;
+import org.apache.hop.core.exception.HopException;
+import org.apache.hop.core.extension.ExtensionPoint;
+import org.apache.hop.core.extension.IExtensionPoint;
+import org.apache.hop.core.logging.ILogChannel;
+import org.apache.hop.core.variables.IVariables;
+import org.apache.hop.pipeline.PipelineExecutionConfiguration;
+import org.apache.hop.pipeline.PipelineMeta;
+import org.apache.hop.testing.PipelineUnitTest;
+import org.apache.hop.testing.VariableValue;
+import org.apache.hop.testing.util.DataSetConst;
+import org.apache.hop.ui.hopgui.HopGui;
+import org.apache.hop.ui.hopgui.file.pipeline.HopGuiPipelineGraph;
+
+/**
+ * When a pipeline unit test is selected in Hop GUI, copy its configured variables into the pipeline
+ * execution configuration so they appear on the Variables tab of the run dialog.
+ */
+@ExtensionPoint(
+    extensionPointId = "HopGuiPipelineExecutionConfiguration",
+    id = "HopGuiUnitTestVariablesExtensionPoint",
+    description =
+        "Add variables defined in the active pipeline unit test to the execution configuration dialog")
+public class HopGuiUnitTestVariablesExtensionPoint
+    implements IExtensionPoint<PipelineExecutionConfiguration> {
+
+  @Override
+  public void callExtensionPoint(
+      ILogChannel log, IVariables variables, PipelineExecutionConfiguration executionConfiguration)
+      throws HopException {
+
+    HopGuiPipelineGraph activePipelineGraph = HopGui.getActivePipelineGraph();
+    if (activePipelineGraph == null) {
+      return;
+    }
+
+    Map<String, Object> stateMap = activePipelineGraph.getStateMap();
+    if (stateMap == null) {
+      return;
+    }
+
+    PipelineUnitTest unitTest =
+        (PipelineUnitTest) stateMap.get(DataSetConst.STATE_KEY_ACTIVE_UNIT_TEST);
+    if (unitTest == null) {
+      return;
+    }
+
+    applyUnitTestVariables(
+        executionConfiguration, unitTest, activePipelineGraph.getPipelineMeta(), variables);
+  }
+
+  /**
+   * Copy unit test variables (and parameter-named entries) into the execution configuration maps.
+   * Package-private for unit testing without Hop GUI.
+   */
+  static void applyUnitTestVariables(
+      PipelineExecutionConfiguration executionConfiguration,
+      PipelineUnitTest unitTest,
+      PipelineMeta pipelineMeta,
+      IVariables variables) {
+    if (executionConfiguration == null || unitTest == null) {
+      return;
+    }
+
+    List<VariableValue> variableValues = unitTest.getVariableValues();
+    if (variableValues == null || variableValues.isEmpty()) {
+      return;
+    }
+
+    String[] parameters = pipelineMeta != null ? pipelineMeta.listParameters() : new String[0];
+
+    for (VariableValue variableValue : variableValues) {
+      if (variableValue == null) {
+        continue;
+      }
+
+      String key = variableValue.getKey();
+      String value = variableValue.getValue();
+      if (variables != null) {
+        key = variables.resolve(key);
+        value = variables.resolve(value);
+      }
+      if (StringUtils.isEmpty(key)) {
+        continue;
+      }
+
+      String resolvedValue = Const.NVL(value, "");
+      if (Const.indexOfString(key, parameters) < 0) {
+        executionConfiguration.getVariablesMap().put(key, resolvedValue);
+      } else {
+        executionConfiguration.getParametersMap().put(key, resolvedValue);
+      }
+    }
+  }
+}

--- a/plugins/misc/testing/src/test/java/org/apache/hop/testing/xp/HopGuiUnitTestVariablesExtensionPointTest.java
+++ b/plugins/misc/testing/src/test/java/org/apache/hop/testing/xp/HopGuiUnitTestVariablesExtensionPointTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.testing.xp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.hop.core.variables.Variables;
+import org.apache.hop.pipeline.PipelineExecutionConfiguration;
+import org.apache.hop.pipeline.PipelineMeta;
+import org.apache.hop.testing.PipelineUnitTest;
+import org.apache.hop.testing.VariableValue;
+import org.junit.jupiter.api.Test;
+
+class HopGuiUnitTestVariablesExtensionPointTest {
+
+  @Test
+  void applyUnitTestVariablesPutsEntriesInVariablesMap() {
+    PipelineUnitTest unitTest = new PipelineUnitTest();
+    unitTest.getVariableValues().add(new VariableValue("UNIT_VAR", "unit-value"));
+    unitTest.getVariableValues().add(new VariableValue("OTHER", "other-value"));
+
+    PipelineExecutionConfiguration config = new PipelineExecutionConfiguration();
+    config.getVariablesMap().put("EXISTING", "keep-me");
+
+    HopGuiUnitTestVariablesExtensionPoint.applyUnitTestVariables(
+        config, unitTest, new PipelineMeta(), new Variables());
+
+    assertEquals("unit-value", config.getVariablesMap().get("UNIT_VAR"));
+    assertEquals("other-value", config.getVariablesMap().get("OTHER"));
+    assertEquals("keep-me", config.getVariablesMap().get("EXISTING"));
+  }
+
+  @Test
+  void applyUnitTestVariablesOverridesExistingVariableWithSameName() {
+    PipelineUnitTest unitTest = new PipelineUnitTest();
+    unitTest.getVariableValues().add(new VariableValue("SHARED", "from-unit-test"));
+
+    PipelineExecutionConfiguration config = new PipelineExecutionConfiguration();
+    config.getVariablesMap().put("SHARED", "from-previous-run");
+
+    HopGuiUnitTestVariablesExtensionPoint.applyUnitTestVariables(
+        config, unitTest, new PipelineMeta(), new Variables());
+
+    assertEquals("from-unit-test", config.getVariablesMap().get("SHARED"));
+  }
+
+  @Test
+  void applyUnitTestVariablesPutsParameterNamesInParametersMap() throws Exception {
+    PipelineMeta pipelineMeta = new PipelineMeta();
+    pipelineMeta.addParameterDefinition("INPUT_PARAM", "default", "description");
+
+    PipelineUnitTest unitTest = new PipelineUnitTest();
+    unitTest.getVariableValues().add(new VariableValue("INPUT_PARAM", "param-value"));
+    unitTest.getVariableValues().add(new VariableValue("PLAIN_VAR", "var-value"));
+
+    PipelineExecutionConfiguration config = new PipelineExecutionConfiguration();
+
+    HopGuiUnitTestVariablesExtensionPoint.applyUnitTestVariables(
+        config, unitTest, pipelineMeta, new Variables());
+
+    assertEquals("param-value", config.getParametersMap().get("INPUT_PARAM"));
+    assertFalse(config.getVariablesMap().containsKey("INPUT_PARAM"));
+    assertEquals("var-value", config.getVariablesMap().get("PLAIN_VAR"));
+  }
+
+  @Test
+  void applyUnitTestVariablesSkipsEmptyKeysAndNullEntries() {
+    PipelineUnitTest unitTest = new PipelineUnitTest();
+    unitTest.getVariableValues().add(null);
+    unitTest.getVariableValues().add(new VariableValue("", "ignored"));
+    unitTest.getVariableValues().add(new VariableValue(null, "ignored-too"));
+    unitTest.getVariableValues().add(new VariableValue("OK", null));
+
+    PipelineExecutionConfiguration config = new PipelineExecutionConfiguration();
+
+    HopGuiUnitTestVariablesExtensionPoint.applyUnitTestVariables(
+        config, unitTest, new PipelineMeta(), new Variables());
+
+    assertEquals(1, config.getVariablesMap().size());
+    assertTrue(config.getVariablesMap().containsKey("OK"));
+    assertEquals("", config.getVariablesMap().get("OK"));
+  }
+
+  @Test
+  void applyUnitTestVariablesResolvesKeyAndValueAgainstVariables() {
+    Variables variables = new Variables();
+    variables.setVariable("PREFIX", "env");
+    variables.setVariable("SUFFIX", "prod");
+
+    PipelineUnitTest unitTest = new PipelineUnitTest();
+    unitTest.getVariableValues().add(new VariableValue("${PREFIX}_MODE", "${SUFFIX}"));
+
+    PipelineExecutionConfiguration config = new PipelineExecutionConfiguration();
+
+    HopGuiUnitTestVariablesExtensionPoint.applyUnitTestVariables(
+        config, unitTest, new PipelineMeta(), variables);
+
+    assertEquals("prod", config.getVariablesMap().get("env_MODE"));
+  }
+
+  @Test
+  void applyUnitTestVariablesNoopsWhenNoUnitTestVariables() {
+    PipelineUnitTest unitTest = new PipelineUnitTest();
+    PipelineExecutionConfiguration config = new PipelineExecutionConfiguration();
+    config.getVariablesMap().put("KEEP", "yes");
+
+    HopGuiUnitTestVariablesExtensionPoint.applyUnitTestVariables(
+        config, unitTest, new PipelineMeta(), new Variables());
+
+    assertEquals(1, config.getVariablesMap().size());
+    assertEquals("yes", config.getVariablesMap().get("KEEP"));
+  }
+}

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/delegates/HopGuiPipelineRunDelegate.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/delegates/HopGuiPipelineRunDelegate.java
@@ -159,6 +159,14 @@ public class HopGuiPipelineRunDelegate {
       }
     }
 
+    // Let plugins enrich the execution configuration (for example unit test variables) before the
+    // configuration dialog is shown so the user can review and change the values.
+    ExtensionPointHandler.callExtensionPoint(
+        log,
+        pipelineGraph.getVariables(),
+        HopExtensionPoint.HopGuiPipelineExecutionConfiguration.id,
+        executionConfiguration);
+
     boolean execConfigAnswer = true;
 
     if (debugAnswer == PipelineDebugDialog.DEBUG_CONFIG) {
@@ -216,11 +224,6 @@ public class HopGuiPipelineRunDelegate {
           pipelineGraph.getVariables(),
           HopExtensionPoint.HopGuiPipelineMetaExecutionStart.id,
           pipelineMeta);
-      ExtensionPointHandler.callExtensionPoint(
-          log,
-          pipelineGraph.getVariables(),
-          HopExtensionPoint.HopGuiPipelineExecutionConfiguration.id,
-          executionConfiguration);
 
       if (previewDebug) {
         if (pipelineDebugMeta.getNrOfUsedTransforms() == 0) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a pipeline unit test is selected in Hop GUI, its configured variables are now pre-loaded into the Variables (and Parameters) tabs of the pipeline execution dialog so the user can review and change them before running.

### Details

- Move `HopGuiPipelineExecutionConfiguration` in `HopGuiPipelineRunDelegate.executePipeline()` to **before** the run configuration dialog (matching the extension point description).
- Add `HopGuiUnitTestVariablesExtensionPoint` in the testing plugin to copy active unit-test variables into the execution configuration.
- Parameter-named unit-test entries go into the parameters map; others into the variables map.
- Keys/values are resolved against the current variables; unit-test values override existing map entries.

## What was tested?

- Manual: select a unit test with variables, open Launch — variables appear on the Variables tab.
- Unit tests: `HopGuiUnitTestVariablesExtensionPointTest` (6 tests)

## How can this be tested?

1. Open a pipeline that has a unit test with variables defined.
2. Select that unit test in the toolbar.
3. Run / Launch the pipeline.
4. Confirm the unit test variables appear on the Variables tab (and parameter-named ones on Parameters).
5. Change a value and launch — confirm the edited value is used for that run.

Fixes: #7245