### PR TITLE
Fix SMTP Mail Server Connection test routing

### DIFF
--- a/docs/hop-dev-manual/antora.yml
+++ b/docs/hop-dev-manual/antora.yml
@@ -18,6 +18,5 @@
 name: dev-manual
 title: Development Documentation
 version: 2.16.0
-prerelease: true
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/hop-tech-manual/antora.yml
+++ b/docs/hop-tech-manual/antora.yml
@@ -18,6 +18,5 @@
 name: tech-manual
 title: Technical Documentation
 version: 2.16.0
-prerelease: true
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/hop-user-manual/antora.yml
+++ b/docs/hop-user-manual/antora.yml
@@ -18,7 +18,5 @@
 name: manual
 title: User manual
 version: 2.16.0
-prerelease: true
-display_version: 2.16.0 (pre-release)
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/hop-user-manual/modules/ROOT/nav.adoc
+++ b/docs/hop-user-manual/modules/ROOT/nav.adoc
@@ -450,7 +450,7 @@ under the License.
 ** xref:metadata-types/variable-resolver/index.adoc[Variable Resolver]
 *** xref:metadata-types/variable-resolver/azure-key-vault-variable-resolver.adoc[Azure Key Vault variable resolver]
 *** xref:metadata-types/variable-resolver/google-secret-manager-variable-resolver.adoc[Google Secret Manager variable resolver]
-*** xref:metadata-types/variable-resolver/vault-variable-resolver.adoc[Hashicorp Vault variable resolver]
+*** xref:metadata-types/variable-resolver/hashicorp-vault-variable-resolver.adoc[Hashicorp Vault variable resolver]
 *** xref:metadata-types/variable-resolver/pipeline-variable-resolver.adoc[Pipeline variable resolver]
 ** xref:metadata-types/static-schema-definition.adoc[Static Schema Definition]
 ** xref:hop-server/web-service.adoc[Web Service]

--- a/docs/hop-user-manual/modules/ROOT/pages/database/databases/as400.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/database/databases/as400.adoc
@@ -25,7 +25,7 @@ under the License.
 | Option | Info
 |Type | Relational
 |Driver | Included
-|Version Included | 21.0.0
+|Version Included | 21.0.6
 |Hop Dependencies | None
 |Documentation | https://www.ibm.com/support/knowledgecenter/ssw_ibm_i_71/rzahh/javadoc/com/ibm/as400/access/doc-files/JDBCProperties.html[Documentation Link]
 |JDBC Url | jdbc:as400://hostname/default-schema

--- a/docs/hop-user-manual/modules/ROOT/pages/metadata-types/salesforce-connection.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/metadata-types/salesforce-connection.adoc
@@ -212,7 +212,7 @@ Once your Connected App is configured, create the OAuth connection in Hop:
 When you click "Authorize", a browser window will open with the Salesforce login page:
 
 1. **Login**: Enter your Salesforce credentials and log in
-2. **Force Re-authorization** (Optional): If you're already logged in to Salesforce, you may not see the authorization screen. To force Salesforce to show the authorization screen again, add `&prompt=login` to the authorization URL
+2. **Force Re-authorization** (Optional): If you're already logged in to Salesforce, you may not see the authorization screen. To force Salesforce to show the authorization screen again, add `&amp;prompt=login` to the authorization URL
 3. **Grant Access**: Click "Allow" to authorize the application
 4. **Extract Authorization Code**: 
    * After authorization, Salesforce will redirect to your callback URL

--- a/docs/hop-user-manual/modules/ROOT/pages/metadata-types/salesforce-connection.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/metadata-types/salesforce-connection.adoc
@@ -212,7 +212,7 @@ Once your Connected App is configured, create the OAuth connection in Hop:
 When you click "Authorize", a browser window will open with the Salesforce login page:
 
 1. **Login**: Enter your Salesforce credentials and log in
-2. **Force Re-authorization** (Optional): If you're already logged in to Salesforce, you may not see the authorization screen. To force Salesforce to show the authorization screen again, add `&amp;prompt=login` to the authorization URL
+2. **Force Re-authorization** (Optional): If you're already logged in to Salesforce, you may not see the authorization screen. To force Salesforce to show the authorization screen again, add `prompt=login` to the authorization URL
 3. **Grant Access**: Click "Allow" to authorize the application
 4. **Extract Authorization Code**: 
    * After authorization, Salesforce will redirect to your callback URL

