### PR TITLE
issue #7547: harden CI SNAPSHOT upload of marketplace plugin zips

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -193,14 +193,19 @@ pipeline {
                   }
             }
         }
+        // Marketplace depends on this stage: plugin zips (spark, beam, parquet, …) from
+        // local-snapshots-dir are wagon-uploaded to ASF SNAPSHOTS so
+        // `hop marketplace install` works without a private Nexus.
         stage('Deploy'){
             when {
                 branch 'main'
                anyOf { changeset pattern: "^(?!docs).*^(?!integration-tests).*" , comparator: "REGEXP" ; equals expected: true, actual: params.FORCE_BUILD }
             }
             steps{
-                echo 'Deploying'
-                sh 'mvn -X -P deploy-snapshots wagon:upload'
+                echo 'Verify marketplace plugin zips in local-snapshots-dir'
+                sh './tools/verify-ci-snapshot-zips.sh ./local-snapshots-dir'
+                echo 'Uploading SNAPSHOTs (incl. marketplace plugin zips) to ASF Nexus'
+                sh 'mvn -B -e -V -P deploy-snapshots wagon:upload'
             }
         }
 

--- a/plugins/misc/marketplace/README.md
+++ b/plugins/misc/marketplace/README.md
@@ -380,15 +380,33 @@ https://repository.apache.org/content/groups/public/org/apache/hop/hop-tech-parq
 
 ### SNAPSHOT (CI)
 
-Jenkins on **main** does two steps (see `Jenkinsfile`):
+Jenkins on **main** (`Jenkinsfile`) publishes marketplace-installable plugin zips
+to ASF Nexus SNAPSHOTS:
 
-1. `mvn … -DaltDeploymentRepository=…::file:./local-snapshots-dir clean deploy`  
-   (full reactor: tests, assemblies, plugin zips)
-2. `mvn -P deploy-snapshots wagon:upload` → ASF snapshots  
-   (`repository.apache.org`). Plugin zips are **included**; hop-assemblies and
-   core/engine/ui zips stay excluded.
+1. **Test & Build** — `mvn … -DaltDeploymentRepository=…::file:./local-snapshots-dir clean deploy`  
+   Full reactor: jars + attached plugin zips land in `local-snapshots-dir` (Maven layout).
+2. **Deploy** (after Docker stages) —
+   - `./tools/verify-ci-snapshot-zips.sh ./local-snapshots-dir`  
+     Fails the job if any `optional-plugins.yaml` artifact lacks a `.zip` (spark, beam, parquet, …).
+   - `mvn -B -P deploy-snapshots wagon:upload`  
+     Uploads that tree to `repository.apache.org` snapshots (`apache.snapshots.https`).  
+     Plugin zips are **included**; hop-assemblies and core/engine/ui zips stay excluded.
 
-**Pre-merge confidence (does not need ASF credentials):**
+Example after a green main Deploy:
+
+```text
+https://repository.apache.org/content/repositories/snapshots/org/apache/hop/hop-tech-parquet/2.19.0-SNAPSHOT/
+https://repository.apache.org/content/repositories/snapshots/org/apache/hop/hop-engines-spark/2.19.0-SNAPSHOT/
+```
+
+Install from a lean client (ASF primary is the default):
+
+```bash
+./hop marketplace install hop-tech-parquet
+./hop marketplace install hop-engines-spark
+```
+
+**Pre-merge confidence (no ASF credentials needed):**
 
 ```bash
 # 1) Same deploy *layout* as Jenkins step 1 (skipTests optional on a laptop)
@@ -400,20 +418,14 @@ rm -rf local-snapshots-dir && mkdir local-snapshots-dir
 # 2) Every optional-plugins.yaml artifact must have a .zip in that tree
 ./tools/verify-ci-snapshot-zips.sh
 
-# Full CI flags (longer; needs xvfb for UI tests) — closer to Jenkins:
-# xvfb-run -a --server-args='-screen 0 1280x1024x24' ./mvnw -T 2 -U -B -e -fae -V \
-#   -Dmaven.compiler.fork=true -Dsurefire.rerunFailingTestsCount=2 -DSkipTestContainers=true \
-#   -DaltDeploymentRepository=snapshot-repo::default::file:$(pwd)/local-snapshots-dir \
-#   clean deploy
+# wagon:upload only if ~/.m2/settings.xml has apache.snapshots.https
+# ./mvnw -B -P deploy-snapshots wagon:upload
 ```
 
-**After merge to apache/hop main:** wait for Jenkins Deploy green, then check e.g.
+IT/Docker still inject Wave 1 plugins from **local** `target/*.zip` via
+`install-wave1-plugins.sh` (offline); that does not replace ASF SNAPSHOT publish.
 
-`https://repository.apache.org/content/repositories/snapshots/org/apache/hop/hop-tech-parquet/`
-
-for a `.zip` under the SNAPSHOT folder. Private data-hopper deploys do **not** replace this check.
-
-Point marketplace at ASF snapshots when testing SNAPSHOT Hop builds from Apache CI.
+Private data-hopper deploys do **not** replace the ASF check.
 
 ### SNAPSHOT to a private Nexus (e.g. data-hopper)
 

