### PR TITLE
Fix Hop Server system property value parsing

### DIFF
--- a/engine/src/main/java/org/apache/hop/www/HopServer.java
+++ b/engine/src/main/java/org/apache/hop/www/HopServer.java
@@ -520,7 +520,7 @@ public class HopServer implements Runnable, IHasHopMetadataProvider, IHopCommand
     //
     if (systemProperties != null) {
       for (String parameter : systemProperties) {
-        String[] split = parameter.split("=");
+        String[] split = parameter.split("=", 2);
         String key = split.length > 0 ? split[0] : null;
         String value = split.length > 1 ? split[1] : null;
         if (StringUtils.isNotEmpty(key) && StringUtils.isNotEmpty(value)) {

--- a/engine/src/test/java/org/apache/hop/www/HopServerTest.java
+++ b/engine/src/test/java/org/apache/hop/www/HopServerTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.www;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class HopServerTest {
+
+  @Test
+  void testApplySystemPropertiesPreservesEqualsSignsInValue() {
+    String key = "hop.test.connection.url";
+    String value = "jdbc:test://localhost/database?user=admin";
+    HopServer hopServer = new HopServer();
+    hopServer.setSystemProperties(new String[] {key + "=" + value});
+
+    try {
+      hopServer.applySystemProperties();
+
+      assertEquals(value, System.getProperty(key));
+    } finally {
+      System.clearProperty(key);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- preserve equals signs contained in Hop Server system property values
- add a regression test covering a JDBC-style URL with a query parameter

## Problem

Hop Server split each `KEY=VALUE` system property at every equals sign and used only the second segment. Values containing additional equals signs, including JDBC URLs, query strings, signed tokens, and encoded configuration, were silently truncated.

## Fix

Limit the split to two parts so only the first equals sign separates the property name from its value.

Fixes #7502.

## Validation

```text
./mvnw -pl engine -Dtest=org.apache.hop.www.HopServerTest test
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

`git diff --check` also passes.