--- a/plugins/misc/mail/src/main/java/org/apache/hop/mail/metadata/MailServerConnection.java
+++ b/plugins/misc/mail/src/main/java/org/apache/hop/mail/metadata/MailServerConnection.java
@@ -233,26 +233,27 @@ public class MailServerConnection extends HopMetadataBase implements IHopMetadat
 
   public Session getSession(IVariables variables) {
     this.variables = variables;
+    String resolvedProtocol = resolve(protocol);
 
     // SMTP
-    if (protocol.equals("SMTP")) {
+    if (isSmtpProtocol(resolvedProtocol)) {
       // Send an e-mail...
       // create some properties and get the default Session
 
-      protocol = "smtp";
+      String smtpProtocol = getSmtpProtocol(resolvedProtocol);
       if (useSecureAuthentication) {
         if (useXOAuth2) {
           props.put("mail.smtp.auth.mechanisms", "XOAUTH2");
         }
-        if (secureConnectionType.equals("TLS")) {
+        String resolvedSecureConnectionType = resolve(secureConnectionType);
+        if ("TLS".equalsIgnoreCase(resolvedSecureConnectionType)) {
           // Allow TLS authentication
           props.put("mail.smtp.starttls.enable", "true");
-        } else if (secureConnectionType.equals("TLS 1.2")) {
+        } else if ("TLS 1.2".equalsIgnoreCase(resolvedSecureConnectionType)) {
           // Allow TLS 1.2 authentication
           props.put("mail.smtp.starttls.enable", "true");
           props.put("mail.smtp.ssl.protocols", "TLSv1.2");
         } else {
-          protocol = "smtps";
           // required to get rid of a SSL exception :
           // nested exception is:
           // javax.net.ssl.SSLException: Unsupported record version Unknown
@@ -265,13 +266,13 @@ public class MailServerConnection extends HopMetadataBase implements IHopMetadat
         }
       }
 
-      props.put(CONST_MAIL + protocol.toLowerCase() + ".host", variables.resolve(serverHost));
+      props.put(CONST_MAIL + smtpProtocol + ".host", variables.resolve(serverHost));
       if (!Utils.isEmpty(serverPort)) {
-        props.put(CONST_MAIL + protocol.toLowerCase() + ".port", variables.resolve(serverPort));
+        props.put(CONST_MAIL + smtpProtocol + ".port", variables.resolve(serverPort));
       }
 
       if (useAuthentication) {
-        props.put(CONST_MAIL + protocol + ".auth", "true");
+        props.put(CONST_MAIL + smtpProtocol + ".auth", "true");
       }
     } else {
       String protocolString = "";
@@ -282,17 +283,19 @@ public class MailServerConnection extends HopMetadataBase implements IHopMetadat
         props.put("mail.imap.sasl.authorizationid", proxyUsername);
       }
 
-      if (protocol.equals("POP3")) {
+      if ("POP3".equalsIgnoreCase(resolvedProtocol)) {
         props.setProperty("mail.pop3s.rsetbeforequit", "true");
         props.setProperty("mail.pop3.rsetbeforequit", "true");
-      } else if (protocol.equals("MBOX")) {
+      } else if ("MBOX".equalsIgnoreCase(resolvedProtocol)) {
         props.setProperty("mstor.mbox.metadataStrategy", "none"); // none|xml|yaml
         props.setProperty("mstor.cache.disabled", "true"); // prevent diskstore fail
       }
 
       protocolString =
-          (protocol.equals("POP3")) ? "pop3" : protocol.equals("MBOX") ? "mstor" : "imap";
-      if (useSecureAuthentication && !protocol.equals("MBOX")) {
+          ("POP3".equalsIgnoreCase(resolvedProtocol))
+              ? "pop3"
+              : "MBOX".equalsIgnoreCase(resolvedProtocol) ? "mstor" : "imap";
+      if (useSecureAuthentication && !"MBOX".equalsIgnoreCase(resolvedProtocol)) {
         // Supports IMAP/POP3 connection with SSL, the connection is established via SSL.
         props.setProperty(
             CONST_MAIL + protocolString + ".socketFactory.class", "javax.net.ssl.SSLSocketFactory");
@@ -329,7 +332,7 @@ public class MailServerConnection extends HopMetadataBase implements IHopMetadat
 
   // SMTP
   public Transport getTransport() throws MessagingException {
-    Transport transport = session.getTransport(protocol);
+    Transport transport = session.getTransport(getSmtpProtocol(resolve(protocol)));
     String authPass = getPassword(password);
 
     if (useAuthentication) {
@@ -354,31 +357,34 @@ public class MailServerConnection extends HopMetadataBase implements IHopMetadat
 
   // IMAP, POP, MBOX
   public Store getStore() throws MessagingException {
-    if (useSecureAuthentication && !protocol.equals("MBOX")) {
+    String resolvedProtocol = resolve(protocol);
+    if (isSmtpProtocol(resolvedProtocol)
+        || (!"POP3".equalsIgnoreCase(resolvedProtocol)
+            && !"IMAP".equalsIgnoreCase(resolvedProtocol)
+            && !"MBOX".equalsIgnoreCase(resolvedProtocol))) {
+      throw new NoSuchProviderException("Unsupported mail store protocol: " + resolvedProtocol);
+    }
+
+    if (useSecureAuthentication && !"MBOX".equalsIgnoreCase(resolvedProtocol)) {
       URLName url =
           new URLName(
-              protocol,
+              resolvedProtocol,
               variables.resolve(serverHost),
               Integer.valueOf(variables.resolve(serverPort)),
               "",
               variables.resolve(username),
               variables.resolve(password));
 
-      switch (protocol) {
-        case "POP3":
-          store = new POP3SSLStore(session, url);
-          break;
-        case "IMAP":
-          store = new IMAPSSLStore(session, url);
-          break;
-        default:
-          break;
+      if ("POP3".equalsIgnoreCase(resolvedProtocol)) {
+        store = new POP3SSLStore(session, url);
+      } else {
+        store = new IMAPSSLStore(session, url);
       }
     } else {
-      if (protocol.equals("MBOX")) {
-        this.store = this.session.getStore(new URLName(protocol + ":" + serverHost));
+      if ("MBOX".equalsIgnoreCase(resolvedProtocol)) {
+        this.store = this.session.getStore(new URLName(resolvedProtocol + ":" + serverHost));
       } else {
-        this.store = this.session.getStore(protocol);
+        this.store = this.session.getStore(resolvedProtocol);
       }
     }
 
@@ -454,12 +460,39 @@ public class MailServerConnection extends HopMetadataBase implements IHopMetadat
   public boolean testConnection(Session session) {
     try {
       this.session = session;
-      Store theStore = getStore();
-      theStore.connect();
+      if (isSmtpProtocol(resolve(protocol))) {
+        getTransport();
+      } else {
+        Store theStore = getStore();
+        theStore.connect();
+      }
       return true;
     } catch (MessagingException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  private String resolve(String value) {
+    String resolvedValue = variables == null ? value : variables.resolve(value);
+    return Const.NVL(resolvedValue, "").trim();
+  }
+
+  private static boolean isSmtpProtocol(String value) {
+    return "SMTP".equalsIgnoreCase(value) || "SMTPS".equalsIgnoreCase(value);
+  }
+
+  private String getSmtpProtocol(String resolvedProtocol) {
+    if ("SMTPS".equalsIgnoreCase(resolvedProtocol)) {
+      return "smtps";
+    }
+    if (useSecureAuthentication) {
+      String resolvedSecureConnectionType = resolve(secureConnectionType);
+      if (!"TLS".equalsIgnoreCase(resolvedSecureConnectionType)
+          && !"TLS 1.2".equalsIgnoreCase(resolvedSecureConnectionType)) {
+        return "smtps";
+      }
+    }
+    return "smtp";
   }
 
   public String getPassword(String authPassword) {


### PR DESCRIPTION
FIX #5712 

## Description

Fixes the Mail Server Connection test for SMTP configurations, including TLS,
TLS 1.2, and SSL connections.

Previously, `MailServerConnection.getSession()` changed the configured
`protocol` field from `SMTP` to either `smtp` or `smtps`. The connection test
then attempted to obtain and connect a Jakarta Mail `Store`, even though SMTP
is a transport protocol.

Depending on the security configuration, this resulted in either:

- `NoSuchProviderException: invalid provider`, because a Store provider was
  requested for SMTP/SMTPS.
- A `NullPointerException` when `getStore()` returned `null` and
  `Store.connect()` was called.

This PR keeps the configured logical protocol unchanged and calculates the
effective Jakarta Mail protocol locally.

## Changes

- Route `SMTP` and `SMTPS` connection tests through `jakarta.mail.Transport`.
- Keep IMAP, POP3, and MBOX connection tests on the `jakarta.mail.Store` path.
- Use `smtp` for regular SMTP, TLS, and TLS 1.2 connections.
- Use `smtps` for SSL connections or when SMTPS is explicitly configured.
- Stop mutating the configured `protocol` while building the mail session.
- Resolve variables and normalize protocol/security values using `trim()` and
  case-insensitive comparisons.
- Reject SMTP and unsupported Store protocols with
  `NoSuchProviderException` instead of returning `null`.
- Preserve the existing public API and the valid behavior of receiving
  protocols.

## Tests

Added unit tests covering:

- SMTP without secure authentication.
- SMTP with TLS.
- SMTP with TLS 1.2.
- SMTP with SSL.
- Explicit SMTPS.
- SMTP values with whitespace and mixed case.
- IMAP connection-test routing through Store.
- POP3 connection-test routing through Store.
- Preservation of the logical SMTP protocol.
- SMTPS session properties for SSL.
- Rejection of SMTP and unsupported protocols by `getStore()`.
- Verification that SMTP connection tests never request a Store.

No real SMTP or mail server is required by the tests.

## Validation

Executed:

```text
mvn -pl :hop-misc-mail -Dtest=MailServerConnectionTest test