### PR TITLE
Fix#7604  show variable picker icons in run configuration Variables tables

### DIFF
--- a/engine/src/test/java/org/apache/hop/pipeline/config/PipelineRunConfigurationVariablesTest.java
+++ b/engine/src/test/java/org/apache/hop/pipeline/config/PipelineRunConfigurationVariablesTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.pipeline.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.apache.hop.core.variables.DescribedVariable;
+import org.apache.hop.core.variables.Variables;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Confirms configuration variable <em>values</em> are resolved while names stay literal (#7604).
+ */
+class PipelineRunConfigurationVariablesTest {
+
+  @Test
+  void applyToVariablesResolvesValueExpressions() {
+    PipelineRunConfiguration config = new PipelineRunConfiguration();
+    config
+        .getConfigurationVariables()
+        .add(new DescribedVariable("RUN_PATH", "${PROJECT_HOME}/data", "path"));
+
+    Variables variables = new Variables();
+    variables.setVariable("PROJECT_HOME", "/tmp/project");
+    config.applyToVariables(variables);
+
+    assertEquals("/tmp/project/data", variables.getVariable("RUN_PATH"));
+  }
+
+  @Test
+  void applyToVariablesDoesNotResolveVariableName() {
+    PipelineRunConfiguration config = new PipelineRunConfiguration();
+    config
+        .getConfigurationVariables()
+        .add(new DescribedVariable("${NAME_VAR}", "literal-value", null));
+
+    Variables variables = new Variables();
+    variables.setVariable("NAME_VAR", "RESOLVED_NAME");
+    config.applyToVariables(variables);
+
+    assertEquals("literal-value", variables.getVariable("${NAME_VAR}"));
+    assertNull(variables.getVariable("RESOLVED_NAME"));
+  }
+}

--- a/ui/src/main/java/org/apache/hop/ui/core/dialog/ConfigurationDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/dialog/ConfigurationDialog.java
@@ -317,6 +317,8 @@ public abstract class ConfigurationDialog extends Dialog {
           false,
           false), // Preview size
     };
+    cVariables[0].setUsingVariables(true);
+    cVariables[1].setUsingVariables(true);
 
     int nrVariables =
         configuration.getVariablesMap() != null ? configuration.getVariablesMap().size() : 0;

--- a/ui/src/main/java/org/apache/hop/ui/core/dialog/ConfigurationDialog.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/dialog/ConfigurationDialog.java
@@ -305,20 +305,10 @@ public abstract class ConfigurationDialog extends Dialog {
     variablesComposite.setLayout(new FormLayout());
     tbtmVariables.setControl(variablesComposite);
 
-    ColumnInfo[] cVariables = {
-      new ColumnInfo(
-          BaseMessages.getString(PKG, prefix + ".VariablesColumn.Argument"),
-          ColumnInfo.COLUMN_TYPE_TEXT,
-          false,
-          false), // TransformName
-      new ColumnInfo(
-          BaseMessages.getString(PKG, prefix + ".VariablesColumn.Value"),
-          ColumnInfo.COLUMN_TYPE_TEXT,
-          false,
-          false), // Preview size
-    };
-    cVariables[0].setUsingVariables(true);
-    cVariables[1].setUsingVariables(true);
+    ColumnInfo[] cVariables =
+        createVariablesColumns(
+            BaseMessages.getString(PKG, prefix + ".VariablesColumn.Argument"),
+            BaseMessages.getString(PKG, prefix + ".VariablesColumn.Value"));
 
     int nrVariables =
         configuration.getVariablesMap() != null ? configuration.getVariablesMap().size() : 0;
@@ -382,4 +372,17 @@ public abstract class ConfigurationDialog extends Dialog {
   }
 
   protected abstract void optionsSectionControls();
+
+  /**
+   * Builds the Variables table columns for Run Options. Only the Value column enables the variable
+   * picker — names are literal keys and are not resolved at runtime.
+   */
+  static ColumnInfo[] createVariablesColumns(String nameTitle, String valueTitle) {
+    ColumnInfo[] columns = {
+      new ColumnInfo(nameTitle, ColumnInfo.COLUMN_TYPE_TEXT, false, false),
+      new ColumnInfo(valueTitle, ColumnInfo.COLUMN_TYPE_TEXT, false, false),
+    };
+    columns[1].setUsingVariables(true);
+    return columns;
+  }
 }

--- a/ui/src/main/java/org/apache/hop/ui/pipeline/config/PipelineRunConfigurationEditor.java
+++ b/ui/src/main/java/org/apache/hop/ui/pipeline/config/PipelineRunConfigurationEditor.java
@@ -360,20 +360,12 @@ public class PipelineRunConfigurationEditor extends MetadataEditor<PipelineRunCo
     variablesLayout.marginHeight = 0;
     wVariablesComp.setLayout(variablesLayout);
 
