### PR TITLE
Fix catalog and schema identifier quoting

### DIFF
--- a/core/src/main/java/org/apache/hop/core/database/DatabaseMeta.java
+++ b/core/src/main/java/org/apache/hop/core/database/DatabaseMeta.java
@@ -1082,8 +1082,20 @@ public class DatabaseMeta extends HopMetadataBase implements Cloneable, IHopMeta
       }
     } else {
       return iDatabase.getSchemaTableCombination(
-          quoteField(variables.resolve(schemaName)), quoteField(variables.resolve(tableName)));
+          quoteSchema(variables.resolve(schemaName)), quoteField(variables.resolve(tableName)));
     }
+  }
+
+  private String quoteSchema(String schemaName) {
+    if (supportsCatalogs()) {
+      int separatorIndex = schemaName.indexOf('.');
+      if (separatorIndex > 0 && separatorIndex < schemaName.length() - 1) {
+        String catalogName = schemaName.substring(0, separatorIndex);
+        String schemaPart = schemaName.substring(separatorIndex + 1);
+        return quoteField(catalogName) + "." + quoteField(schemaPart);
+      }
+    }
+    return quoteField(schemaName);
   }
 
   public boolean isClob(IValueMeta v) {

--- a/core/src/test/java/org/apache/hop/core/database/DatabaseMetaTest.java
+++ b/core/src/test/java/org/apache/hop/core/database/DatabaseMetaTest.java
@@ -179,6 +179,24 @@ class DatabaseMetaTest {
   }
 
   @Test
+  void quotesCatalogAndSchemaSeparately() {
+    when(iDatabase.getStartQuote()).thenReturn("\"");
+    when(iDatabase.getEndQuote()).thenReturn("\"");
+    when(iDatabase.isSupportsCatalogs()).thenReturn(true);
+    when(iDatabase.getSchemaTableCombination(anyString(), anyString()))
+        .thenAnswer(invocation -> invocation.getArgument(0) + "." + invocation.getArgument(1));
+
+    assertEquals(
+        "catalog.schema.sample",
+        databaseMeta.getQuotedSchemaTableCombination(variables, "catalog.schema", "sample"));
+
+    when(iDatabase.isQuoteAllFields()).thenReturn(true);
+    assertEquals(
+        "\"catalog\".\"schema\".\"sample\"",
+        databaseMeta.getQuotedSchemaTableCombination(variables, "catalog.schema", "sample"));
+  }
+
+  @Test
   @SuppressWarnings("unchecked")
   void testModifyingName() {
     DatabaseMeta meta = mock(DatabaseMeta.class);


### PR DESCRIPTION
Fixes #5538.

## Summary

- quote catalog and schema identifiers separately when catalogs are supported
- preserve the existing schema quoting behavior for databases without catalog support
- add coverage for quoted and unquoted identifiers

## Root cause

The catalog and schema were passed to `quoteField` as one dotted value. The dot caused the full value to be treated as a single identifier, producing output such as `"catalog.schema".sample`.

## Validation

- `./mvnw -pl core -Dtest=DatabaseMetaTest test spotless:check`
- `git diff --check`
