### PR TITLE
issue #7516 : fix integration tests broken by single-JVM runner

### DIFF
--- a/core/src/main/java/org/apache/hop/core/parameters/NamedParameters.java
+++ b/core/src/main/java/org/apache/hop/core/parameters/NamedParameters.java
@@ -137,8 +137,19 @@ public class NamedParameters implements INamedParameters {
   public void activateParameters(IVariables variables) {
     for (NamedParameter param : params.values()) {
       if (StringUtils.isNotEmpty(param.key)) {
-        variables.setVariable(
-            param.getKey(), Const.NVL(param.getValue(), Const.NVL(param.getDefaultValue(), "")));
+        String value = param.getValue();
+        if (StringUtils.isEmpty(value)) {
+          // Prefer an already-set variable (environment / parent) over the parameter default.
+          // Nested workflows and pipelines used to clobber env values such as HOSTNAME or
+          // BOOTSTRAP_SERVERS when activateParameters applied empty defaults.
+          String existing = variables != null ? variables.getVariable(param.getKey()) : null;
+          if (StringUtils.isNotEmpty(existing)) {
+            value = existing;
+          } else {
+            value = Const.NVL(param.getDefaultValue(), "");
+          }
+        }
+        variables.setVariable(param.getKey(), value);
       }
     }
   }

--- a/core/src/test/java/org/apache/hop/core/parameters/NamedParamsDefaultTest.java
+++ b/core/src/test/java/org/apache/hop/core/parameters/NamedParamsDefaultTest.java
@@ -79,6 +79,36 @@ class NamedParamsDefaultTest {
   }
 
   @Test
+  void testActivateParametersPrefersExistingVariableOverDefault() throws Exception {
+    Variables variables = new Variables();
+    variables.setVariable("HOSTNAME", "http");
+    variables.setVariable("BOOTSTRAP_SERVERS", "kafka:9092");
+
+    namedParams.addParameterDefinition("HOSTNAME", "localhost", "HTTP host");
+    namedParams.addParameterDefinition("BOOTSTRAP_SERVERS", "", "Kafka bootstrap");
+    namedParams.addParameterDefinition("ONLY_DEFAULT", "from-default", "No prior variable");
+
+    namedParams.activateParameters(variables);
+
+    assertEquals("http", variables.getVariable("HOSTNAME"));
+    assertEquals("kafka:9092", variables.getVariable("BOOTSTRAP_SERVERS"));
+    assertEquals("from-default", variables.getVariable("ONLY_DEFAULT"));
+  }
+
+  @Test
+  void testActivateParametersExplicitValueWinsOverExistingVariable() throws Exception {
+    Variables variables = new Variables();
+    variables.setVariable("HOSTNAME", "http");
+
+    namedParams.addParameterDefinition("HOSTNAME", "localhost", "HTTP host");
+    namedParams.setParameterValue("HOSTNAME", "explicit-host");
+
+    namedParams.activateParameters(variables);
+
+    assertEquals("explicit-host", variables.getVariable("HOSTNAME"));
+  }
+
+  @Test
   void testAddParameterDefinitionWithException() throws DuplicateParamException {
     namedParams.addParameterDefinition("key", "value", "description");
 

--- a/engine/src/main/java/org/apache/hop/run/HopRunBase.java
+++ b/engine/src/main/java/org/apache/hop/run/HopRunBase.java
@@ -290,7 +290,10 @@ public abstract class HopRunBase implements Runnable, IHasHopMetadataProvider {
           PipelineEngineFactory.createPipelineEngine(
               variables, pipelineRunConfigurationName, metadataProvider, pipelineMeta);
       pipeline.getPipelineMeta().setInternalHopVariables(pipeline);
-      pipeline.initializeFrom(null);
+      // Do not call initializeFrom(null) here: the factory already initialized the engine from
+      // hop-run's variables (project + environment). Re-initializing from null would drop those
+      // values (e.g. HOSTNAME, TEST_0012) and only re-apply hop-config defaults — breaking the
+      // single-JVM IT suite runner and any hop-run of a pipeline with -e.
 
       List<EngineCompatibilityChecker.Violation> pipelineViolations =
           EngineCompatibilityChecker.checkPipeline(pipelineMeta, pipeline);

--- a/integration-tests/aes/dev-env-config.json
+++ b/integration-tests/aes/dev-env-config.json
@@ -3,5 +3,13 @@
     "name" : "AES2_PASSWORD",
     "value" : "AES2 5SPGXV3SEPhoDRiYIxBv+wtnSC7WQYoYU6zyJx1Y75sEzHAM",
     "description" : ""
+  }, {
+    "name" : "HOP_PASSWORD_ENCODER_PLUGIN",
+    "value" : "AES2",
+    "description" : "AES2 encoder required to decrypt AES2_PASSWORD in this suite"
+  }, {
+    "name" : "HOP_AES_ENCODER_KEY",
+    "value" : "abcdef",
+    "description" : "Key matching the ciphertext stored in AES2_PASSWORD"
   } ]
 }

