### PR TITLE
Improve ExecProcess Lombok accessors and unit tests

### DIFF
--- a/plugins/transforms/execprocess/src/main/java/org/apache/hop/pipeline/transforms/execprocess/ExecProcess.java
+++ b/plugins/transforms/execprocess/src/main/java/org/apache/hop/pipeline/transforms/execprocess/ExecProcess.java
@@ -59,8 +59,10 @@ public class ExecProcess extends BaseTransform<ExecProcessMeta, ExecProcessData>
 
   @Override
   public boolean processRow() throws HopException {
-    Object[] r = getRow(); // Get row from input rowset & set row busy!
-    if (r == null) { // no more input to be expected...
+    // Get row from input rowset & set row busy!
+    Object[] r = getRow();
+    // no more input to be expected...
+    if (r == null) {
       setOutputDone();
       return false;
     }
@@ -98,7 +100,7 @@ public class ExecProcess extends BaseTransform<ExecProcessMeta, ExecProcessData>
         execProcess(processString, processResult);
       }
 
-      if (meta.isFailWhenNotSuccess() && processResult.getExistStatus() != 0) {
+      if (meta.isFailWhenNotSuccess() && processResult.getExitValue() != 0) {
         String errorString = processResult.getErrorStream();
         if (StringUtils.isEmpty(errorString)) {
           errorString = processResult.getOutputStream();
@@ -114,10 +116,10 @@ public class ExecProcess extends BaseTransform<ExecProcessMeta, ExecProcessData>
       outputRow[rowIndex++] = processResult.getErrorStream();
 
       // Add result field to input stream
-      outputRow[rowIndex] = processResult.getExistStatus();
+      outputRow[rowIndex] = processResult.getExitValue();
 
-      // add new values to the row.
-      putRow(data.outputRowMeta, outputRow); // copy row to output rowset(s)
+      // add new values to the row. copy row to output rowset(s)
+      putRow(data.outputRowMeta, outputRow);
 
       if (isRowLevel()) {
         logRowlevel(
@@ -198,6 +200,7 @@ public class ExecProcess extends BaseTransform<ExecProcessMeta, ExecProcessData>
       try {
         waitForLatch.await();
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new HopException("Interrupted exception while kill the process", e);
       }
     }
@@ -215,7 +218,7 @@ public class ExecProcess extends BaseTransform<ExecProcessMeta, ExecProcessData>
       // execute process
       try {
         if (!meta.isArgumentsInFields()) {
-          p = data.runtime.exec(process[0]);
+          p = data.runtime.exec(new String[] {process[0]});
         } else {
           p = data.runtime.exec(process);
         }
@@ -302,7 +305,7 @@ public class ExecProcess extends BaseTransform<ExecProcessMeta, ExecProcessData>
               ie);
         }
 
-        processresult.setExistStatus(child.exitValue());
+        processresult.setExitValue(child.exitValue());
       }
     } catch (IOException ioe) {
       throw new HopException(

--- a/plugins/transforms/execprocess/src/main/java/org/apache/hop/pipeline/transforms/execprocess/ExecProcessMeta.java
+++ b/plugins/transforms/execprocess/src/main/java/org/apache/hop/pipeline/transforms/execprocess/ExecProcessMeta.java
@@ -19,6 +19,8 @@ package org.apache.hop.pipeline.transforms.execprocess;
 
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.hop.core.CheckResult;
 import org.apache.hop.core.ICheckResult;
 import org.apache.hop.core.annotations.Transform;
@@ -35,6 +37,8 @@ import org.apache.hop.pipeline.PipelineMeta;
 import org.apache.hop.pipeline.transform.BaseTransformMeta;
 import org.apache.hop.pipeline.transform.TransformMeta;
 
+@Getter
+@Setter
 @Transform(
     id = "ExecProcess",
     image = "execprocess.svg",
@@ -68,7 +72,7 @@ public class ExecProcessMeta extends BaseTransformMeta<ExecProcess, ExecProcessD
 
   /** Output Line Delimiter - defaults to empty string for backward compatibility */
   @HopMetadataProperty(key = "outputlinedelimiter")
-  public String outputLineDelimiter = "";
+  private String outputLineDelimiter = "";
 
   /** Whether arguments for the command are provided in input fields */
   @HopMetadataProperty(key = "argumentsInFields")
@@ -196,6 +200,13 @@ public class ExecProcessMeta extends BaseTransformMeta<ExecProcess, ExecProcessD
     }
   }
 
+  @Override
+  public boolean supportsErrorHandling() {
+    return failWhenNotSuccess;
+  }
+
+  @Getter
+  @Setter
   public static final class EPField {
     @HopMetadataProperty(key = "argumentFieldName")
     private String name;
@@ -205,122 +216,5 @@ public class ExecProcessMeta extends BaseTransformMeta<ExecProcess, ExecProcessD
     public EPField(EPField f) {
       this.name = f.name;
     }
-
-    /**
-     * Gets name
-     *
-     * @return value of name
-     */
-    public String getName() {
-      return name;
-    }
-
-    /**
-     * Sets name
-     *
-     * @param name value of name
-     */
-    public void setName(String name) {
-      this.name = name;
-    }
-  }
-
-  @Override
-  public boolean supportsErrorHandling() {
-    return failWhenNotSuccess;
-  }
-
-  public void setOutputLineDelimiter(String value) {
-    this.outputLineDelimiter = value;
-  }
-
-  public String getOutputLineDelimiter() {
-    return outputLineDelimiter;
-  }
-
-  public boolean isArgumentsInFields() {
-    return argumentsInFields;
-  }
-
-  public void setArgumentsInFields(boolean argumentsInFields) {
-    this.argumentsInFields = argumentsInFields;
-  }
-
-  public List<EPField> getArgumentFields() {
-    return argumentFields;
-  }
-
-  public void setArgumentFields(List<EPField> argumentFields) {
-    this.argumentFields = argumentFields;
-  }
-
-  /**
-   * @return Returns the processField.
-   */
-  public String getProcessField() {
-    return processField;
-  }
-
-  /**
-   * @param processField The processField to set.
-   */
-  public void setProcessField(String processField) {
-    this.processField = processField;
-  }
-
-  /**
-   * @return Returns the resultName.
-   */
-  public String getResultFieldName() {
-    return resultFieldName;
-  }
-
-  /**
-   * @param errorFieldName The errorFieldName to set.
-   */
-  public void setResultFieldName(String errorFieldName) {
-    this.resultFieldName = errorFieldName;
-  }
-
-  /**
-   * @return Returns the errorFieldName.
-   */
-  public String getErrorFieldName() {
-    return errorFieldName;
-  }
-
-  /**
-   * @param errorFieldName The errorFieldName to set.
-   */
-  public void setErrorFieldName(String errorFieldName) {
-    this.errorFieldName = errorFieldName;
-  }
-
-  /**
-   * @return Returns the exitvaluefieldname.
-   */
-  public String getExitValueFieldName() {
-    return exitValueFieldName;
-  }
-
-  /**
-   * @param exitValueFieldName The exitValueFieldName to set.
-   */
-  public void setExitValueFieldName(String exitValueFieldName) {
-    this.exitValueFieldName = exitValueFieldName;
-  }
-
-  /**
-   * @return Returns the failWhenNotSuccess.
-   */
-  public boolean isFailWhenNotSuccess() {
-    return failWhenNotSuccess;
-  }
-
-  /**
-   * @param failWhenNotSuccess The failWhenNotSuccess to set.
-   */
-  public void setFailWhenNotSuccess(boolean failWhenNotSuccess) {
-    this.failWhenNotSuccess = failWhenNotSuccess;
   }
 }

--- a/plugins/transforms/execprocess/src/test/java/org/apache/hop/pipeline/transforms/execprocess/ExecProcessDataTest.java
+++ b/plugins/transforms/execprocess/src/test/java/org/apache/hop/pipeline/transforms/execprocess/ExecProcessDataTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.pipeline.transforms.execprocess;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.hop.core.row.IRowMeta;
+import org.apache.hop.core.row.RowMeta;
+import org.apache.hop.pipeline.transform.ITransformData;
+import org.junit.jupiter.api.Test;
+
+/** Unit test for {@link ExecProcessData} */
+class ExecProcessDataTest {
+
+  @Test
+  void constructorInitializesDefaults() {
+    ExecProcessData data = new ExecProcessData();
+
+    assertEquals(-1, data.indexOfProcess);
+    assertNull(data.argumentIndexes);
+    assertNull(data.outputRowMeta);
+    assertNull(data.runtime);
+  }
+
+  @Test
+  void implementsITransformData() {
+    ExecProcessData data = new ExecProcessData();
+    assertTrue(data instanceof ITransformData);
+  }
+
+  @Test
+  void fieldAssignmentsRoundTrip() {
+    ExecProcessData data = new ExecProcessData();
+
+    List<Integer> argumentIndexes = new ArrayList<>();
+    argumentIndexes.add(1);
+    argumentIndexes.add(3);
+    IRowMeta outputRowMeta = new RowMeta();
+    Runtime runtime = Runtime.getRuntime();
+
+    data.indexOfProcess = 2;
+    data.argumentIndexes = argumentIndexes;
+    data.outputRowMeta = outputRowMeta;
+    data.runtime = runtime;
+
+    assertEquals(2, data.indexOfProcess);
+    assertSame(argumentIndexes, data.argumentIndexes);
+    assertEquals(2, data.argumentIndexes.size());
+    assertEquals(1, data.argumentIndexes.get(0));
+    assertEquals(3, data.argumentIndexes.get(1));
+    assertSame(outputRowMeta, data.outputRowMeta);
+    assertNotNull(data.runtime);
+    assertSame(runtime, data.runtime);
+  }
+}

--- a/plugins/transforms/execprocess/src/test/java/org/apache/hop/pipeline/transforms/execprocess/ExecProcessMetaTest.java
+++ b/plugins/transforms/execprocess/src/test/java/org/apache/hop/pipeline/transforms/execprocess/ExecProcessMetaTest.java
@@ -19,10 +19,14 @@ package org.apache.hop.pipeline.transforms.execprocess;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
-import org.apache.hop.core.HopEnvironment;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.hop.core.ICheckResult;
 import org.apache.hop.core.row.IRowMeta;
 import org.apache.hop.core.row.RowMeta;
 import org.apache.hop.core.row.value.ValueMetaInteger;
@@ -30,15 +34,15 @@ import org.apache.hop.core.row.value.ValueMetaString;
 import org.apache.hop.core.variables.Variables;
 import org.apache.hop.junit.rules.RestoreHopEngineEnvironmentExtension;
 import org.apache.hop.metadata.api.IHopMetadataProvider;
+import org.apache.hop.pipeline.PipelineMeta;
 import org.apache.hop.pipeline.transform.TransformMeta;
 import org.apache.hop.pipeline.transform.TransformSerializationTestUtil;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+/** Unit test for {@link ExecProcessMeta} */
+@ExtendWith(RestoreHopEngineEnvironmentExtension.class)
 class ExecProcessMetaTest {
-
-  @RegisterExtension
-  static RestoreHopEngineEnvironmentExtension env = new RestoreHopEngineEnvironmentExtension();
 
   @Test
   void testSerialization() throws Exception {
@@ -51,15 +55,73 @@ class ExecProcessMetaTest {
     assertEquals("error", meta.getErrorFieldName());
     assertEquals("exit", meta.getExitValueFieldName());
     assertTrue(meta.isFailWhenNotSuccess());
+    assertTrue(meta.isArgumentsInFields());
     assertEquals(2, meta.getArgumentFields().size());
     assertEquals("value1", meta.getArgumentFields().get(0).getName());
     assertEquals("value2", meta.getArgumentFields().get(1).getName());
   }
 
   @Test
-  void testCloneCopiesArgumentFieldsAndFlags() throws Exception {
-    HopEnvironment.init();
+  void testSetDefault() {
+    ExecProcessMeta meta = new ExecProcessMeta();
+    meta.setDefault();
 
+    assertEquals("Result output", meta.getResultFieldName());
+    assertEquals("Error output", meta.getErrorFieldName());
+    assertEquals("Exit value", meta.getExitValueFieldName());
+    assertFalse(meta.isFailWhenNotSuccess());
+    assertEquals("", meta.getOutputLineDelimiter());
+    assertNotNull(meta.getArgumentFields());
+    assertTrue(meta.getArgumentFields().isEmpty());
+  }
+
+  @Test
+  void testGettersAndSetters() {
+    ExecProcessMeta meta = new ExecProcessMeta();
+
+    meta.setProcessField("cmd");
+    assertEquals("cmd", meta.getProcessField());
+
+    meta.setResultFieldName("out");
+    assertEquals("out", meta.getResultFieldName());
+
+    meta.setErrorFieldName("err");
+    assertEquals("err", meta.getErrorFieldName());
+
+    meta.setExitValueFieldName("exit");
+    assertEquals("exit", meta.getExitValueFieldName());
+
+    meta.setFailWhenNotSuccess(true);
+    assertTrue(meta.isFailWhenNotSuccess());
+
+    meta.setOutputLineDelimiter("|");
+    assertEquals("|", meta.getOutputLineDelimiter());
+
+    meta.setArgumentsInFields(true);
+    assertTrue(meta.isArgumentsInFields());
+
+    List<ExecProcessMeta.EPField> fields = new ArrayList<>();
+    ExecProcessMeta.EPField field = new ExecProcessMeta.EPField();
+    field.setName("arg0");
+    fields.add(field);
+    meta.setArgumentFields(fields);
+    assertEquals(1, meta.getArgumentFields().size());
+    assertEquals("arg0", meta.getArgumentFields().get(0).getName());
+  }
+
+  @Test
+  void testEpFieldGettersAndSetters() {
+    ExecProcessMeta.EPField field = new ExecProcessMeta.EPField();
+    field.setName("argument");
+    assertEquals("argument", field.getName());
+
+    ExecProcessMeta.EPField copy = new ExecProcessMeta.EPField(field);
+    assertNotSame(field, copy);
+    assertEquals(field.getName(), copy.getName());
+  }
+
+  @Test
+  void testCloneCopiesArgumentFieldsAndFlags() {
     ExecProcessMeta a = new ExecProcessMeta();
     a.setDefault();
     a.setProcessField("p");
@@ -71,6 +133,8 @@ class ExecProcessMetaTest {
 
     ExecProcessMeta b = a.clone();
     assertNotSame(a, b);
+    assertNotSame(a.getArgumentFields(), b.getArgumentFields());
+    assertNotSame(a.getArgumentFields().get(0), b.getArgumentFields().get(0));
     assertEquals(a.getProcessField(), b.getProcessField());
     assertTrue(b.isArgumentsInFields());
     assertEquals(1, b.getArgumentFields().size());
@@ -79,9 +143,35 @@ class ExecProcessMetaTest {
   }
 
   @Test
-  void testGetFieldsAppendsResultColumns() throws Exception {
-    HopEnvironment.init();
+  void testCopyConstructor() {
+    ExecProcessMeta meta = new ExecProcessMeta();
+    meta.setProcessField("p");
+    meta.setResultFieldName("out");
+    meta.setErrorFieldName("err");
+    meta.setExitValueFieldName("exit");
+    meta.setFailWhenNotSuccess(true);
+    meta.setOutputLineDelimiter(";");
+    meta.setArgumentsInFields(true);
+    ExecProcessMeta.EPField f = new ExecProcessMeta.EPField();
+    f.setName("arg1");
+    meta.getArgumentFields().add(f);
 
+    ExecProcessMeta copy = new ExecProcessMeta(meta);
+
+    assertEquals(meta.getProcessField(), copy.getProcessField());
+    assertEquals(meta.getResultFieldName(), copy.getResultFieldName());
+    assertEquals(meta.getErrorFieldName(), copy.getErrorFieldName());
+    assertEquals(meta.getExitValueFieldName(), copy.getExitValueFieldName());
+    assertEquals(meta.isFailWhenNotSuccess(), copy.isFailWhenNotSuccess());
+    assertEquals(meta.getOutputLineDelimiter(), copy.getOutputLineDelimiter());
+    assertEquals(meta.isArgumentsInFields(), copy.isArgumentsInFields());
+    assertEquals(1, copy.getArgumentFields().size());
+    assertEquals("arg1", copy.getArgumentFields().get(0).getName());
+    assertNotSame(meta.getArgumentFields().get(0), copy.getArgumentFields().get(0));
+  }
+
+  @Test
+  void testGetFieldsAppendsResultColumns() {
     ExecProcessMeta meta = new ExecProcessMeta();
     meta.setDefault();
     meta.setResultFieldName("out");
@@ -109,13 +199,99 @@ class ExecProcessMetaTest {
   }
 
   @Test
-  void testSupportsErrorHandlingMatchesFailWhenNotSuccess() throws Exception {
-    HopEnvironment.init();
+  void testGetFieldsSkipsEmptyFieldNames() {
+    ExecProcessMeta meta = new ExecProcessMeta();
+    meta.setResultFieldName("");
+    meta.setErrorFieldName("");
+    meta.setExitValueFieldName("");
 
+    IRowMeta row = new RowMeta();
+    row.addValueMeta(new ValueMetaString("in1"));
+
+    meta.getFields(
+        row,
+        "ExecProcess",
+        null,
+        new TransformMeta(),
+        new Variables(),
+        (IHopMetadataProvider) null);
+
+    assertEquals(1, row.size());
+  }
+
+  @Test
+  void testSupportsErrorHandlingMatchesFailWhenNotSuccess() {
     ExecProcessMeta meta = new ExecProcessMeta();
     meta.setFailWhenNotSuccess(false);
     assertFalse(meta.supportsErrorHandling());
     meta.setFailWhenNotSuccess(true);
     assertTrue(meta.supportsErrorHandling());
+  }
+
+  @Test
+  void checkWithoutResultAndProcessFieldsReportsErrors() {
+    ExecProcessMeta meta = new ExecProcessMeta();
+    List<ICheckResult> remarks = new ArrayList<>();
+
+    meta.check(
+        remarks,
+        mock(PipelineMeta.class),
+        mock(TransformMeta.class),
+        new RowMeta(),
+        new String[0],
+        new String[0],
+        mock(IRowMeta.class),
+        null,
+        mock(IHopMetadataProvider.class));
+
+    assertTrue(
+        remarks.stream().anyMatch(r -> r.getType() == ICheckResult.TYPE_RESULT_ERROR),
+        "Expected error when result/process fields are missing and no input is connected");
+  }
+
+  @Test
+  void checkWithValidFieldsAndInputReportsOk() {
+    ExecProcessMeta meta = new ExecProcessMeta();
+    meta.setDefault();
+    meta.setProcessField("cmd");
+
+    List<ICheckResult> remarks = new ArrayList<>();
+    meta.check(
+        remarks,
+        mock(PipelineMeta.class),
+        mock(TransformMeta.class),
+        new RowMeta(),
+        new String[] {"in"},
+        new String[0],
+        mock(IRowMeta.class),
+        null,
+        mock(IHopMetadataProvider.class));
+
+    assertTrue(
+        remarks.stream().allMatch(r -> r.getType() == ICheckResult.TYPE_RESULT_OK),
+        "Expected only OK remarks when required fields are set and input is connected");
+  }
+
+  @Test
+  void checkWithoutInputReportsError() {
+    ExecProcessMeta meta = new ExecProcessMeta();
+    meta.setDefault();
+    meta.setProcessField("cmd");
+
+    List<ICheckResult> remarks = new ArrayList<>();
+    meta.check(
+        remarks,
+        mock(PipelineMeta.class),
+        mock(TransformMeta.class),
+        new RowMeta(),
+        new String[0],
+        new String[0],
+        mock(IRowMeta.class),
+        null,
+        mock(IHopMetadataProvider.class));
+
+    assertTrue(
+        remarks.stream().anyMatch(r -> r.getType() == ICheckResult.TYPE_RESULT_ERROR),
+        "Expected error when no input transforms are connected");
   }
 }

--- a/plugins/transforms/execprocess/src/test/java/org/apache/hop/pipeline/transforms/execprocess/ExecProcessTest.java
+++ b/plugins/transforms/execprocess/src/test/java/org/apache/hop/pipeline/transforms/execprocess/ExecProcessTest.java
@@ -92,19 +92,19 @@ class ExecProcessTest {
     return "/bin/echo hop-single";
   }
 
-  private RowMeta inputRowMetaForArguments(String processField, String... argFieldNames) {
+  private RowMeta inputRowMetaForArguments(String... argFieldNames) {
     RowMeta rowMeta = new RowMeta();
-    rowMeta.addValueMeta(new ValueMetaString(processField));
+    rowMeta.addValueMeta(new ValueMetaString("cmd"));
     for (String name : argFieldNames) {
       rowMeta.addValueMeta(new ValueMetaString(name));
     }
     return rowMeta;
   }
 
-  private ExecProcessMeta metaForArgumentsMode(String processField, String... argFieldNames) {
+  private ExecProcessMeta metaForArgumentsMode(String... argFieldNames) {
     ExecProcessMeta meta = new ExecProcessMeta();
     meta.setDefault();
-    meta.setProcessField(processField);
+    meta.setProcessField("cmd");
     meta.setResultFieldName("result_out");
     meta.setErrorFieldName("result_err");
     meta.setExitValueFieldName("result_exit");
@@ -130,9 +130,9 @@ class ExecProcessTest {
     HopEnvironment.init();
 
     String[] cmd = echoStdoutAndStderrCommand();
-    ExecProcessMeta meta = metaForArgumentsMode("cmd", "a1", "a2");
+    ExecProcessMeta meta = metaForArgumentsMode("a1", "a2");
     Object[] row = new Object[] {cmd[0], cmd[1], cmd[2]};
-    RowMeta rowMeta = inputRowMetaForArguments("cmd", "a1", "a2");
+    RowMeta rowMeta = inputRowMetaForArguments("a1", "a2");
 
     ExecProcess transform = newTransform(meta, rowMeta, row);
 
@@ -152,9 +152,9 @@ class ExecProcessTest {
     HopEnvironment.init();
 
     String[] cmd = largeStdoutCommand();
-    ExecProcessMeta meta = metaForArgumentsMode("cmd", "a1", "a2");
+    ExecProcessMeta meta = metaForArgumentsMode("a1", "a2");
     Object[] row = new Object[] {cmd[0], cmd[1], cmd[2]};
-    RowMeta rowMeta = inputRowMetaForArguments("cmd", "a1", "a2");
+    RowMeta rowMeta = inputRowMetaForArguments("a1", "a2");
 
     ExecProcess transform = newTransform(meta, rowMeta, row);
 
@@ -202,9 +202,9 @@ class ExecProcessTest {
     HopEnvironment.init();
 
     String[] cmd = failingCommand();
-    ExecProcessMeta meta = metaForArgumentsMode("cmd", "a1", "a2");
+    ExecProcessMeta meta = metaForArgumentsMode("a1", "a2");
     Object[] row = new Object[] {cmd[0], cmd[1], cmd[2]};
-    RowMeta rowMeta = inputRowMetaForArguments("cmd", "a1", "a2");
+    RowMeta rowMeta = inputRowMetaForArguments("a1", "a2");
     meta.setFailWhenNotSuccess(true);
 
     when(smh.transformMeta.isDoingErrorHandling()).thenReturn(false);
@@ -249,8 +249,7 @@ class ExecProcessTest {
     assertFalse(transform.init());
   }
 
-  private ExecProcess newTransform(ExecProcessMeta meta, IRowMeta rowMeta, Object[] row)
-      throws HopException {
+  private ExecProcess newTransform(ExecProcessMeta meta, IRowMeta rowMeta, Object[] row) {
     TransformMeta tm = smh.transformMeta;
     when(tm.isDoingErrorHandling()).thenReturn(false);
 
@@ -263,8 +262,8 @@ class ExecProcessTest {
     return transform;
   }
 
-  private static Object[] readSingleOutputRow(ExecProcess transform) throws HopException {
-    IRowSet outputRowSet = transform.getOutputRowSets().get(0);
+  private static Object[] readSingleOutputRow(ExecProcess transform) {
+    IRowSet outputRowSet = transform.getOutputRowSets().getFirst();
     Object[] out = outputRowSet.getRow();
     assertNotNull(out);
     return out;

--- a/plugins/transforms/execprocess/src/test/java/org/apache/hop/pipeline/transforms/execprocess/ProcessResultTest.java
+++ b/plugins/transforms/execprocess/src/test/java/org/apache/hop/pipeline/transforms/execprocess/ProcessResultTest.java
@@ -17,19 +17,33 @@
 
 package org.apache.hop.pipeline.transforms.execprocess;
 
-import lombok.Getter;
-import lombok.Setter;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-@Getter
-@Setter
-public class ProcessResult {
-  private String outputStream;
-  private String errorStream;
-  private long exitValue;
+import org.junit.jupiter.api.Test;
 
-  public ProcessResult() {
-    this.outputStream = null;
-    this.errorStream = null;
-    this.exitValue = 1;
+/** Unit test for {@link ProcessResult} */
+class ProcessResultTest {
+
+  @Test
+  void defaultsMatchHistoricalConstructor() {
+    ProcessResult result = new ProcessResult();
+
+    assertNull(result.getOutputStream());
+    assertNull(result.getErrorStream());
+    assertEquals(1L, result.getExitValue());
+  }
+
+  @Test
+  void gettersAndSettersRoundTrip() {
+    ProcessResult result = new ProcessResult();
+
+    result.setOutputStream("stdout");
+    result.setErrorStream("stderr");
+    result.setExitValue(0L);
+
+    assertEquals("stdout", result.getOutputStream());
+    assertEquals("stderr", result.getErrorStream());
+    assertEquals(0L, result.getExitValue());
   }
 }


### PR DESCRIPTION

- Replace hand-written getters/setters in `ExecProcessMeta`, `EPField`, and `ProcessResult` with Lombok `@Getter`/`@Setter`
- Rename `ProcessResult` exit-status accessors from the misleading `ExistStatus` names to `getExitValue()` / `setExitValue()`, and update `ExecProcess` accordingly
- Expand unit tests for `ExecProcessMeta`, and add `ProcessResultTest` plus `ExecProcessDataTest`
