### PR TITLE
Fix REST Client parameter field dropdowns

### DIFF
--- a/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/rest.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/rest.adoc
@@ -119,24 +119,31 @@ TIP: To figure out what Headers are required, you can use Postman and remove as 
 
 === Parameters Tab
 
-The Parameters tab enables you to define parameter values for POST, GET, PUT, and DELETE requests.
+The Parameters tab enables you to add URL query parameters to POST, GET, PUT, DELETE, and PATCH requests.
+Each row maps a field from the incoming Hop stream to a query parameter name.
+Click **Get fields** to populate the **Parameter field** list, then enter the parameter name expected by the API in **Parameter name**.
+
+For example, if an incoming field named `search_value` contains `apache hop`, mapping it to the parameter name `q` adds `?q=apache+hop` to the request URL.
+Hop URL-encodes the parameter name and value.
 
 [options="header"]
 |===
 |Option|Description
-|Parameter|The field from incoming Hop stream that contains the parameter information
-|Parameter|The name of the outgoing Hop field from this transform
+|Parameter field|The field from the incoming Hop stream that contains the parameter value
+|Parameter name|The query parameter name expected by the REST API
 |===
 
 === Matrix Parameters tab
 
 Use the Matrix Parameters tab to define matrix parameter values for POST, PUT, DELETE, and PATCH requests.
+Unlike query parameters, which follow a `?`, matrix parameters are appended to the URL path with a semicolon.
+For example, a matrix parameter named `language` with the value `en` produces a path such as `/resource;language=en`.
 
 [options="header"]
 |===
 |Option|Description
-|Parameter|The field from the incoming Hop stream that contains the matrix parameter information
-|Parameter|The name of the outgoing Hop field from this transform
+|Parameter field|The field from the incoming Hop stream that contains the matrix parameter value
+|Parameter name|The matrix parameter name expected by the REST API
 |===
 
 === Pagination tab

--- a/plugins/transforms/rest/src/main/java/org/apache/hop/pipeline/transforms/rest/RestDialog.java
+++ b/plugins/transforms/rest/src/main/java/org/apache/hop/pipeline/transforms/rest/RestDialog.java
@@ -108,7 +108,9 @@ public class RestDialog extends BaseTransformDialog {
 
   private ColumnInfo[] colinf;
 
-  private ColumnInfo[] colinfoparams;
+  private ColumnInfo[] queryParameterColumns;
+
+  private ColumnInfo[] matrixParameterColumns;
 
   private TextVar wConnectionTimeout;
 
@@ -692,7 +694,7 @@ public class RestDialog extends BaseTransformDialog {
 
     int matrixParametersRows = input.getMatrixParameterFields().size();
 
-    colinfoparams =
+    matrixParameterColumns =
         new ColumnInfo[] {
           new ColumnInfo(
               BaseMessages.getString(PKG, "RestDialog.ColumnInfo.ParameterField"),
@@ -710,7 +712,7 @@ public class RestDialog extends BaseTransformDialog {
             variables,
             wMatrixParametersComp,
             SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI,
-            colinfoparams,
+            matrixParameterColumns,
             matrixParametersRows,
             lsMod,
             props);
@@ -757,7 +759,7 @@ public class RestDialog extends BaseTransformDialog {
 
     int ParametersRows = input.getParameterFields().size();
 
-    colinfoparams =
+    queryParameterColumns =
         new ColumnInfo[] {
           new ColumnInfo(
               BaseMessages.getString(PKG, "RestDialog.ColumnInfo.ParameterField"),
@@ -775,7 +777,7 @@ public class RestDialog extends BaseTransformDialog {
             variables,
             wParametersComp,
             SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI,
-            colinfoparams,
+            queryParameterColumns,
             ParametersRows,
             lsMod,
             props);
@@ -1548,7 +1550,7 @@ public class RestDialog extends BaseTransformDialog {
                 }
 
                 String[] fieldNames = Const.sortStrings(rowMeta.getFieldNames());
-                colinfoparams[0].setComboValues(fieldNames);
+                setParameterComboValues(queryParameterColumns, matrixParameterColumns, fieldNames);
                 colinf[0].setComboValues(fieldNames);
                 wUrlField.setItems(fieldNames);
                 wBody.setItems(fieldNames);
@@ -1562,6 +1564,14 @@ public class RestDialog extends BaseTransformDialog {
           }
         };
     shell.getDisplay().asyncExec(runnable);
+  }
+
+  static void setParameterComboValues(
+      ColumnInfo[] queryParameterColumns,
+      ColumnInfo[] matrixParameterColumns,
+      String[] fieldNames) {
+    queryParameterColumns[0].setComboValues(fieldNames);
+    matrixParameterColumns[0].setComboValues(fieldNames);
   }
 
   private void activateUrlInfield() {

--- a/plugins/transforms/rest/src/test/java/org/apache/hop/pipeline/transforms/rest/RestDialogTest.java
+++ b/plugins/transforms/rest/src/test/java/org/apache/hop/pipeline/transforms/rest/RestDialogTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hop.pipeline.transforms.rest;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import org.apache.hop.ui.core.widget.ColumnInfo;
+import org.junit.jupiter.api.Test;
+
+class RestDialogTest {
+
+  @Test
+  void populatesQueryAndMatrixParameterFieldLists() {
+    ColumnInfo[] queryColumns = parameterColumns();
+    ColumnInfo[] matrixColumns = parameterColumns();
+    String[] fieldNames = {"id", "search_value"};
+
+    RestDialog.setParameterComboValues(queryColumns, matrixColumns, fieldNames);
+
+    assertArrayEquals(fieldNames, queryColumns[0].getComboValues());
+    assertArrayEquals(fieldNames, matrixColumns[0].getComboValues());
+  }
+
+  private static ColumnInfo[] parameterColumns() {
+    return new ColumnInfo[] {
+      new ColumnInfo("Parameter field", ColumnInfo.COLUMN_TYPE_CCOMBO, new String[] {""}, false)
+    };
+  }
+}


### PR DESCRIPTION
Fixes #7530.

## Summary

- keep separate column definitions for query and matrix parameter fields
- populate both parameter field dropdowns from incoming fields
- add a regression test for both dropdowns
- clarify query and matrix parameter configuration in the REST Client documentation

## Root cause

The query and matrix parameter tables shared the same `ColumnInfo` array field. Initializing the matrix parameter tab replaced the query parameter column reference, so field discovery updated only the matrix parameter dropdown.

## Validation

- `./mvnw -pl plugins/transforms/rest -Dtest=RestDialogTest test`
- `./mvnw -pl plugins/transforms/rest -DskipTests spotless:check`
- `git diff --check`
