### PR TITLE
Fix MongoDB ObjectId JSON match fields

### DIFF
--- a/plugins/tech/mongodb/src/main/java/org/apache/hop/pipeline/transforms/mongodboutput/MongoDbOutputData.java
+++ b/plugins/tech/mongodb/src/main/java/org/apache/hop/pipeline/transforms/mongodboutput/MongoDbOutputData.java
@@ -815,7 +815,7 @@ public class MongoDbOutputData extends BaseTransformData implements ITransformDa
         {
           String val = hopType.getString(hopValue);
           if (hopValueIsJSON) {
-            valueToSet = Document.parse(val);
+            valueToSet = Document.parse("{\"value\":" + val + "}").get("value");
           } else {
             valueToSet = val;
           }

--- a/plugins/tech/mongodb/src/test/java/org/apache/hop/pipeline/transforms/mongodboutput/MongoDbOutputDataTest.java
+++ b/plugins/tech/mongodb/src/test/java/org/apache/hop/pipeline/transforms/mongodboutput/MongoDbOutputDataTest.java
@@ -46,6 +46,7 @@ import org.apache.hop.mongo.wrapper.collection.MongoCollectionWrapper;
 import org.apache.hop.pipeline.transforms.mongodboutput.MongoDbOutputMeta.MongoIndex;
 import org.bson.Document;
 import org.bson.conversions.Bson;
+import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -255,6 +256,29 @@ class MongoDbOutputDataTest {
     // Compare the contents rather than toString() representation
     Document expected = Document.parse(query);
     assertThat(result.get("foo"), equalTo(expected.get("foo")));
+  }
+
+  @Test
+  void testGetQueryObjectWithIncomingObjectIdJson() throws HopException {
+    MongoDbOutputMeta.MongoField field = new MongoDbOutputMeta.MongoField();
+    field.inputJson = true;
+    field.updateMatchField = true;
+    field.mongoDocPath = "_id";
+    field.environUpdateMongoDocPath = "_id";
+    when(rowMeta.getValueMeta(anyInt())).thenReturn(valueMeta);
+    when(valueMeta.getType()).thenReturn(IValueMeta.TYPE_STRING);
+    when(valueMeta.getString(any(Object.class)))
+        .thenReturn("{\"$oid\":\"6a15efdd0a93aa5ed3b4b947\"}");
+
+    Document result =
+        MongoDbOutputData.getQueryObject(
+            Collections.singletonList(field),
+            rowMeta,
+            new Object[] {"object id"},
+            variables,
+            MongoDbOutputData.MongoTopLevel.RECORD);
+
+    assertThat(result.get("_id"), equalTo(new ObjectId("6a15efdd0a93aa5ed3b4b947")));
   }
 
   @Test


### PR DESCRIPTION
## What changed

- Parse incoming JSON field values through a temporary wrapper document before assigning them to MongoDB documents.
- Add a regression test for using extended JSON `{"$oid": "..."}` as an `_id` update match field.

## Why

After the BSON 5.x upgrade, parsing top-level extended JSON ObjectId values directly with `Document.parse()` throws `BsonInvalidOperationException`. Wrapping the value in a document lets the BSON codec decode the extended JSON scalar and preserves its `ObjectId` type.

This restores ObjectId matching in the MongoDB Output transform instead of treating the value as a string or failing during query construction.

Fixes #7183.

## Validation

- `./mvnw -pl plugins/tech/mongodb -Dtest=MongoDbOutputDataTest test`
- `./mvnw -pl plugins/tech/mongodb test` (214 tests, 0 failures)
