### PR TITLE
issue #7652: skip Nexus browse for ASF/Central Maven group URLs

### DIFF
--- a/plugins/misc/marketplace/src/main/java/org/apache/hop/marketplace/catalog/NexusRepositoryBrowser.java
+++ b/plugins/misc/marketplace/src/main/java/org/apache/hop/marketplace/catalog/NexusRepositoryBrowser.java
@@ -45,6 +45,16 @@ public final class NexusRepositoryBrowser {
 
   private NexusRepositoryBrowser() {}
 
+  /**
+   * Whether {@code repositoryUrl} looks like a Sonatype Nexus 3 Maven base ({@code
+   * …/repository/&lt;name&gt;/}). Classic Maven group URLs (ASF public, Central) are not browsable
+   * this way — use the bundled Apache catalog and/or optional definition {@code plugins} metadata
+   * instead.
+   */
+  public static boolean isNexusBrowseUrl(String repositoryUrl) {
+    return StringUtils.isNotBlank(extractRepositoryName(repositoryUrl));
+  }
+
   public static List<OptionalPluginInfo> browse(
       MarketplaceRepository repository, String textFilter, ILogChannel log) throws HopException {
     if (repository == null || StringUtils.isBlank(repository.getUrl())) {
@@ -53,8 +63,15 @@ public final class NexusRepositoryBrowser {
     String repoName = extractRepositoryName(repository.getUrl());
     String nexusBase = extractNexusBase(repository.getUrl());
     if (StringUtils.isBlank(repoName) || StringUtils.isBlank(nexusBase)) {
-      throw new HopException(
-          "Cannot derive Nexus host/repository name from URL: " + repository.getUrl());
+      // ASF groups/public and Maven Central are install endpoints, not Nexus REST search.
+      if (log != null) {
+        log.logDetailed(
+            "Skipping Nexus zip browse for repository '"
+                + repository.getId()
+                + "' (URL is not a Nexus …/repository/<name>/ base): "
+                + repository.getUrl());
+      }
+      return List.of();
     }
 
     HttpClient client =

--- a/plugins/misc/marketplace/src/main/java/org/apache/hop/marketplace/catalog/PluginDiscovery.java
+++ b/plugins/misc/marketplace/src/main/java/org/apache/hop/marketplace/catalog/PluginDiscovery.java
@@ -95,12 +95,14 @@ public final class PluginDiscovery {
           }
         } catch (Exception e) {
           if (log != null) {
-            log.logError(
-                "Marketplace discovery failed for repository '"
+            // Network/Nexus errors: keep listing other sources; full stack only when detailed.
+            log.logBasic(
+                "Marketplace discovery skipped for repository '"
                     + repo.getId()
                     + "': "
-                    + e.getMessage(),
-                e);
+                    + e.getMessage());
+            log.logDetailed(
+                "Marketplace discovery failure for repository '" + repo.getId() + "'", e);
           }
         }
       }
@@ -270,14 +272,26 @@ public final class PluginDiscovery {
     if (StringUtils.isNotBlank(repo.getCatalogUrl())) {
       live = RemotePluginCatalog.load(repo);
       live = RemotePluginCatalog.filter(live, repo, filter);
-    } else {
+    } else if (NexusRepositoryBrowser.isNexusBrowseUrl(repo.getUrl())) {
       live = NexusRepositoryBrowser.browse(repo, filter, log);
+    } else {
+      // ASF public / Maven Central: install-only layout; Apache optionals come from the bundled
+      // catalog. Optional definition plugins still surface for browse=true non-Nexus repos.
+      live = List.of();
+      if (log != null) {
+        log.logDetailed(
+            "Repository '"
+                + repo.getId()
+                + "' is not a Nexus browse URL; using definition plugin metadata only if present.");
+      }
     }
 
-    // If live listing failed empty but definition has explicit plugins, use those (not a cache —
+    // If live listing is empty but definition has explicit plugins, use those (not a cache —
     // author-supplied list in the YAML).
     if (live.isEmpty() && repo.getPlugins() != null && !repo.getPlugins().isEmpty()) {
-      return RemotePluginCatalog.filter(repo.getPlugins(), repo, filter);
+      List<OptionalPluginInfo> fromDef =
+          RemotePluginCatalog.filter(repo.getPlugins(), repo, filter);
+      return enrichWithDefinitionMetadata(fromDef, repo);
     }
 
     return enrichWithDefinitionMetadata(live, repo);

--- a/plugins/misc/marketplace/src/test/java/org/apache/hop/marketplace/catalog/NexusRepositoryBrowserTest.java
+++ b/plugins/misc/marketplace/src/test/java/org/apache/hop/marketplace/catalog/NexusRepositoryBrowserTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.marketplace.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.hop.marketplace.config.MarketplaceRepository;
+import org.junit.jupiter.api.Test;
+
+class NexusRepositoryBrowserTest {
+
+  @Test
+  void asfPublicGroupIsNotNexusBrowseUrl() {
+    assertFalse(
+        NexusRepositoryBrowser.isNexusBrowseUrl(
+            "https://repository.apache.org/content/groups/public/"));
+    assertFalse(NexusRepositoryBrowser.isNexusBrowseUrl("https://repo1.maven.org/maven2/"));
+  }
+
+  @Test
+  void nexusRepositoryPathIsBrowsable() {
+    assertTrue(
+        NexusRepositoryBrowser.isNexusBrowseUrl(
+            "https://repository.data-hopper.com/repository/hop-community-plugins/"));
+    assertEquals(
+        "hop-community-plugins",
+        NexusRepositoryBrowser.extractRepositoryName(
+            "https://repository.data-hopper.com/repository/hop-community-plugins/"));
+  }
+
+  @Test
+  void browseAsfReturnsEmptyWithoutThrowing() throws Exception {
+    MarketplaceRepository asf =
+        new MarketplaceRepository("asf", "https://repository.apache.org/content/groups/public/");
+    asf.setBrowse(true);
+    assertTrue(NexusRepositoryBrowser.browse(asf, null, null).isEmpty());
+  }
+}


### PR DESCRIPTION
## Summary

After installing a plugin from the marketplace GUI, refresh called live discovery for every `browse=true` repository. The default **asf** URL (`https://repository.apache.org/content/groups/public/`) is a Maven group endpoint, not a Nexus `…/repository/<name>/` base, which produced:

`Cannot derive Nexus host/repository name from URL` (full ERROR stack).

Install itself already worked; only post-install refresh was noisy.

### Changes
- Detect Nexus browse URLs and skip non-Nexus bases quietly (ASF public, Central).
- Fall back to optional definition plugin metadata only for those repos.
- Demote unexpected discovery failures to basic log (stack at detailed).
- Unit tests for ASF vs Nexus URL handling.

## Test plan

- [x] `./mvnw -pl plugins/misc/marketplace test -Dtest=NexusRepositoryBrowserTest`
- [ ] Marketplace install (e.g. beam) from GUI; refresh table shows no ERROR for `asf`
- [ ] Real Nexus `browse=true` repos still list plugins

Fixes #7652