-    ColumnInfo[] columns = {
-      new ColumnInfo(
-          BaseMessages.getString(PKG, "PipelineRunConfigurationDialog.Variables.Column.Name"),
-          ColumnInfo.COLUMN_TYPE_TEXT),
-      new ColumnInfo(
-          BaseMessages.getString(PKG, "PipelineRunConfigurationDialog.Variables.Column.Value"),
-          ColumnInfo.COLUMN_TYPE_TEXT),
-      new ColumnInfo(
-          BaseMessages.getString(
-              PKG, "PipelineRunConfigurationDialog.Variables.Column.Description"),
-          ColumnInfo.COLUMN_TYPE_TEXT),
-    };
-    columns[0].setUsingVariables(true);
-    columns[1].setUsingVariables(true);
+    ColumnInfo[] columns =
+        createVariablesColumns(
+            BaseMessages.getString(PKG, "PipelineRunConfigurationDialog.Variables.Column.Name"),
+            BaseMessages.getString(PKG, "PipelineRunConfigurationDialog.Variables.Column.Value"),
+            BaseMessages.getString(
+                PKG, "PipelineRunConfigurationDialog.Variables.Column.Description"));
 
     wVariables =
         new TableView(
@@ -660,5 +652,21 @@ public class PipelineRunConfigurationEditor extends MetadataEditor<PipelineRunCo
     }
     Arrays.sort(types, String.CASE_INSENSITIVE_ORDER);
     return types;
+  }
+
+  /**
+   * Builds the Variables table columns for a pipeline run configuration. Only the Value column
+   * enables the variable picker — names are literal keys and are resolved at runtime only for
+   * values (see {@code PipelineEngineFactory.applyVariableDefinitions}).
+   */
+  static ColumnInfo[] createVariablesColumns(
+      String nameTitle, String valueTitle, String descriptionTitle) {
+    ColumnInfo[] columns = {
+      new ColumnInfo(nameTitle, ColumnInfo.COLUMN_TYPE_TEXT),
+      new ColumnInfo(valueTitle, ColumnInfo.COLUMN_TYPE_TEXT),
+      new ColumnInfo(descriptionTitle, ColumnInfo.COLUMN_TYPE_TEXT),
+    };
+    columns[1].setUsingVariables(true);
+    return columns;
   }
 }

--- a/ui/src/main/java/org/apache/hop/ui/pipeline/config/PipelineRunConfigurationEditor.java
+++ b/ui/src/main/java/org/apache/hop/ui/pipeline/config/PipelineRunConfigurationEditor.java
@@ -372,6 +372,8 @@ public class PipelineRunConfigurationEditor extends MetadataEditor<PipelineRunCo
               PKG, "PipelineRunConfigurationDialog.Variables.Column.Description"),
           ColumnInfo.COLUMN_TYPE_TEXT),
     };
+    columns[0].setUsingVariables(true);
+    columns[1].setUsingVariables(true);
 
     wVariables =
         new TableView(

--- a/ui/src/test/java/org/apache/hop/ui/core/dialog/ConfigurationDialogVariablesColumnsTest.java
+++ b/ui/src/test/java/org/apache/hop/ui/core/dialog/ConfigurationDialogVariablesColumnsTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.ui.core.dialog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.hop.ui.core.widget.ColumnInfo;
+import org.junit.jupiter.api.Test;
+
+/** Verifies Run Options Variables table only enables the picker on Value (#7604). */
+class ConfigurationDialogVariablesColumnsTest {
+
+  @Test
+  void onlyValueColumnUsesVariables() {
+    ColumnInfo[] columns = ConfigurationDialog.createVariablesColumns("Variable", "Value");
+
+    assertEquals(2, columns.length);
+    assertFalse(columns[0].isUsingVariables(), "variable name is a literal key");
+    assertTrue(columns[1].isUsingVariables(), "value supports ${...} references");
+  }
+}

--- a/ui/src/test/java/org/apache/hop/ui/pipeline/config/PipelineRunConfigurationVariablesColumnsTest.java
+++ b/ui/src/test/java/org/apache/hop/ui/pipeline/config/PipelineRunConfigurationVariablesColumnsTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.ui.pipeline.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.hop.ui.core.widget.ColumnInfo;
+import org.junit.jupiter.api.Test;
+
+/** Verifies Pipeline Run Configuration Variables tab only enables the picker on Value (#7604). */
+class PipelineRunConfigurationVariablesColumnsTest {
+
+  @Test
+  void onlyValueColumnUsesVariables() {
+    ColumnInfo[] columns =
+        PipelineRunConfigurationEditor.createVariablesColumns("Name", "Value", "Description");
+
+    assertEquals(3, columns.length);
+    assertFalse(columns[0].isUsingVariables(), "variable name is a literal key");
+    assertTrue(columns[1].isUsingVariables(), "value supports ${...} references");
+    assertFalse(columns[2].isUsingVariables(), "description does not use variables");
+  }
+}


### PR DESCRIPTION
Fix https://github.com/apache/hop/issues/7604

## Summary
- Enable the variable picker (`$`) icon on the Variable name and Value columns in the pipeline Run Options dialog.
- Enable the same icons on the Variable name and Value columns in the Pipeline Run Configuration editor Variables tab.
- Aligns behavior with Database connection Options, which already calls `setUsingVariables(true)` on both columns.
