### PR TITLE
issue #7507 : restore empty-parameter defaults after single-JVM runner fix

### DIFF
--- a/core/src/main/java/org/apache/hop/core/parameters/NamedParameters.java
+++ b/core/src/main/java/org/apache/hop/core/parameters/NamedParameters.java
@@ -139,14 +139,16 @@ public class NamedParameters implements INamedParameters {
       if (StringUtils.isNotEmpty(param.key)) {
         String value = param.getValue();
         if (StringUtils.isEmpty(value)) {
-          // Prefer an already-set variable (environment / parent) over the parameter default.
-          // Nested workflows and pipelines used to clobber env values such as HOSTNAME or
-          // BOOTSTRAP_SERVERS when activateParameters applied empty defaults.
+          String defaultValue = Const.NVL(param.getDefaultValue(), "");
+          // Prefer an already-set variable only when the parameter has a non-empty default.
+          // That is the HOSTNAME=localhost case: nested files must not clobber env/project values.
+          // When the default is empty, applying "" is intentional (unset parameter) and must not
+          // silently adopt a same-named parent CURRENT_WORKFLOW variable — see IT main-0004/0006.
           String existing = variables != null ? variables.getVariable(param.getKey()) : null;
-          if (StringUtils.isNotEmpty(existing)) {
+          if (StringUtils.isNotEmpty(existing) && StringUtils.isNotEmpty(defaultValue)) {
             value = existing;
           } else {
-            value = Const.NVL(param.getDefaultValue(), "");
+            value = defaultValue;
           }
         }
         variables.setVariable(param.getKey(), value);

--- a/core/src/test/java/org/apache/hop/core/parameters/NamedParamsDefaultTest.java
+++ b/core/src/test/java/org/apache/hop/core/parameters/NamedParamsDefaultTest.java
@@ -79,20 +79,32 @@ class NamedParamsDefaultTest {
   }
 
   @Test
-  void testActivateParametersPrefersExistingVariableOverDefault() throws Exception {
+  void testActivateParametersPrefersExistingVariableOverNonEmptyDefault() throws Exception {
+    // Nested pipelines often declare HOSTNAME default "localhost"; that must not clobber env.
     Variables variables = new Variables();
     variables.setVariable("HOSTNAME", "http");
-    variables.setVariable("BOOTSTRAP_SERVERS", "kafka:9092");
 
     namedParams.addParameterDefinition("HOSTNAME", "localhost", "HTTP host");
-    namedParams.addParameterDefinition("BOOTSTRAP_SERVERS", "", "Kafka bootstrap");
     namedParams.addParameterDefinition("ONLY_DEFAULT", "from-default", "No prior variable");
 
     namedParams.activateParameters(variables);
 
     assertEquals("http", variables.getVariable("HOSTNAME"));
-    assertEquals("kafka:9092", variables.getVariable("BOOTSTRAP_SERVERS"));
     assertEquals("from-default", variables.getVariable("ONLY_DEFAULT"));
+  }
+
+  @Test
+  void testActivateParametersEmptyDefaultDoesNotAdoptExistingVariable() throws Exception {
+    // Empty parameter default means unset: do not silently keep a same-named parent variable
+    // (integration tests main-0004 / main-0006).
+    Variables variables = new Variables();
+    variables.setVariable("TEST_PARAM", "from-parent-variable");
+
+    namedParams.addParameterDefinition("TEST_PARAM", "", "Empty default");
+
+    namedParams.activateParameters(variables);
+
+    assertEquals("", variables.getVariable("TEST_PARAM"));
   }
 
   @Test

--- a/integration-tests/samples/read-samples-build-hop-run.hpl
+++ b/integration-tests/samples/read-samples-build-hop-run.hpl
@@ -559,6 +559,14 @@ var hop_run_cmd = './hop-run.sh -j samples -r ' + run_config + ' -f ' + filename
         <item>rest-client-slack-conversations-loop.hpl</item>
         <item>requires SLACK_BOT_TOKEN with channels:read or conversations:read</item>
       </line>
+      <line>
+        <item>ssh-password.hpl</item>
+        <item>requires reachable SSH host (sample points at a private lab IP)</item>
+      </line>
+      <line>
+        <item>ssh-pri-key.hpl</item>
+        <item>requires SSH private key and reachable SSH host</item>
+      </line>
     </data>
     <distribute>Y</distribute>
     <copies>1</copies>

--- a/plugins/actions/workflow/src/main/java/org/apache/hop/workflow/actions/workflow/ActionWorkflow.java
+++ b/plugins/actions/workflow/src/main/java/org/apache/hop/workflow/actions/workflow/ActionWorkflow.java
@@ -476,17 +476,12 @@ public class ActionWorkflow extends ActionBase implements Cloneable, IAction {
             // opted to do.
             //
             if (parameterDefinition.isPassingAllParameters()) {
+              // Only formal parent parameter values are passed here. Env/project protection for
+              // parameters with non-empty defaults is handled in NamedParameters.activateParameters
+              // (prefer existing variable over a non-empty default such as HOSTNAME=localhost).
               String parentValue = parentWorkflow.getParameterValue(parameterName);
               if (!Utils.isEmpty(parentValue)) {
                 workflow.setParameterValue(parameterName, parentValue);
-              } else {
-                // Match hop-run: if the parent has a variable of the same name (env, -p as
-                // variable, project config), use it so nested main-*.hwf parameters do not
-                // fall back to their local-dev defaults (e.g. HOSTNAME=localhost).
-                String parentVariable = parentWorkflow.getVariable(parameterName);
-                if (!Utils.isEmpty(parentVariable)) {
-                  workflow.setParameterValue(parameterName, parentVariable);
-                }
               }
             }
           }


### PR DESCRIPTION
## Summary

Jenkins remaining failures after earlier #7507 work included `parameters_and_variables` **0004** / **0006** and samples.

### Repro finding (important)

These are **not** single-JVM suite-only failures. On a build with #7517:

```text
hop-run -e dev -r local -f main-0004-pass-variables-and-parameters.hwf  → FAIL
hop-run -e dev -r local -f main-0006-not-passing-parameters.hwf         → FAIL
```

Same outcomes as Jenkins. So the suite “loop” is not the root cause; **#7517 parameter activation** is. That also explains why the tests still match long-standing GUI/historical semantics: empty parameter defaults mean unset, and same-named parent CURRENT_WORKFLOW variables must not silently fill them.

### Product fix

1. **`NamedParameters.activateParameters`**  
   Prefer an already-set variable over the parameter default **only when the default is non-empty** (the `HOSTNAME=localhost` clobber case from #7516).  
   When the default is empty, apply `""` so empty defaults still mean “unset” (main-0004 / main-0006).

2. **`ActionWorkflow`**  
   Remove the #7517 parent-**variable** fallback under `pass_all_parameters`. Formal parent **parameter** values still pass through. Env protection for non-empty defaults remains in `activateParameters`.

3. **Unit tests** updated for the refined rule (including empty-default must not adopt existing variable).

### Samples

Ignore `ssh-password.hpl` and `ssh-pri-key.hpl` in the samples IT ignore list (private lab host / keys; not runnable on CI).

### Not changed

- Backbone tests **main-0004** / **main-0006** expectations (left intact).
- Full revert of #7517 (HOSTNAME non-empty-default protection kept).

## Test plan

- [x] `NamedParamsDefaultTest` — 5 tests pass  
- [x] `hop-run` alone: main-0004 and main-0006 exit **0** after the fix  
- [ ] Jenkins Hop-integration-tests: parameters_and_variables + samples green  