### PR TITLE
Remove the need to call the PropsUi.setLook() #2638

### DIFF
--- a/plugins/transforms/datagrid/src/main/java/org/apache/hop/pipeline/transforms/datagrid/DataGridDialog.java
+++ b/plugins/transforms/datagrid/src/main/java/org/apache/hop/pipeline/transforms/datagrid/DataGridDialog.java
@@ -282,6 +282,9 @@ public class DataGridDialog extends BaseTransformDialog {
     fdData.bottom = new FormAttachment(100, 0);
     wData.setLayoutData(fdData);
 
+    // Set a theme for this control that changes dynamically
+    PropsUi.setTheme(wData);
+
     wTabFolder.layout(true, true);
 
     wFields.nrNonEmpty();

--- a/ui/src/main/java/org/apache/hop/ui/core/PropsUi.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/PropsUi.java
@@ -733,7 +733,18 @@ public class PropsUi extends Props {
     setProperty(METRICS_PANEL_SHOW_DATA_VOLUME_OUT, show ? YES : NO);
   }
 
+  @Deprecated(since = "2.19.0", forRemoval = true)
   public static void setLook(Widget widget) {
+    // Do nothing
+  }
+
+  @Deprecated(since = "2.19.0", forRemoval = true)
+  public static void setLook(final Widget widget, int style) {
+    // Do nothing
+  }
+
+  /** Set themes colors and font to the widget and all its children. */
+  public static void setTheme(final Widget widget) {
     int style = WIDGET_STYLE_DEFAULT;
     if (widget instanceof Table) {
       style = WIDGET_STYLE_TABLE;
@@ -755,31 +766,31 @@ public class PropsUi extends Props {
       }
     }
 
-    setLook(widget, style);
+    setTheme(widget, style);
 
     if (widget instanceof Composite composite) {
-      for (Control child : composite.getChildren()) {
-        setLook(child);
+      for (Control control : composite.getChildren()) {
+        setTheme(control);
       }
     }
   }
 
-  public static void setLook(final Widget widget, int style) {
+  public static void setTheme(final Widget widget, int style) {
     if (EnvironmentUtils.getInstance().isWeb()) {
-      setLookOnWeb(widget, style);
+      setThemeOnWeb(widget, style);
       return;
     }
     if (OsHelper.isWindows()) {
-      setLookOnWindows(widget, style);
+      setThemeOnWindows(widget, style);
     } else if (OsHelper.isMac()) {
-      setLookOnMac(widget, style);
+      setThemeOnMac(widget, style);
     } else {
-      setLookOnLinux(widget, style);
+      setThemeOnLinux(widget, style);
     }
   }
 
   /** Hop Web (RAP) specific look. Keeps web theme logic separate from OS-specific setLookOn*. */
-  protected static void setLookOnWeb(final Widget widget, int style) {
+  protected static void setThemeOnWeb(final Widget widget, int style) {
     final GuiResource gui = GuiResource.getInstance();
     Font font = gui.getFontDefault();
     Color background = gui.getWidgetBackGroundColor();
@@ -891,7 +902,7 @@ public class PropsUi extends Props {
     }
   }
 
-  protected static void setLookOnWindows(final Widget widget, int style) {
+  protected static void setThemeOnWindows(final Widget widget, int style) {
     final GuiResource gui = GuiResource.getInstance();
     Font font = gui.getFontDefault();
     Color background = gui.getWidgetBackGroundColor();
@@ -968,7 +979,7 @@ public class PropsUi extends Props {
     }
   }
 
-  protected static void setLookOnMac(final Widget widget, int style) {
+  protected static void setThemeOnMac(final Widget widget, int style) {
     final GuiResource gui = GuiResource.getInstance();
     Font font = gui.getFontDefault();
     Color background = null;
@@ -1030,7 +1041,7 @@ public class PropsUi extends Props {
     }
   }
 
-  protected static void setLookOnLinux(final Widget widget, int style) {
+  protected static void setThemeOnLinux(final Widget widget, int style) {
     final GuiResource gui = GuiResource.getInstance();
     Font font = gui.getFontDefault();
     Color background = GuiResource.getInstance().getWidgetBackGroundColor();

--- a/ui/src/main/java/org/apache/hop/ui/core/database/dialog/DatabaseExplorerDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/database/dialog/DatabaseExplorerDialog.java
@@ -41,6 +41,7 @@ import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.i18n.BaseMessages;
 import org.apache.hop.ui.core.ConstUi;
 import org.apache.hop.ui.core.PropsUi;
+import org.apache.hop.ui.core.dialog.BaseDialog;
 import org.apache.hop.ui.core.dialog.EnterSelectionDialog;
 import org.apache.hop.ui.core.dialog.ErrorDialog;
 import org.apache.hop.ui.core.dialog.MessageBox;
@@ -57,7 +58,6 @@ import org.apache.hop.ui.pipeline.transform.BaseTransformDialog;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.FormAttachment;
 import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.layout.FormLayout;
@@ -65,7 +65,6 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Dialog;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
@@ -276,23 +275,8 @@ public class DatabaseExplorerDialog extends Dialog {
             setTreeMenu();
           }
         });
-    shell.addListener(SWT.Close, e -> cancel());
 
-    // Prevent resizing below the complete control layout (notably right-side action buttons).
-    Point minSize = shell.computeSize(SWT.DEFAULT, SWT.DEFAULT);
-    shell.setMinimumSize(minSize);
-    BaseTransformDialog.setSize(shell);
-
-    shell.open();
-
-    // Handle the event loop until we're done with this shell...
-    //
-    Display display = shell.getDisplay();
-    while (!shell.isDisposed()) {
-      if (!display.readAndDispatch()) {
-        display.sleep();
-      }
-    }
+    BaseDialog.defaultShellHandling(shell, c -> ok(), c -> cancel());
 
     return tableName != null;
   }

--- a/ui/src/main/java/org/apache/hop/ui/core/dialog/BaseDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/dialog/BaseDialog.java
@@ -808,6 +808,8 @@ public abstract class BaseDialog extends Dialog {
     //
     addSpacesOnTabs(shell);
 
+    PropsUi.setTheme(shell);
+
     if (useStandardMinimumSize) {
       shell.setMinimumSize(650, 250);
     } else {

--- a/ui/src/main/java/org/apache/hop/ui/core/dialog/ContextDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/dialog/ContextDialog.java
@@ -564,6 +564,8 @@ public class ContextDialog extends Dialog {
     // Manually set canvas size otherwise canvas never gets drawn.
     wCanvas.setSize(10, 10);
 
+    PropsUi.setTheme(shell);
+
     // Show the dialog now
     //
     shell.open();

--- a/ui/src/main/java/org/apache/hop/ui/core/dialog/DialogBoxWithButtons.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/dialog/DialogBoxWithButtons.java
@@ -96,9 +96,10 @@ public class DialogBoxWithButtons {
     BaseTransformDialog.positionBottomButtons(
         shell, buttons.toArray(new Button[0]), formMargin, wLabel);
 
-    BaseTransformDialog.setSize(shell);
     shell.addListener(SWT.Close, e -> dispose());
     BaseTransformDialog.setSize(shell);
+
+    PropsUi.setTheme(shell);
 
     shell.open();
 

--- a/ui/src/main/java/org/apache/hop/ui/core/dialog/EnterMappingDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/dialog/EnterMappingDialog.java
@@ -36,7 +36,6 @@ import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.layout.FormLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Dialog;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.List;
 import org.eclipse.swt.widgets.Shell;
@@ -316,26 +315,7 @@ public class EnterMappingDialog extends Dialog {
 
     getData();
 
-    // Set the size as well...
-    //
-    BaseTransformDialog.setSize(shell);
-
-    // Shell closed?
-    //
-    shell.addListener(SWT.Close, e -> cancel());
-
-    // Open the shell
-    //
-    shell.open();
-
-    // Handle the event loop until we're done with this shell...
-    //
-    Display display = shell.getDisplay();
-    while (!shell.isDisposed()) {
-      if (!display.readAndDispatch()) {
-        display.sleep();
-      }
-    }
+    BaseDialog.defaultShellHandling(shell, e -> ok(), e -> cancel());
 
     return mappings;
   }

--- a/ui/src/main/java/org/apache/hop/ui/core/dialog/EnterTextDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/dialog/EnterTextDialog.java
@@ -27,14 +27,12 @@ import org.apache.hop.ui.core.gui.WindowProperty;
 import org.apache.hop.ui.hopgui.file.workflow.HopGuiWorkflowGraph;
 import org.apache.hop.ui.pipeline.transform.BaseTransformDialog;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.ShellAdapter;
 import org.eclipse.swt.events.ShellEvent;
 import org.eclipse.swt.layout.FormAttachment;
 import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.layout.FormLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Dialog;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
@@ -184,34 +182,10 @@ public class EnterTextDialog extends Dialog {
 
     enrich(this);
 
-    // Detect [X] or ALT-F4 or something that kills this window...
-    shell.addShellListener(
-        new ShellAdapter() {
-          @Override
-          public void shellClosed(ShellEvent e) {
-            checkCancel(e);
-          }
-        });
-
     origText = text;
     getData();
 
-    // Set the size as well...
-    //
-    BaseTransformDialog.setSize(shell);
-
-    // Open the shell
-    //
-    shell.open();
-
-    // Handle the event loop until we're done with this shell...
-    //
-    Display display = shell.getDisplay();
-    while (!shell.isDisposed()) {
-      if (!display.readAndDispatch()) {
-        display.sleep();
-      }
-    }
+    BaseDialog.defaultShellHandling(shell, c -> ok(), c -> cancel());
 
     return text;
   }

--- a/ui/src/main/java/org/apache/hop/ui/core/dialog/MessageBox.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/dialog/MessageBox.java
@@ -78,7 +78,6 @@ public class MessageBox extends Dialog {
 
     int shellStyle = style & (SWT.APPLICATION_MODAL | SWT.SYSTEM_MODAL | SWT.PRIMARY_MODAL);
     shell = new Shell(parent, SWT.DIALOG_TRIM | SWT.RESIZE | SWT.MAX | SWT.MIN | shellStyle);
-    PropsUi.setLook(shell);
     shell.setImage(GuiResource.getInstance().getImageHop());
     shell.setText(Const.NVL(text, ""));
 
@@ -92,7 +91,6 @@ public class MessageBox extends Dialog {
     int margin = PropsUi.getMargin();
 
     Composite composite = new Composite(shell, SWT.NONE);
-    PropsUi.setLook(composite);
     composite.setLayout(new GridLayout());
     GridLayout gridLayout = new GridLayout();
     gridLayout.numColumns = 2;
@@ -102,7 +100,6 @@ public class MessageBox extends Dialog {
     // The message...
     //
     Label wMessage = new Label(composite, SWT.LEFT | SWT.WRAP);
-    PropsUi.setLook(wMessage);
     wMessage.setText(message);
     wMessage.setLayoutData(new GridData(GridData.FILL_BOTH));
 
@@ -184,6 +181,8 @@ public class MessageBox extends Dialog {
 
     BaseTransformDialog.setSize(shell);
 
+    PropsUi.setTheme(shell);
+
     // If minimum size is set, use it directly instead of packing
     if (minimumWidth > 0 || minimumHeight > 0) {
       shell.layout();
@@ -203,6 +202,8 @@ public class MessageBox extends Dialog {
         shell.getDisplay().sleep();
       }
     }
+
+    // BaseDialog.defaultShellHandling(shell, c -> ok(), c -> dispose());
 
     return returnValue;
   }

--- a/ui/src/main/java/org/apache/hop/ui/core/dialog/MessageDialogWithToggle.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/dialog/MessageDialogWithToggle.java
@@ -160,6 +160,8 @@ public class MessageDialogWithToggle {
           }
         });
 
+    PropsUi.setTheme(shell);
+
     shell.open();
     while (!shell.isDisposed()) {
       if (!display.readAndDispatch()) {

--- a/ui/src/main/java/org/apache/hop/ui/core/dialog/ProgressMonitorDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/dialog/ProgressMonitorDialog.java
@@ -75,6 +75,9 @@ public class ProgressMonitorDialog {
     addCancelButtonIfNeeded(cancelable, margin);
     BaseTransformDialog.setSize(shell);
     addShellCloseHandler();
+
+    PropsUi.setTheme(shell);
+
     shell.open();
 
     Cursor oldCursor = shell.getCursor();
@@ -92,6 +95,7 @@ public class ProgressMonitorDialog {
         new Shell(parent, SWT.RESIZE | SWT.APPLICATION_MODAL | (cancelable ? SWT.CLOSE : SWT.NONE));
     shell.setText(BaseMessages.getString(PKG, "ProgressMonitorDialog.Shell.Title"));
     shell.setImage(GuiResource.getInstance().getImageHopUi());
+    shell.setMinimumSize(500, 200);
     PropsUi.setLook(shell);
     display = shell.getDisplay();
 

--- a/ui/src/main/java/org/apache/hop/ui/core/dialog/ShowMessageDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/dialog/ShowMessageDialog.java
@@ -255,6 +255,8 @@ public class ShowMessageDialog extends Dialog {
     final String ok = button.getText();
     long startTime = new Date().getTime();
 
+    PropsUi.setTheme(shell);
+
     shell.open();
     while (!shell.isDisposed()) {
       if (!display.readAndDispatch()) {

--- a/ui/src/main/java/org/apache/hop/ui/core/gui/GuiCompositeWidgets.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/gui/GuiCompositeWidgets.java
@@ -203,7 +203,7 @@ public class GuiCompositeWidgets {
         // others
         int labelStyle = useNewLayout ? SWT.LEFT : (SWT.RIGHT | SWT.SINGLE);
         label = new Label(parent, labelStyle);
-        PropsUi.setLook(label);
+        PropsUi.setTheme(label);
         label.setText(Const.NVL(guiElements.getLabel(), ""));
         if (StringUtils.isNotEmpty(guiElements.getToolTip())) {
           label.setToolTipText(guiElements.getToolTip());
@@ -298,13 +298,13 @@ public class GuiCompositeWidgets {
     }
     if (guiElements.isVariablesEnabled()) {
       ComboVar comboVar = new ComboVar(variables, parent, SWT.BORDER | SWT.SINGLE | SWT.LEFT);
-      PropsUi.setLook(comboVar);
+      PropsUi.setTheme(comboVar);
       widgetsMap.put(guiElements.getId(), comboVar);
       comboVar.setItems(comboItems);
       control = comboVar;
     } else {
       Combo combo = new Combo(parent, SWT.BORDER | SWT.SINGLE | SWT.LEFT);
-      PropsUi.setLook(combo);
+      PropsUi.setTheme(combo);
       combo.setItems(comboItems);
       widgetsMap.put(guiElements.getId(), combo);
       control = combo;
@@ -362,7 +362,7 @@ public class GuiCompositeWidgets {
       boolean useNewLayout) {
 
     Button button = new Button(parent, SWT.PUSH);
-    PropsUi.setLook(button);
+    PropsUi.setTheme(button);
     button.setText(Const.NVL(guiElements.getLabel(), ""));
     if (StringUtils.isNotEmpty(guiElements.getToolTip())) {
       button.setToolTipText(guiElements.getToolTip());
@@ -458,7 +458,7 @@ public class GuiCompositeWidgets {
       boolean useNewLayout) {
 
     Link link = new Link(parent, SWT.NONE);
-    PropsUi.setLook(link);
+    PropsUi.setTheme(link);
     link.setText(Const.NVL(guiElements.getLabel(), ""));
     if (StringUtils.isNotEmpty(guiElements.getToolTip())) {
       link.setToolTipText(guiElements.getToolTip());
@@ -539,7 +539,7 @@ public class GuiCompositeWidgets {
       boolean useNewLayout) {
     Control control;
     Button button = new Button(parent, SWT.CHECK | SWT.LEFT);
-    PropsUi.setLook(button);
+    PropsUi.setTheme(button);
     if (useNewLayout) {
       // New layout: label text on the checkbox itself
       button.setText(Const.NVL(guiElements.getLabel(), ""));
@@ -612,14 +612,14 @@ public class GuiCompositeWidgets {
         // PasswordTextVar never mirrors the field value in the tooltip (TextVar may on some
         // platforms when echo char is reported as '\\0' for PASSWORD fields).
         PasswordTextVar textVar = new PasswordTextVar(variables, parent, style, toolTip);
-        PropsUi.setLook(textVar);
+        PropsUi.setTheme(textVar);
         widgetsMap.put(guiElements.getId(), textVar);
         addModifyListener(textVar.getTextWidget(), guiElements.getId());
         control = textVar;
         text = textVar.getTextWidget();
       } else {
         TextVar textVar = new TextVar(variables, parent, style);
-        PropsUi.setLook(textVar);
+        PropsUi.setTheme(textVar);
         widgetsMap.put(guiElements.getId(), textVar);
         addModifyListener(textVar.getTextWidget(), guiElements.getId());
         control = textVar;
@@ -630,7 +630,7 @@ public class GuiCompositeWidgets {
         style |= SWT.PASSWORD;
       }
       text = new Text(parent, style);
-      PropsUi.setLook(text);
+      PropsUi.setTheme(text);
       widgetsMap.put(guiElements.getId(), text);
       addModifyListener(text, guiElements.getId());
       control = text;
@@ -1333,6 +1333,8 @@ public class GuiCompositeWidgets {
     scrolledComposite.setExpandVertical(true);
     scrolledComposite.setMinWidth(bounds.width);
     scrolledComposite.setMinHeight(bounds.height);
+
+    PropsUi.setTheme(scrolledComposite);
 
     return widgets;
   }

--- a/ui/src/main/java/org/apache/hop/ui/core/gui/GuiToolbarWidgets.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/gui/GuiToolbarWidgets.java
@@ -201,7 +201,7 @@ public class GuiToolbarWidgets extends BaseGuiWidgets implements IToolbarWidgetR
           new CLabel(toolBar, SWT.CENTER | (toolbarItem.isAlignRight() ? SWT.RIGHT : SWT.LEFT));
       label.setText(Const.NVL(toolbarItem.getLabel(), ""));
       label.setToolTipText(Const.NVL(toolbarItem.getToolTip(), ""));
-      PropsUi.setLook(label, Props.WIDGET_STYLE_TOOLBAR);
+      PropsUi.setTheme(label, Props.WIDGET_STYLE_TOOLBAR);
       label.pack();
       labelSeparator.setWidth(label.getSize().x);
       labelSeparator.setControl(label);
@@ -245,7 +245,7 @@ public class GuiToolbarWidgets extends BaseGuiWidgets implements IToolbarWidgetR
           new CLabel(parent, SWT.CENTER | (toolbarItem.isAlignRight() ? SWT.RIGHT : SWT.LEFT));
       label.setText(Const.NVL(toolbarItem.getLabel(), ""));
       label.setToolTipText(Const.NVL(toolbarItem.getToolTip(), ""));
-      PropsUi.setLook(label, Props.WIDGET_STYLE_TOOLBAR);
+      PropsUi.setTheme(label, Props.WIDGET_STYLE_TOOLBAR);
       label.pack();
     }
 
@@ -280,7 +280,7 @@ public class GuiToolbarWidgets extends BaseGuiWidgets implements IToolbarWidgetR
     Canvas canvas = new Canvas(parent, SWT.NONE);
     canvas.setLayoutData(new RowData(width, height));
     canvas.setBackground(parent.getBackground());
-    PropsUi.setLook(canvas, Props.WIDGET_STYLE_TOOLBAR);
+    PropsUi.setTheme(canvas, Props.WIDGET_STYLE_TOOLBAR);
     canvas.addPaintListener(
         new PaintListener() {
           @Override
@@ -305,7 +305,7 @@ public class GuiToolbarWidgets extends BaseGuiWidgets implements IToolbarWidgetR
         new CLabel(parent, SWT.CENTER | (toolbarItem.isAlignRight() ? SWT.RIGHT : SWT.LEFT));
     label.setText(Const.NVL(toolbarItem.getLabel(), ""));
     label.setToolTipText(Const.NVL(toolbarItem.getToolTip(), ""));
-    PropsUi.setLook(label, Props.WIDGET_STYLE_TOOLBAR);
+    PropsUi.setTheme(label, Props.WIDGET_STYLE_TOOLBAR);
     label.pack();
     widgetsMap.put(toolbarItem.getId(), label);
     Listener listener = getListener(toolbarItem);
@@ -322,7 +322,7 @@ public class GuiToolbarWidgets extends BaseGuiWidgets implements IToolbarWidgetR
                 | (toolbarItem.isReadOnly() ? SWT.READ_ONLY : SWT.NONE));
     combo.setToolTipText(Const.NVL(toolbarItem.getToolTip(), ""));
     combo.setItems(getComboItems(toolbarItem));
-    PropsUi.setLook(combo, Props.WIDGET_STYLE_TOOLBAR);
+    PropsUi.setTheme(combo, Props.WIDGET_STYLE_TOOLBAR);
     combo.pack();
     int width = calculateComboWidth(combo) + toolbarItem.getExtraWidth();
     combo.setLayoutData(new RowData(width, SWT.DEFAULT));
@@ -342,7 +342,7 @@ public class GuiToolbarWidgets extends BaseGuiWidgets implements IToolbarWidgetR
                 | (toolbarItem.isReadOnly() ? SWT.READ_ONLY : SWT.NONE));
     text.setText(Const.NVL(toolbarItem.getDefaultText(), ""));
     text.setToolTipText(Const.NVL(toolbarItem.getToolTip(), ""));
-    PropsUi.setLook(text, Props.WIDGET_STYLE_TOOLBAR);
+    PropsUi.setTheme(text, Props.WIDGET_STYLE_TOOLBAR);
     text.pack();
     int width = 200 + toolbarItem.getExtraWidth();
     text.setLayoutData(new RowData(width, SWT.DEFAULT));
@@ -357,7 +357,7 @@ public class GuiToolbarWidgets extends BaseGuiWidgets implements IToolbarWidgetR
         new Button(parent, SWT.CHECK | (toolbarItem.isAlignRight() ? SWT.RIGHT : SWT.LEFT));
     checkbox.setToolTipText(Const.NVL(toolbarItem.getToolTip(), ""));
     checkbox.setText(Const.NVL(toolbarItem.getLabel(), ""));
-    PropsUi.setLook(checkbox, Props.WIDGET_STYLE_TOOLBAR);
+    PropsUi.setTheme(checkbox, Props.WIDGET_STYLE_TOOLBAR);
     checkbox.pack();
     checkbox.setLayoutData(
         new RowData(checkbox.getSize().x + toolbarItem.getExtraWidth(), SWT.DEFAULT));
@@ -374,7 +374,7 @@ public class GuiToolbarWidgets extends BaseGuiWidgets implements IToolbarWidgetR
     layout.horizontalSpacing = 4;
     layout.verticalSpacing = 0;
     composite.setLayout(layout);
-    PropsUi.setLook(composite, Props.WIDGET_STYLE_TOOLBAR);
+    PropsUi.setTheme(composite, Props.WIDGET_STYLE_TOOLBAR);
 
     Label imageLabel = new Label(composite, SWT.NONE);
     if (StringUtils.isNotEmpty(toolbarItem.getToolTip())) {
@@ -413,7 +413,7 @@ public class GuiToolbarWidgets extends BaseGuiWidgets implements IToolbarWidgetR
 
     Label textLabel = new Label(composite, SWT.NONE);
     textLabel.setText("");
-    PropsUi.setLook(textLabel, Props.WIDGET_STYLE_TOOLBAR);
+    PropsUi.setTheme(textLabel, Props.WIDGET_STYLE_TOOLBAR);
     if (StringUtils.isNotEmpty(toolbarItem.getToolTip())) {
       textLabel.setToolTipText(toolbarItem.getToolTip());
     }
@@ -454,7 +454,7 @@ public class GuiToolbarWidgets extends BaseGuiWidgets implements IToolbarWidgetR
         new CLabel(toolBar, SWT.CENTER | (toolbarItem.isAlignRight() ? SWT.RIGHT : SWT.LEFT));
     label.setText(Const.NVL(toolbarItem.getLabel(), ""));
     label.setToolTipText(Const.NVL(toolbarItem.getToolTip(), ""));
-    PropsUi.setLook(label, Props.WIDGET_STYLE_TOOLBAR);
+    PropsUi.setTheme(label, Props.WIDGET_STYLE_TOOLBAR);
     label.pack();
     labelSeparator.setWidth(label.getSize().x);
     labelSeparator.setControl(label);
@@ -475,7 +475,7 @@ public class GuiToolbarWidgets extends BaseGuiWidgets implements IToolbarWidgetR
                 | (toolbarItem.isReadOnly() ? SWT.READ_ONLY : SWT.NONE));
     combo.setToolTipText(Const.NVL(toolbarItem.getToolTip(), ""));
     combo.setItems(getComboItems(toolbarItem));
-    PropsUi.setLook(combo, Props.WIDGET_STYLE_TOOLBAR);
+    PropsUi.setTheme(combo, Props.WIDGET_STYLE_TOOLBAR);
     combo.pack();
     comboSeparator.setWidth(
         calculateComboWidth(combo)
@@ -487,7 +487,7 @@ public class GuiToolbarWidgets extends BaseGuiWidgets implements IToolbarWidgetR
     combo.addListener(SWT.DefaultSelection, listener);
     toolItemMap.put(toolbarItem.getId(), comboSeparator);
     widgetsMap.put(toolbarItem.getId(), combo);
-    PropsUi.setLook(combo, Props.WIDGET_STYLE_TOOLBAR);
+    PropsUi.setTheme(combo, Props.WIDGET_STYLE_TOOLBAR);
   }
 
   private void addToolbarText(GuiToolbarItem toolbarItem, ToolBar toolBar) {
@@ -501,7 +501,7 @@ public class GuiToolbarWidgets extends BaseGuiWidgets implements IToolbarWidgetR
                 | (toolbarItem.isReadOnly() ? SWT.READ_ONLY : SWT.NONE));
     text.setText(Const.NVL(toolbarItem.getDefaultText(), ""));
     text.setToolTipText(Const.NVL(toolbarItem.getToolTip(), ""));
-    PropsUi.setLook(text, Props.WIDGET_STYLE_TOOLBAR);
+    PropsUi.setTheme(text, Props.WIDGET_STYLE_TOOLBAR);
     text.pack();
     // extra room for widget decorations
     textSeparator.setWidth(200 + toolbarItem.getExtraWidth());
@@ -512,7 +512,7 @@ public class GuiToolbarWidgets extends BaseGuiWidgets implements IToolbarWidgetR
     text.addListener(SWT.DefaultSelection, listener);
     toolItemMap.put(toolbarItem.getId(), textSeparator);
     widgetsMap.put(toolbarItem.getId(), text);
-    PropsUi.setLook(text, Props.WIDGET_STYLE_TOOLBAR);
+    PropsUi.setTheme(text, Props.WIDGET_STYLE_TOOLBAR);
   }
 
   private void addToolbarCheckbox(GuiToolbarItem toolbarItem, ToolBar toolBar) {
@@ -521,7 +521,7 @@ public class GuiToolbarWidgets extends BaseGuiWidgets implements IToolbarWidgetR
         new Button(toolBar, SWT.CHECK | (toolbarItem.isAlignRight() ? SWT.RIGHT : SWT.LEFT));
     checkbox.setToolTipText(Const.NVL(toolbarItem.getToolTip(), ""));
     checkbox.setText(Const.NVL(toolbarItem.getLabel(), ""));
-    PropsUi.setLook(checkbox, Props.WIDGET_STYLE_TOOLBAR);
+    PropsUi.setTheme(checkbox, Props.WIDGET_STYLE_TOOLBAR);
     checkbox.pack();
     checkboxSeparator.setWidth(
         checkbox.getSize().x + toolbarItem.getExtraWidth()); // extra room for widget decorations
@@ -591,7 +591,7 @@ public class GuiToolbarWidgets extends BaseGuiWidgets implements IToolbarWidgetR
     layout.horizontalSpacing = 4;
     layout.verticalSpacing = 0;
     composite.setLayout(layout);
-    PropsUi.setLook(composite, Props.WIDGET_STYLE_TOOLBAR);
+    PropsUi.setTheme(composite, Props.WIDGET_STYLE_TOOLBAR);
 
     // Create the image label
     Label imageLabel = new Label(composite, SWT.NONE);
@@ -646,7 +646,7 @@ public class GuiToolbarWidgets extends BaseGuiWidgets implements IToolbarWidgetR
     // Create the text label (initially empty, will be set later if needed)
     Label textLabel = new Label(composite, SWT.NONE);
     textLabel.setText("");
-    PropsUi.setLook(textLabel, Props.WIDGET_STYLE_TOOLBAR);
+    PropsUi.setTheme(textLabel, Props.WIDGET_STYLE_TOOLBAR);
     if (StringUtils.isNotEmpty(toolbarItem.getToolTip())) {
       textLabel.setToolTipText(toolbarItem.getToolTip());
     }

--- a/ui/src/main/java/org/apache/hop/ui/core/vfs/HopVfsFileDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/vfs/HopVfsFileDialog.java
@@ -625,6 +625,8 @@ public class HopVfsFileDialog implements IFileDialog, IDirectoryDialog {
     keyHandler.addParentObjectToHandle(this, shell);
     HopGui.getInstance().replaceKeyboardShortcutListeners(shell, keyHandler);
 
+    PropsUi.setTheme(shell);
+
     shell.open();
 
     while (!shell.isDisposed()) {

--- a/ui/src/main/java/org/apache/hop/ui/core/widget/TableView.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/widget/TableView.java
@@ -31,7 +31,6 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hop.core.Condition;
 import org.apache.hop.core.Const;
-import org.apache.hop.core.Props;
 import org.apache.hop.core.RowMetaAndData;
 import org.apache.hop.core.config.HopConfig;
 import org.apache.hop.core.exception.HopRuntimeException;
@@ -515,7 +514,6 @@ public class TableView extends Composite {
 
     // Create table, add columns & rows...
     table = new Table(this, style | SWT.MULTI);
-    PropsUi.setLook(table);
     table.setLinesVisible(true);
 
     FormData fdTable = new FormData();
@@ -534,7 +532,6 @@ public class TableView extends Composite {
     // which we use on the desktop). Add a footnote pointing users to the editor for the full value.
     if (EnvironmentUtils.getInstance().isWeb()) {
       Label webNewlineHint = new Label(this, SWT.LEFT);
-      PropsUi.setLook(webNewlineHint);
       webNewlineHint.setText(BaseMessages.getString(PKG, "TableView.WebNewlineHint.Label"));
       FormData fdHint = new FormData();
       fdHint.left = new FormAttachment(0, 0);
@@ -1528,7 +1525,6 @@ public class TableView extends Composite {
       fdToolBar.top = new FormAttachment(0, 0);
       fdToolBar.right = new FormAttachment(100, 0);
       toolbar.setLayoutData(fdToolBar);
-      PropsUi.setLook(toolbar, Props.WIDGET_STYLE_TOOLBAR);
 
       toolbarWidgets.createToolbarWidgets(toolBarContainer, ID_TOOLBAR, removeToolItems);
       toolbar.pack();
@@ -2024,7 +2020,7 @@ public class TableView extends Composite {
     popup.setLayout(new FillLayout());
 
     final Text multi = new Text(popup, SWT.MULTI | SWT.WRAP | SWT.V_SCROLL | SWT.BORDER);
-    PropsUi.setLook(multi);
+    PropsUi.setTheme(multi);
     // Seed with the platform delimiter so line breaks render (Windows needs \r\n).
     multi.setText(toPlatformLineBreaks(seed));
 
@@ -3017,7 +3013,7 @@ public class TableView extends Composite {
         textWidget.addListener(SWT.KeyUp, lsKeyUp);
       }
     }
-    PropsUi.setLook(text);
+    PropsUi.setTheme(text);
 
     // Double-clicking inside the inline editor expands it into the multi-line editor. The inline
     // editor is created on the first click, so on some platforms (Windows) the second click of a
@@ -3169,7 +3165,7 @@ public class TableView extends Composite {
       } else {
         comboVar.setItems(opt);
       }
-      PropsUi.setLook(comboVar);
+      PropsUi.setTheme(comboVar);
       comboVar.addTraverseListener(lsTraverse);
       comboVar.setData(CANCEL_KEYS, new String[] {"TAB", CONST_SHIFT_TAB});
       comboVar.addModifyListener(lsModCombo);
@@ -3199,7 +3195,7 @@ public class TableView extends Composite {
       safelyDisposeControl(combo);
       String cellValue = item.getText(colNr);
       combo = new Combo(table, columnInfo.isReadOnly() ? SWT.READ_ONLY : SWT.NONE);
-      PropsUi.setLook(combo);
+      PropsUi.setTheme(combo);
       combo.addTraverseListener(lsTraverse);
       combo.setData(CANCEL_KEYS, new String[] {"TAB", CONST_SHIFT_TAB});
       combo.addModifyListener(lsModCombo);
@@ -3249,7 +3245,7 @@ public class TableView extends Composite {
     }
 
     button = new Button(table, SWT.PUSH);
-    PropsUi.setLook(button);
+    PropsUi.setTheme(button);
     String buttonText = columns[colNr - 1].getButtonText();
     if (buttonText != null) {
       button.setText(buttonText);

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/HopGui.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/HopGui.java
@@ -606,6 +606,8 @@ public class HopGui
       new WelcomeDialog().open();
     }
 
+    PropsUi.setTheme(shell);
+
     // On RAP, return here otherwise UIThread doesn't get terminated properly.
     if (EnvironmentUtils.getInstance().isWeb()) {
       return;

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/dialog/AboutDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/dialog/AboutDialog.java
@@ -24,6 +24,7 @@ import org.apache.hop.core.variables.VariableRegistry;
 import org.apache.hop.core.variables.VariableScope;
 import org.apache.hop.i18n.BaseMessages;
 import org.apache.hop.ui.core.PropsUi;
+import org.apache.hop.ui.core.dialog.BaseDialog;
 import org.apache.hop.ui.core.dialog.ErrorDialog;
 import org.apache.hop.ui.core.gui.GuiResource;
 import org.apache.hop.ui.hopgui.HopGui;
@@ -31,8 +32,6 @@ import org.apache.hop.ui.pipeline.transform.BaseTransformDialog;
 import org.apache.hop.ui.util.EnvironmentUtils;
 import org.apache.hop.ui.util.SwtSvgImageUtil;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.ShellAdapter;
-import org.eclipse.swt.events.ShellEvent;
 import org.eclipse.swt.layout.FormAttachment;
 import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.layout.FormLayout;
@@ -150,21 +149,7 @@ public class AboutDialog extends Dialog {
     wText.setLayoutData(fdText);
     PropsUi.setLook(wText);
 
-    // Detect [X] or ALT-F4 or something that kills this window...
-    shell.addShellListener(
-        new ShellAdapter() {
-          @Override
-          public void shellClosed(ShellEvent e) {
-            ok();
-          }
-        });
-
-    shell.open();
-    while (!shell.isDisposed()) {
-      if (!display.readAndDispatch()) {
-        display.sleep();
-      }
-    }
+    BaseDialog.defaultShellHandling(shell, e -> ok(), e -> dispose());
   }
 
   protected String getVersion() {

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/HopGuiPipelineGraph.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/HopGuiPipelineGraph.java
@@ -5124,6 +5124,8 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
       extraViewTabFolder.setSelection(0);
     }
 
+    PropsUi.setTheme(extraViewTabFolder);
+
     toolBarWidgets.setToolbarItemImage(
         TOOLBAR_ITEM_SHOW_EXECUTION_RESULTS, "ui/images/hide-results.svg");
     toolBarWidgets.setToolbarItemToolTip(

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/HopGuiWorkflowGraph.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/HopGuiWorkflowGraph.java
@@ -4253,6 +4253,8 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
       extraViewTabFolder.setSelection(0);
     }
 
+    PropsUi.setTheme(extraViewTabFolder);
+
     toolBarWidgets.setToolbarItemToolTip(
         TOOLBAR_ITEM_SHOW_EXECUTION_RESULTS,
         TranslateUtil.translate(

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/execution/ExecutionPerspective.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/execution/ExecutionPerspective.java
@@ -435,6 +435,8 @@ public class ExecutionPerspective implements IHopPerspective, TabClosable {
     tabItem.setControl(viewer.getControl());
     tabItem.setData(viewer);
 
+    PropsUi.setTheme(viewer.getControl());
+
     viewers.add(viewer);
 
     // Activate the perspective unless we are restoring tabs after a project switch
@@ -442,6 +444,10 @@ public class ExecutionPerspective implements IHopPerspective, TabClosable {
     if (!restoringTabs) {
       this.activate();
     }
+
+    // Set a theme for this control that changes dynamically
+    //
+    PropsUi.setTheme(tabItem.getControl());
 
     // Switch to the tab
     //

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/execution/PipelineExecutionViewer.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/execution/PipelineExecutionViewer.java
@@ -413,7 +413,6 @@ public class PipelineExecutionViewer extends BaseExecutionViewer
     dataList =
         new org.eclipse.swt.widgets.List(
             dataSash, SWT.SINGLE | SWT.LEFT | SWT.V_SCROLL | SWT.H_SCROLL);
-    PropsUi.setLook(dataList);
     dataList.addListener(SWT.Selection, e -> showDataRows());
 
     // An empty table view on the right.  This will be populated during a refresh.
@@ -429,7 +428,6 @@ public class PipelineExecutionViewer extends BaseExecutionViewer
             true,
             null,
             props);
-    PropsUi.setLook(dataView);
 
     dataView.optimizeTableView();
 
@@ -457,7 +455,6 @@ public class PipelineExecutionViewer extends BaseExecutionViewer
             true,
             null,
             props);
-    PropsUi.setLook(metricsView);
 
     metricsView.optimizeTableView();
 
@@ -528,6 +525,10 @@ public class PipelineExecutionViewer extends BaseExecutionViewer
       }
 
       metricsTab.setControl(metricsView);
+
+      // Set a theme for this control that changes dynamically
+      PropsUi.setTheme(metricsView);
+
       metricsView.layout(true, true);
       metricsView.optimizeTableView();
     }

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/ExplorerPerspective.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/ExplorerPerspective.java
@@ -1911,6 +1911,9 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
           });
     }
 
+    // Set a theme for this control that changes dynamically
+    PropsUi.setTheme(folder);
+
     return folder;
   }
 
@@ -2258,7 +2261,7 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
     Composite composite = new Composite(targetFolder, SWT.NONE);
     composite.setLayout(new FormLayout());
     composite.setLayoutData(new FormDataBuilder().fullSize().result());
-    PropsUi.setLook(composite);
+    PropsUi.setTheme(composite);
 
     fileTypeHandler.renderFile(composite);
 
@@ -2351,6 +2354,8 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
           e);
     }
 
+    PropsUi.setTheme(pipelineGraph);
+
     HopGuiKeyHandler keyHandler = HopGuiKeyHandler.getInstance();
     keyHandler.addParentObjectToHandle(this);
     HopGui.getInstance().replaceKeyboardShortcutListeners(this.getShell(), keyHandler);
@@ -2432,6 +2437,8 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
               + " trying to handle a new workflow tab",
           e);
     }
+
+    PropsUi.setTheme(workflowGraph);
 
     HopGuiKeyHandler keyHandler = HopGuiKeyHandler.getInstance();
     keyHandler.addParentObjectToHandle(this);
@@ -4379,6 +4386,9 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
 
     // Collapse the docked source pane if the detach emptied it.
     reclaimFolder(sourceFolder);
+
+    // Set a theme for this control that changes dynamically
+    PropsUi.setTheme(shell);
 
     // The window's close box re-docks its tabs rather than discarding them.
     shell.addListener(

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/metadata/MetadataOverview.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/metadata/MetadataOverview.java
@@ -131,6 +131,9 @@ public class MetadataOverview extends Composite {
 
     scrolledComposite.setContent(content);
     scrolledComposite.setMinSize(content.computeSize(SWT.DEFAULT, SWT.DEFAULT));
+
+    PropsUi.setTheme(scrolledComposite);
+
     content.layout();
     scrolledComposite.layout();
   }

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/metadata/MetadataPerspective.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/metadata/MetadataPerspective.java
@@ -809,6 +809,9 @@ public class MetadataPerspective implements IHopPerspective, TabClosable, IMetad
     tabItem.setControl(composite);
     tabItem.setData(editor);
 
+    // Set a theme for this control that changes dynamically
+    PropsUi.setTheme(composite);
+
     editors.add(editor);
 
     // Add listeners

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/search/SearchEverywhereDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/search/SearchEverywhereDialog.java
@@ -220,6 +220,8 @@ public class SearchEverywhereDialog {
           dispose();
         });
 
+    PropsUi.setTheme(shell);
+
     updateShowAll();
     restoreSize();
 


### PR DESCRIPTION
It's currently a proof of concept, but it works well on Windows (39 calls to setTheme vs. 8,000 calls to setLook).

However, we need to remember to use setTheme() for a control that changes dynamically. I think I've updated many places, but we might still find others.

Calls to the PropsUi.setLook() function haven't been removed yet, but these functions no longer do anything.

I'd like some help understanding how this works on other operating systems.