--- a/pom.xml
+++ b/pom.xml
@@ -902,13 +902,16 @@
         </profile>
         <profile>
             <!--
-           This profile is used to deploy all the artifacts in the
-           'local-snapshots-dir' to Apache's SNAPSHOT repo.
+           Upload local-snapshots-dir (from Jenkins Test & Build altDeploymentRepository)
+           to Apache SNAPSHOTS via wagon.
 
-           Plugin zips under hop-plugins/** are intentionally included so the
-           marketplace can install SNAPSHOT optional plugins from
-           repository.apache.org (needed for ongoing marketplace testing).
-           hop-assemblies* products (client/web) stay excluded.
+           Marketplace: plugin type=zip artifacts (hop-tech-*, hop-engines-spark/beam,
+           hop-transform-*, …) are intentionally included so
+           `hop marketplace install` can resolve SNAPSHOTs from
+           repository.apache.org without a private Nexus.
+
+           Excluded: hop-assemblies* (client/web products) and non-plugin module zips
+           (core/engine/ui/rest). Paths are under Maven layout org/apache/hop/….
             -->
             <id>deploy-snapshots</id>
             <build>
@@ -916,11 +919,12 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>wagon-maven-plugin</artifactId>
+                        <version>2.0.2</version>
                         <configuration>
                             <fromDir>${project.basedir}/local-snapshots-dir</fromDir>
                             <includes>**</includes>
-                            <!-- Comma-separated Ant patterns (single excludes element). -->
-                            <excludes>**/hop-assemblies*/**,hop-core/**/*.zip,hop-engine/**/*.zip,hop-ui/**/*.zip,hop-ui-rap/**/*.zip,hop-ui-rcp/**/*.zip,hop-rest/**/*.zip,**/org.eclipse.tm4e.core/**</excludes>
+                            <!-- Comma-separated Ant patterns relative to fromDir. -->
+                            <excludes>**/hop-assemblies*/**,**/hop-core/**/*.zip,**/hop-engine/**/*.zip,**/hop-ui/**/*.zip,**/hop-ui-rap/**/*.zip,**/hop-ui-rcp/**/*.zip,**/hop-rest/**/*.zip,**/org.eclipse.tm4e.core/**</excludes>
                             <serverId>apache.snapshots.https</serverId>
                             <url>${distMgmtSnapshotsUrl}</url>
                         </configuration>

--- a/tools/verify-ci-snapshot-zips.sh
+++ b/tools/verify-ci-snapshot-zips.sh
@@ -72,10 +72,11 @@ echo "Summary: ok=${ok} missing=${missing} (of ${#IDS[@]})"
 
 # Remind about wagon excludes (plugin zips are intentionally kept)
 echo
-echo "Jenkins Deploy stage uses -P deploy-snapshots wagon:upload from local-snapshots-dir."
-echo "Current excludes drop hop-assemblies* and core/engine/ui zips — not marketplace plugins."
-echo "After merge to main, confirm a zip on ASF snapshots, e.g.:"
-echo "  https://repository.apache.org/content/repositories/snapshots/org/apache/hop/hop-tech-parquet/"
+echo "Jenkins Deploy stage runs this script, then: mvn -B -P deploy-snapshots wagon:upload"
+echo "Profile excludes hop-assemblies* and core/engine/ui zips — marketplace plugin zips are kept."
+echo "After a green main Deploy, confirm a new unique SNAPSHOT zip on ASF, e.g.:"
+echo "  https://repository.apache.org/content/repositories/snapshots/org/apache/hop/hop-tech-parquet/2.19.0-SNAPSHOT/"
+echo "  https://repository.apache.org/content/repositories/snapshots/org/apache/hop/hop-engines-spark/2.19.0-SNAPSHOT/"
 
 if [[ "${missing}" -gt 0 ]]; then
   echo >&2


### PR DESCRIPTION
## Summary

Hardens the existing main-branch Deploy path so marketplace-installable plugin SNAPSHOT zips are reliably published to ASF Nexus.

- Run `./tools/verify-ci-snapshot-zips.sh` before `wagon:upload` so the job fails if any `optional-plugins.yaml` artifact is missing a zip in `local-snapshots-dir`.
- Pin `wagon-maven-plugin` to 2.0.2 and fix wagon excludes for Maven layout (`**/hop-core/**/*.zip`, etc.).
- Document the CI publish flow and ASF install smoke checks in the marketplace README.

This does not invent a new publisher: Test & Build still deploys to `local-snapshots-dir`, and Deploy still wagon-uploads to `repository.apache.org` snapshots with marketplace plugin zips included.

## Test plan

- [x] Diff review of `Jenkinsfile`, `pom.xml` `deploy-snapshots` profile, verify script, README
- [ ] After merge: confirm main Deploy runs verify + wagon, then check a new unique zip under e.g. `…/hop-tech-parquet/2.19.0-SNAPSHOT/` and `…/hop-engines-spark/2.19.0-SNAPSHOT/`
- [ ] Optional: lean client `./hop marketplace install hop-tech-parquet` against ASF primary

Related: #7547, follow-up to #7577