### PR TITLE
issue #7692: reopen files after environment/project refresh

### DIFF
--- a/plugins/misc/projects/src/main/java/org/apache/hop/projects/gui/ProjectsGuiPlugin.java
+++ b/plugins/misc/projects/src/main/java/org/apache/hop/projects/gui/ProjectsGuiPlugin.java
@@ -173,6 +173,11 @@ public class ProjectsGuiPlugin {
       //
       ExecutionPerspective.getInstance().saveState();
 
+      // Save explorer layout (split panes, panel visibility) while tabs are still open so the
+      // restored layout matches what the user had before the switch (issue #7692 / #6708).
+      //
+      ExplorerPerspective.getInstance().saveExplorerStateOnShutdown();
+
       // Close's all (including execution information tabs)
       //
       hopGui.fileDelegate.closeAllFiles();
@@ -182,10 +187,6 @@ public class ProjectsGuiPlugin {
       if (hopGui.getTerminalPanel() != null) {
         hopGui.getTerminalPanel().clearAllTerminals();
       }
-
-      // Save explorer perspective state for the current project before switching namespace
-      //
-      ExplorerPerspective.getInstance().saveExplorerStateOnShutdown();
 
       // This is called only in Hop GUI so we want to start with a new set of variables
       // It avoids variables from one project showing up in another
@@ -224,19 +225,6 @@ public class ProjectsGuiPlugin {
         }
       }
 
-      // We need to change the currently set variables in the newly loaded files
-      //
-      hopGui.setVariables(variables);
-
-      // Re-open last open files for the namespace
-      hopGui.getDisplay().asyncExec(() -> hopGui.auditDelegate.openLastFiles());
-
-      // Restore terminal tabs for the new project (per-project terminals)
-      //
-      if (hopGui.getTerminalPanel() != null && hopGui.getProps().openLastFile()) {
-        hopGui.getDisplay().asyncExec(() -> hopGui.getTerminalPanel().restoreTerminals());
-      }
-
       // Clear last used, fill it with something useful.
       //
       IVariables hopGuiVariables = Variables.getADefaultVariableSpace();
@@ -246,6 +234,18 @@ public class ProjectsGuiPlugin {
         if (!variable.startsWith(Const.INTERNAL_VARIABLE_PREFIX)) {
           hopGuiVariables.setVariable(variable, value);
         }
+      }
+
+      // Re-open last open files for the namespace after HopGui variables are final.
+      // Run synchronously so tabs are restored before ProjectActivated listeners refresh the
+      // explorer layout (async restore raced with layout apply after #6708, issue #7692).
+      //
+      hopGui.auditDelegate.openLastFiles();
+
+      // Restore terminal tabs for the new project (per-project terminals)
+      //
+      if (hopGui.getTerminalPanel() != null && hopGui.getProps().openLastFile()) {
+        hopGui.getTerminalPanel().restoreTerminals();
       }
 
       // Refresh the currently active file

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/delegates/HopGuiAuditDelegate.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/delegates/HopGuiAuditDelegate.java
@@ -82,8 +82,26 @@ public class HopGuiAuditDelegate {
       return;
     }
 
-    String namespace = HopNamespace.getNamespace();
+    // Prevent per-file writeLastOpenFiles() calls (from fileOpenWithType) from rewriting the
+    // audit list mid-restore. Same flag used at Hop GUI startup.
+    //
+    boolean previousReOpening = hopGui.isReOpeningFiles();
+    hopGui.setReOpeningFiles(true);
+    try {
+      openLastFilesInternal();
+    } finally {
+      hopGui.setReOpeningFiles(previousReOpening);
+    }
 
+    // Persist the actual open set once restore is finished (failed opens are omitted).
+    // Only when we were not already inside a broader re-open block.
+    //
+    if (!previousReOpening) {
+      writeLastOpenFiles();
+    }
+  }
+
+  private void openLastFilesInternal() {
     // Collect files that fail to open
     List<String> failedFiles = new ArrayList<>();
 
@@ -301,6 +319,13 @@ public class HopGuiAuditDelegate {
     // Things get chaotic otherwise.
     //
     if (hopGui.isReOpeningFiles()) {
+      return;
+    }
+    // Bulk close (project/environment switch, File → Close All) empties tabs first, then may call
+    // writeLastOpenFiles from closeTab handlers. Writing then would overwrite the list we just
+    // saved for reopen (issue #7692).
+    //
+    if (hopGui.fileDelegate != null && hopGui.fileDelegate.isClosing()) {
       return;
     }
     if (!hopGui.getProps().openLastFile()) {

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/execution/ExecutionPerspective.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/execution/ExecutionPerspective.java
@@ -1474,7 +1474,13 @@ public class ExecutionPerspective implements IHopPerspective, TabClosable {
     tabItem.dispose();
 
     if (isRemoved) {
-      hopGui.auditDelegate.writeLastOpenFiles();
+      // Skip during bulk close (project/environment switch or closeAllTabs): the open-files list
+      // was saved before closeAllFiles; writing here would overwrite it with empty tabs after
+      // pipelines/workflows were already closed (issue #7692).
+      //
+      if (!closingAllTabs && !hopGui.fileDelegate.isClosing()) {
+        hopGui.auditDelegate.writeLastOpenFiles();
+      }
       // Keep the per-project open-tabs audit in sync when the user closes a single tab.
       // Skip during closeAllTabs so a prior saveState() for project switch is not wiped.
       //

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/ExplorerPerspective.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/ExplorerPerspective.java
@@ -398,6 +398,8 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
     }
 
     // Refresh the file explorer when a project is activated or updated.
+    // applyRestoredState() only rebuilds the editor split layout when the editor is empty, so it
+    // is safe after enableHopGuiProject has already reopened tabs (issue #7692).
     //
     hopGui
         .getEventsHandler()
@@ -2142,7 +2144,10 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
       removeHandlerAndDisposeTab(tabItem);
       isRemoved = true;
     }
-    if (isRemoved) {
+    // Skip during bulk close (project/environment switch): writeLastOpenFiles was already called
+    // before closeAllFiles; writing here would persist an empty open-files list (issue #7692).
+    //
+    if (isRemoved && !hopGui.fileDelegate.isClosing()) {
       hopGui.auditDelegate.writeLastOpenFiles();
     }
     if (!isRemoved && event != null) {

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/metadata/MetadataPerspective.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/metadata/MetadataPerspective.java
@@ -3322,7 +3322,10 @@ public class MetadataPerspective implements IHopPerspective, TabClosable, IMetad
     MetadataEditor<?> editor = (MetadataEditor<?>) tabItem.getData();
 
     boolean isRemoved = remove(editor);
-    if (isRemoved) {
+    // Skip during bulk close (project/environment switch): the open-files list was saved before
+    // closeAllFiles; writing here would overwrite it with whatever is left (issue #7692).
+    //
+    if (isRemoved && !hopGui.fileDelegate.isClosing()) {
       hopGui.auditDelegate.writeLastOpenFiles();
     }
     if (!isRemoved && event != null) {


### PR DESCRIPTION
## Summary

Fixes [#7692](https://github.com/apache/hop/issues/7692): after changing a variable in an environment configuration file and accepting the reload prompt, Hop GUI closed all open files but never reopened them.

### Root cause

On project/environment enable, `ProjectsGuiPlugin.enableHopGuiProject()` correctly:

1. Saves the open-files audit list via `writeLastOpenFiles()`
2. Closes all tabs via `closeAllFiles()`
3. Reopens from that list via `openLastFiles()`

During step 2, bulk close paths (especially `ExecutionPerspective.closeAllTabs()` → `closeTab()`) called `writeLastOpenFiles()` **again** after explorer tabs were already empty. That overwrote the just-saved list with an empty one, so step 3 had nothing to restore.

Startup reopen still worked because `reOpeningFiles=true` skips those intermediate writes; mid-session environment reload did not set that flag.

Related recent churn that made this easier to hit: editor split/detach restore (#6708 / #7580) and execution-tab close-all on project switch.

### Fix

1. **Do not rewrite the open-files audit during bulk close**
   - `HopGuiAuditDelegate.writeLastOpenFiles()` returns early when `fileDelegate.isClosing()`
   - `closeTab` in Execution / Explorer / Metadata perspectives skips the audit write while closing en masse

2. **Safer reopen**
   - `openLastFiles()` sets `reOpeningFiles` for the duration of restore (same pattern as GUI startup) so per-file open does not rewrite audit mid-restore
   - After restore completes, write the actual open set once

3. **Project/environment enable ordering**
   - Save explorer layout **before** closing tabs (while the split layout still matches open files)
   - Reopen files **synchronously** after HopGui variables are final, **before** `ProjectActivated` listeners refresh the explorer (avoids async race with layout restore)

## Test plan

- [x] Open one or more pipelines/workflows, optionally with Execution Information tabs open
- [x] Edit a variable in an environment configuration file and accept the reload prompt
- [x] Confirm files close and reopen correctly
- [ ] Switch project/environment from the toolbar and confirm tabs restore
- [ ] Restart Hop GUI with "Reopen tabs on startup" enabled and confirm last files still restore
- [ ] Manually close a single tab and confirm the open-files list still updates (normal close path)