### PR TITLE
issue #7502 : preserve equals signs in HopServer system property values

### DIFF
--- a/engine/src/main/java/org/apache/hop/www/HopServer.java
+++ b/engine/src/main/java/org/apache/hop/www/HopServer.java
@@ -649,7 +649,7 @@ public class HopServer implements Runnable, IHasHopMetadataProvider, IHopCommand
     //
     if (systemProperties != null) {
       for (String parameter : systemProperties) {
-        String[] split = parameter.split("=");
+        String[] split = parameter.split("=", 2);
         String key = split.length > 0 ? split[0] : null;
         String value = split.length > 1 ? split[1] : null;
         if (StringUtils.isNotEmpty(key) && StringUtils.isNotEmpty(value)) {


### PR DESCRIPTION
## Summary

- Fix `HopServer.applySystemProperties()` to split on the first `=` only (`split("=", 2)`), matching `Hop` and `HopRun`.
- System property values that contain additional equals signs (JDBC URLs, query strings, tokens) are no longer truncated.

Fixes #7502

## Test plan

- [ ] Start Hop Server with `--system-properties key=value=with=equals`
- [ ] Confirm `System.getProperty("key")` returns the full value after the first `=`
- [ ] Confirm simple `key=value` properties still work as before