### PR TITLE
Fix ExecProcess command-line tokenization after #7565

### DIFF
--- a/plugins/transforms/execprocess/src/main/java/org/apache/hop/pipeline/transforms/execprocess/ExecProcess.java
+++ b/plugins/transforms/execprocess/src/main/java/org/apache/hop/pipeline/transforms/execprocess/ExecProcess.java
@@ -23,6 +23,7 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.StringTokenizer;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
@@ -218,7 +219,10 @@ public class ExecProcess extends BaseTransform<ExecProcessMeta, ExecProcessData>
       // execute process
       try {
         if (!meta.isArgumentsInFields()) {
-          p = data.runtime.exec(new String[] {process[0]});
+          // Match historical Runtime.exec(String) whitespace tokenization without using the
+          // deprecated String overload. A single-element String[] would treat the whole command
+          // line (e.g. "/bin/echo hop-single") as the executable name.
+          p = data.runtime.exec(tokenizeCommandLine(process[0]));
         } else {
           p = data.runtime.exec(process);
         }
@@ -321,6 +325,19 @@ public class ExecProcess extends BaseTransform<ExecProcessMeta, ExecProcessData>
         p.destroy();
       }
     }
+  }
+
+  /**
+   * Tokenize a command line the same way Runtime.exec(String) historically did (whitespace via
+   * {@link StringTokenizer}).
+   */
+  static String[] tokenizeCommandLine(String command) {
+    StringTokenizer st = new StringTokenizer(command);
+    String[] cmdArray = new String[st.countTokens()];
+    for (int i = 0; st.hasMoreTokens(); i++) {
+      cmdArray[i] = st.nextToken();
+    }
+    return cmdArray;
   }
 
   private String getOutputString(BufferedReader b) throws IOException {

--- a/plugins/transforms/execprocess/src/test/java/org/apache/hop/pipeline/transforms/execprocess/ExecProcessTest.java
+++ b/plugins/transforms/execprocess/src/test/java/org/apache/hop/pipeline/transforms/execprocess/ExecProcessTest.java
@@ -25,6 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
+import java.util.List;
 import org.apache.hop.core.HopEnvironment;
 import org.apache.hop.core.IRowSet;
 import org.apache.hop.core.QueueRowSet;
@@ -213,6 +215,14 @@ class ExecProcessTest {
 
     assertFalse(transform.processRow());
     assertEquals(1, transform.getErrors());
+  }
+
+  @Test
+  void tokenizeCommandLine_splitsOnWhitespaceLikeRuntimeExecString() {
+    assertEquals(
+        Arrays.asList("/bin/echo", "hop-single"),
+        Arrays.asList(ExecProcess.tokenizeCommandLine("/bin/echo hop-single")));
+    assertEquals(List.of("cmd"), Arrays.asList(ExecProcess.tokenizeCommandLine("cmd")));
   }
 
   @Test


### PR DESCRIPTION
Fix
```txt
org.apache.hop.pipeline.transforms.execprocess.ExecProcessTest
Error:  org.apache.hop.pipeline.transforms.execprocess.ExecProcessTest.processRow_singleCommandString_capturesOutput -- Time elapsed: 5.674 s <<< ERROR!
java.lang.NullPointerException: Cannot invoke "Object.toString()" because "out[1]" is null
	at org.apache.hop.pipeline.transforms.execprocess.ExecProcessTest.processRow_singleCommandString_capturesOutput(ExecProcessTest.java:195)

```

## Summary
- Restore historical `Runtime.exec(String)` whitespace tokenization when `argumentsInFields` is false.
- #7565 changed `exec(process[0])` to `exec(new String[] {process[0]})`, which treats the entire command line (e.g. `/bin/echo hop-single`) as the executable name, so stdout is null and CI fails on Linux.
- Tokenize with `StringTokenizer` (same as the old `Runtime.exec(String)` behavior) before calling `exec(String[])`, avoiding the deprecated String overload.
