### PR TITLE
Resolve variables in Excel sheet regex patterns

### DIFF
--- a/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelinput/ExcelInput.java
+++ b/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelinput/ExcelInput.java
@@ -509,9 +509,10 @@ public class ExcelInput extends BaseTransform<ExcelInputMeta, ExcelInputData> {
 
     for (ExcelInputMeta.EISheet sheet : meta.getSheets()) {
       if (sheet.isRegex()) {
-        logBasic("Sheet regex pattern: [" + sheet.getName() + "]");
+        String sheetNameRegex = resolve(sheet.getName());
+        logBasic("Sheet regex pattern: [" + sheetNameRegex + "]");
         try {
-          Pattern pattern = Pattern.compile(sheet.getName());
+          Pattern pattern = Pattern.compile(sheetNameRegex);
           for (String sheetName : allSheetNames) {
             if (pattern.matcher(sheetName).matches()) {
               logBasic("  -> matched: [" + sheetName + "]");
@@ -523,7 +524,7 @@ public class ExcelInput extends BaseTransform<ExcelInputMeta, ExcelInputData> {
         } catch (PatternSyntaxException e) {
           logError(
               BaseMessages.getString(
-                  PKG, "ExcelInput.Error.InvalidSheetRegex", sheet.getName(), e.getMessage()));
+                  PKG, "ExcelInput.Error.InvalidSheetRegex", sheetNameRegex, e.getMessage()));
         }
       } else {
         logBasic("Sheet exact name: [" + sheet.getName() + "]");

--- a/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelinput/ExcelInputDialog.java
+++ b/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelinput/ExcelInputDialog.java
@@ -489,6 +489,7 @@ public class ExcelInputDialog extends BaseTransformDialog {
             BaseMessages.getString(PKG, "ExcelInputDialog.SheetName.Column"),
             ColumnInfo.COLUMN_TYPE_TEXT,
             false);
+    shinfo[0].setUsingVariables(true);
     shinfo[1] =
         new ColumnInfo(
             BaseMessages.getString(PKG, "ExcelInputDialog.StartRow.Column"),

--- a/plugins/transforms/excel/src/test/java/org/apache/hop/pipeline/transforms/excelinput/ExcelInputContentParsingTest.java
+++ b/plugins/transforms/excel/src/test/java/org/apache/hop/pipeline/transforms/excelinput/ExcelInputContentParsingTest.java
@@ -338,4 +338,25 @@ class ExcelInputContentParsingTest extends BaseExcelParsingTest {
     assertEquals(firstResult, rows.get(0)[0], "Wrong first result");
     assertEquals(lastResult, rows.get(TEST_ROW_LIMIT_MULTIPLE_SHEET - 1)[0], "Wrong last result");
   }
+
+  @Test
+  void testSheetRegexResolvedFromVariable() throws Exception {
+    meta.setSpreadSheetType(SpreadSheetType.SAX_POI);
+    meta.setStartsWithHeader(true);
+    setFields(new ExcelInputField("COL", -1, -1));
+
+    ExcelInputMeta.EISheet sheet = new ExcelInputMeta.EISheet();
+    sheet.setName("${SHEET_NAME_REGEX}");
+    sheet.setRegex(true);
+    meta.getSheets().add(sheet);
+
+    init("pdi-17765.xlsx");
+    transform.setVariable("SHEET_NAME_REGEX", "Sheet[12]");
+    process();
+
+    checkErrors();
+    assertEquals(40, rows.size(), "Wrong row count");
+    assertEquals("1.0", rows.get(0)[0], "Wrong first result");
+    assertEquals("101.0", rows.get(rows.size() - 1)[0], "Wrong last result");
+  }
 }


### PR DESCRIPTION
## Summary

Allow sheet-name regex patterns in the **Microsoft Excel Input** transform to contain Hop variables.

**Example:** with `SHEET_NAME_REGEX=Data_.*`, entering `${SHEET_NAME_REGEX}` in the sheet-name column and enabling **Regex?** reads all matching sheets such as `Data_Jan`, `Data_Feb`, and `Data_Mar`.

This is a follow-up to #7059, which introduced regex-based sheet selection.

## Changes

- `ExcelInput` — resolve the configured sheet-name regex before compiling and matching it; report the resolved expression in logs and syntax errors
- `ExcelInputDialog` — mark the sheet-name column as variable-aware, enabling the variable helper, visual indicator, and `Ctrl+Space`
- `ExcelInputContentParsingTest` — add coverage using `${SHEET_NAME_REGEX}` resolved to `Sheet[12]` and verify both matching sheets are read

## Testing

- 32 Excel Input tests pass with 0 failures and 0 errors
- Excel transform plugin builds successfully
- Apache RAT reports 0 unapproved licenses
- Verified end-to-end in a locally built Hop 2.19.0-SNAPSHOT distribution

## Checklist

- [x] `mvn spotless:apply` applied
- [x] `mvn apache-rat:check` passes
- [x] Changes are contained in a single commit
- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)