--- a/integration-tests/aes/hop-config.json
+++ b/integration-tests/aes/hop-config.json
@@ -167,8 +167,8 @@
     },
     {
       "name": "HOP_PASSWORD_ENCODER_PLUGIN",
-      "value": "Hop",
-      "description": "Specifies the password encoder plugin to use by ID (Hop is the default)."
+      "value": "AES2",
+      "description": "AES2 encoder required by the aes integration-test project (matches docker env)."
     },
     {
       "name": "HOP_SYSTEM_HOSTNAME",

--- a/integration-tests/scripts/run-tests.sh
+++ b/integration-tests/scripts/run-tests.sh
@@ -137,9 +137,8 @@ TMP_CONFIG_FOLDER="${HOP_CONFIG_FOLDER}"
 SUREFIRE_DIR="$(cd "${CURRENT_DIR}/../surefire-reports" && pwd)"
 RUNNER_PIPELINE="${CURRENT_DIR}/run-project-tests.hpl"
 
-# Shared hop-run parameters for both single-JVM and per-test modes
+# Shared hop-run parameters for both single-JVM and per-test modes (run configuration added per project)
 HOP_RUN_COMMON_ARGS=(
-  -r "local"
   -e "dev"
   -p "POSTGRES_HOST=${POSTGRES_HOST}"
   -p "POSTGRES_DATABASE=${POSTGRES_DATABASE}"
@@ -180,16 +179,26 @@ for d in "${CURRENT_DIR}"/../${PROJECT_NAME}/; do
       # Create New Project
       export HOP_CONFIG_FOLDER="$d"
 
+      # Default pipeline run configuration name used by hop-run and the suite runner.
+      # Beam projects name their Beam engine "local" and keep a native Local engine as "hop-local".
+      # The single-JVM suite driver (run-project-tests.hpl) must never run under Beam.
+      PIPELINE_RUN_CONFIG="local"
+      SUITE_RUN_CONFIG="local"
+      if [ -f "$d/metadata/pipeline-run-configuration/hop-local.json" ]; then
+        SUITE_RUN_CONFIG="hop-local"
+      fi
+
       # Prefer single-JVM suite runner when available (unless isolation mode is requested)
       if [ "${HOP_IT_PER_TEST_JVM}" != "true" ] && [ -f "${RUNNER_PIPELINE}" ]; then
 
         echo ${SPACER}
-        echo "Running project tests in single JVM via run-project-tests.hpl"
+        echo "Running project tests in single JVM via run-project-tests.hpl (run config: ${SUITE_RUN_CONFIG})"
         echo ${SPACER}
 
         start_time_test=$SECONDS
 
         $HOP_LOCATION/hop-run.sh \
+          -r "${SUITE_RUN_CONFIG}" \
           "${HOP_RUN_COMMON_ARGS[@]}" \
           -p "PROJECT_NAME=${PROJECT_NAME}" \
           -p "IT_SUREFIRE_DIR=${SUREFIRE_DIR}" \
@@ -252,8 +261,9 @@ for d in "${CURRENT_DIR}"/../${PROJECT_NAME}/; do
           #Start time test
           start_time_test=$SECONDS
 
-          #Run Test
+          #Run Test (use project pipeline run config, e.g. Beam "local")
           $HOP_LOCATION/hop-run.sh \
+            -r "${PIPELINE_RUN_CONFIG}" \
             "${HOP_RUN_COMMON_ARGS[@]}" \
             -f "$hop_file" > >(tee /tmp/test_output) 2> >(tee /tmp/test_output_err >&1)
 

--- a/integration-tests/transforms/0083-workflow-executor-run-wf.hpl
+++ b/integration-tests/transforms/0083-workflow-executor-run-wf.hpl
@@ -115,7 +115,7 @@ limitations under the License.
         <group/>
         <length>-1</length>
         <name>expected</name>
-        <nullif>ExecutionTime, ExecutionResult, ExecutionNrErrors, ExecutionLinesRead, ExecutionLinesWritten, ExecutionLinesInput, ExecutionLinesOutput, ExecutionLinesRejected, ExecutionLinesUpdated, ExecutionLinesDeleted, ExecutionFilesRetrieved, ExecutionExitStatus, ExecutionLogText, ExecutionLogChannelId</nullif>
+        <nullif>f1, ExecutionTime, ExecutionResult, ExecutionNrErrors, ExecutionLinesRead, ExecutionLinesWritten, ExecutionLinesInput, ExecutionLinesOutput, ExecutionLinesRejected, ExecutionLinesUpdated, ExecutionLinesDeleted, ExecutionFilesRetrieved, ExecutionExitStatus, ExecutionLogText, ExecutionLogChannelId</nullif>
         <precision>-1</precision>
         <set_empty_string>N</set_empty_string>
         <type>String</type>

--- a/plugins/actions/pipeline/src/main/java/org/apache/hop/workflow/actions/pipeline/ActionPipeline.java
+++ b/plugins/actions/pipeline/src/main/java/org/apache/hop/workflow/actions/pipeline/ActionPipeline.java
@@ -522,8 +522,9 @@ public class ActionPipeline extends ActionBase implements Cloneable, IAction {
         pipeline.setMetadataProvider(getMetadataProvider());
 
         // Handle parameters...
+        // Factory already initialized the pipeline from this action's variables (parent workflow
+        // + env). Do not re-initialize from null or environment variables are dropped.
         //
-        pipeline.initializeFrom(null);
         pipeline.copyParametersFromDefinitions(pipelineMeta);
 
         // Pass the parameter values and activate...

--- a/plugins/actions/workflow/src/main/java/org/apache/hop/workflow/actions/workflow/ActionWorkflow.java
+++ b/plugins/actions/workflow/src/main/java/org/apache/hop/workflow/actions/workflow/ActionWorkflow.java
@@ -479,6 +479,14 @@ public class ActionWorkflow extends ActionBase implements Cloneable, IAction {
               String parentValue = parentWorkflow.getParameterValue(parameterName);
               if (!Utils.isEmpty(parentValue)) {
                 workflow.setParameterValue(parameterName, parentValue);
+              } else {
+                // Match hop-run: if the parent has a variable of the same name (env, -p as
+                // variable, project config), use it so nested main-*.hwf parameters do not
+                // fall back to their local-dev defaults (e.g. HOSTNAME=localhost).
+                String parentVariable = parentWorkflow.getVariable(parameterName);
+                if (!Utils.isEmpty(parentVariable)) {
+                  workflow.setParameterValue(parameterName, parentVariable);
+                }
               }
             }
           }


### PR DESCRIPTION
## Summary

Fixes most of the 19 failing integration tests after the single-JVM suite runner (#7506) and related recent changes.

### Root causes

1. **Hop-run pipelines dropped env vars** — `HopRunBase.runPipeline` called `pipeline.initializeFrom(null)` after the factory had already applied hop-run variables (project + `-e` environment). That wiped values such as `HOSTNAME` and `TEST_0012`. Same pattern fixed in `ActionPipeline`.
2. **Parameter defaults clobbered parent vars** — `NamedParameters.activateParameters` applied empty parameter defaults over existing variables (e.g. `HOSTNAME=localhost` over env `http`, empty `BOOTSTRAP_SERVERS` over `kafka:9092`). Nested `ActionWorkflow` also now copies parent variables into empty parameters (same idea as hop-run).
3. **Beam suite runner ran under Beam** — projects where `local` is Beam now use `hop-local` for `run-project-tests.hpl` only.
4. **AES encoder rebind** — project hop-config said `Hop`, overwriting docker `AES2`; aes project/env now declare AES2 + key.
5. **0083 contract** — WorkflowExecutor execution-result stream keeps input fields (#7506); test expectation updated.

### Out of scope

- `samples.0001-run-samples` (age 41, chronic; needs full log to find first failing sample).

### Test plan

- [x] `NamedParamsDefaultTest` (4 tests)
- [x] Compile core, engine, actions
- [ ] `CLIENT_UNZIP=false ./integration-tests/scripts/run-tests-docker.sh http`
- [ ] `CLIENT_UNZIP=false ./integration-tests/scripts/run-tests-docker.sh kafka`
- [ ] `CLIENT_UNZIP=false ./integration-tests/scripts/run-tests-docker.sh aes`
- [ ] `CLIENT_UNZIP=false ./integration-tests/scripts/run-tests-docker.sh parameters_and_variables`
- [ ] `CLIENT_UNZIP=false ./integration-tests/scripts/run-tests-docker.sh transforms`
- [ ] `CLIENT_UNZIP=false ./integration-tests/scripts/run-tests-docker.sh beam_directrunner`

Fixes #7516