### PR TITLE
[#7499] Fix SQL token merging when removing comments

### DIFF
--- a/core/src/main/java/org/apache/hop/core/database/SqlScriptParser.java
+++ b/core/src/main/java/org/apache/hop/core/database/SqlScriptParser.java
@@ -198,6 +198,12 @@ public class SqlScriptParser {
           if (ch == '*' && nextCh == '/') {
             mode = MODE.SQL;
             i = i + 1;
+            if (!result.isEmpty()
+                && i + 1 < script.length()
+                && isSqlWordCharacter(result.charAt(result.length() - 1))
+                && isSqlWordCharacter(script.charAt(i + 1))) {
+              result.append(' ');
+            }
           }
           ch = 0;
           break;
@@ -242,5 +248,9 @@ public class SqlScriptParser {
     }
 
     return result.toString();
+  }
+
+  private static boolean isSqlWordCharacter(char ch) {
+    return Character.isLetterOrDigit(ch) || ch == '_' || ch == '$';
   }
 }

--- a/core/src/test/java/org/apache/hop/core/database/SqlScriptParserTest.java
+++ b/core/src/test/java/org/apache/hop/core/database/SqlScriptParserTest.java
@@ -93,6 +93,7 @@ class SqlScriptParserTest {
         "SELECT  col1 FROM  account",
         sqlScriptParser.removeComments(
             "SELECT /* \"my_column'\" */ col1 FROM /* 'my_table' */ account"));
+    assertEquals("SELECT 1", sqlScriptParser.removeComments("SELECT/* comment */1"));
     assertEquals(
         "SELECT '/' as col1, '*/*' as regex ",
         sqlScriptParser.removeComments("SELECT '/' as col1, '*/*' as regex "));


### PR DESCRIPTION
Fixes block-comment removal in `SqlScriptParser` so SQL word tokens on either side of a comment remain separated.

Previously, removing a comment from `SELECT/* comment */1` produced `SELECT1`, changing valid SQL into an invalid merged token. The parser now inserts a separator only when both adjacent characters are SQL word characters, preserving existing punctuation-sensitive output.

A regression test covers the failing input and expected output.

Addresses #7499.

Validation:

- `./mvnw -pl core -Dtest=SqlScriptParserTest test`
- `git diff --check`

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
