### PR TITLE
issue #2293: reload after saving system variables

### DIFF
--- a/plugins/misc/projects/src/main/java/org/apache/hop/projects/gui/ProjectsGuiPlugin.java
+++ b/plugins/misc/projects/src/main/java/org/apache/hop/projects/gui/ProjectsGuiPlugin.java
@@ -708,12 +708,69 @@ public class ProjectsGuiPlugin {
     }
   }
 
-  private boolean askAboutProjectRefresh(HopGui hopGui) {
+  private static boolean askAboutProjectRefresh(HopGui hopGui) {
     MessageBox box = new MessageBox(hopGui.getShell(), SWT.ICON_QUESTION | SWT.YES | SWT.NO);
     box.setText(BaseMessages.getString(PKG, "ProjectGuiPlugin.ReloadProject.Dialog.Header"));
     box.setMessage(BaseMessages.getString(PKG, "ProjectGuiPlugin.ReloadProject.Dialog.Message"));
     int answer = box.open();
     return (answer & SWT.YES) != 0;
+  }
+
+  /**
+   * Called after system (described) variables were saved in the configuration perspective. Offers
+   * to reload the active project so open files, metadata and layered project/environment variables
+   * pick up the new hop-config values without a full GUI restart (issue #2293).
+   */
+  public static void reloadAfterSystemVariablesSaved() {
+    if (!ProjectsConfigSingleton.getConfig().isEnabled()) {
+      return;
+    }
+
+    HopGui hopGui = HopGui.getInstance();
+    ProjectsConfig config = ProjectsConfigSingleton.getConfig();
+
+    String projectName = HopNamespace.getNamespace();
+    if (StringUtils.isEmpty(projectName) || HopGui.DEFAULT_HOP_GUI_NAMESPACE.equals(projectName)) {
+      // Fall back to the toolbar label when namespace is not a real project.
+      //
+      if (hopGui.getStatusToolbarWidgets() != null) {
+        projectName = hopGui.getStatusToolbarWidgets().getToolbarItemText(ID_TOOLBAR_ITEM_PROJECT);
+      }
+    }
+    if (StringUtils.isEmpty(projectName)) {
+      return;
+    }
+
+    ProjectConfig projectConfig = config.findProjectConfig(projectName);
+    if (projectConfig == null) {
+      return;
+    }
+
+    if (!askAboutProjectRefresh(hopGui)) {
+      return;
+    }
+
+    try {
+      String environmentName = null;
+      if (hopGui.getStatusToolbarWidgets() != null) {
+        environmentName =
+            hopGui.getStatusToolbarWidgets().getToolbarItemText(ID_TOOLBAR_ITEM_ENVIRONMENT);
+      }
+      LifecycleEnvironment environment =
+          StringUtils.isNotEmpty(environmentName) ? config.findEnvironment(environmentName) : null;
+
+      Project project = projectConfig.loadProject(hopGui.getVariables());
+      if (project != null) {
+        enableHopGuiProject(projectName, project, environment);
+      }
+    } catch (Exception e) {
+      new ErrorDialog(
+          hopGui.getActiveShell(),
+          BaseMessages.getString(PKG, "ProjectGuiPlugin.EditProject.Error.Dialog.Header"),
+          BaseMessages.getString(
+              PKG, "ProjectGuiPlugin.EditProject.Error.Dialog.Message", projectName),
+          e);
+    }
   }
 
   @GuiToolbarElement(

--- a/plugins/misc/projects/src/main/java/org/apache/hop/projects/xp/HopGuiSystemVariablesSavedExtension.java
+++ b/plugins/misc/projects/src/main/java/org/apache/hop/projects/xp/HopGuiSystemVariablesSavedExtension.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.projects.xp;
+
+import java.util.List;
+import org.apache.hop.core.exception.HopException;
+import org.apache.hop.core.extension.ExtensionPoint;
+import org.apache.hop.core.extension.IExtensionPoint;
+import org.apache.hop.core.logging.ILogChannel;
+import org.apache.hop.core.variables.DescribedVariable;
+import org.apache.hop.core.variables.IVariables;
+import org.apache.hop.projects.gui.ProjectsGuiPlugin;
+
+/**
+ * After system variables are saved from the configuration perspective, offer to reload the active
+ * project so variables, open files and metadata pick up the new values (issue #2293).
+ */
+@ExtensionPoint(
+    id = "HopGuiSystemVariablesSaved",
+    extensionPointId = "HopGuiSystemVariablesSaved",
+    description =
+        "After system variables are saved, offer to reload the active project so variables, "
+            + "files and metadata pick up the new values")
+public class HopGuiSystemVariablesSavedExtension
+    implements IExtensionPoint<List<DescribedVariable>> {
+
+  @Override
+  public void callExtensionPoint(
+      ILogChannel log, IVariables variables, List<DescribedVariable> describedVariables)
+      throws HopException {
+    ProjectsGuiPlugin.reloadAfterSystemVariablesSaved();
+  }
+}

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/HopGuiExtensionPoint.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/HopGuiExtensionPoint.java
@@ -17,6 +17,7 @@
 
 package org.apache.hop.ui.hopgui;
 
+import java.util.List;
 import org.apache.hop.ui.hopgui.delegates.HopGuiDirectorySelectedExtension;
 import org.apache.hop.ui.hopgui.delegates.HopGuiFileDialogExtension;
 import org.apache.hop.ui.hopgui.delegates.HopGuiFileOpenedExtension;
@@ -64,6 +65,10 @@ public enum HopGuiExtensionPoint {
   PipelineExecutionViewerUpdate(
       "When the UI needs updating and you want to enable/disable widgets",
       PipelineExecutionViewer.class),
+
+  HopGuiSystemVariablesSaved(
+      "Called after system (described) variables were saved from the configuration perspective",
+      List.class),
   ;
 
   public String id;

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/configuration/tabs/ConfigVariablesTab.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/configuration/tabs/ConfigVariablesTab.java
@@ -22,9 +22,11 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.hop.core.Const;
 import org.apache.hop.core.config.HopConfig;
+import org.apache.hop.core.extension.ExtensionPointHandler;
 import org.apache.hop.core.gui.plugin.GuiPlugin;
 import org.apache.hop.core.gui.plugin.tab.GuiTab;
 import org.apache.hop.core.variables.DescribedVariable;
+import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.core.variables.Variables;
 import org.apache.hop.i18n.BaseMessages;
 import org.apache.hop.ui.core.PropsUi;
@@ -34,6 +36,7 @@ import org.apache.hop.ui.core.gui.GuiResource;
 import org.apache.hop.ui.core.widget.ColumnInfo;
 import org.apache.hop.ui.core.widget.TableView;
 import org.apache.hop.ui.hopgui.HopGui;
+import org.apache.hop.ui.hopgui.HopGuiExtensionPoint;
 import org.apache.hop.ui.hopgui.perspective.configuration.ConfigurationPerspective;
 import org.apache.hop.ui.pipeline.transform.BaseTransformDialog;
 import org.eclipse.swt.SWT;
@@ -150,6 +153,28 @@ public class ConfigVariablesTab {
       }
       HopConfig.getInstance().setDescribedVariables(variables);
       HopConfig.getInstance().saveToFile();
+
+      // Apply the saved variables to the live HopGui variable space so non-project
+      // usage picks them up without a restart. Open files still need a project reload
+      // (or restart) for a full refresh of resolved paths and metadata.
+      //
+      HopGui hopGui = HopGui.getInstance();
+      IVariables hopGuiVariables = hopGui.getVariables();
+      if (hopGuiVariables != null) {
+        for (DescribedVariable variable : variables) {
+          if (variable.getName() != null) {
+            hopGuiVariables.setVariable(variable.getName(), variable.getValue());
+          }
+        }
+      }
+
+      // Allow plugins (e.g. Projects) to reload so files and metadata see the new values.
+      //
+      ExtensionPointHandler.callExtensionPoint(
+          hopGui.getLog(),
+          hopGuiVariables,
+          HopGuiExtensionPoint.HopGuiSystemVariablesSaved.id,
+          variables);
     } catch (Exception e) {
       new ErrorDialog(
           HopGui.getInstance().getShell(),


### PR DESCRIPTION
## Summary

- After saving system variables in the configuration perspective, apply them to the live HopGui variable space so non-project usage picks up new values without a restart.
- Fire a new `HopGuiSystemVariablesSaved` GUI extension point after a successful save.
- Projects plugin implementation offers “Reload project?” (same dialog as environment/project edit) and re-enables the active project/environment via `enableHopGuiProject`, so open files and metadata resolve the new hop-config values.

Fixes #2293 (HOP-4572).

## Test plan

- [x] Change a system variable, Save → value is applied on HopGui variables
- [x] With an active project, Save → “Reload project?” dialog appears
- [x] Accept reload → project re-opens with new variable values available to files/metadata
- [x] Decline reload → hop-config saved; runtime project state unchanged until later reload/restart
- [x] No project / projects disabled → Save still works; no dialog/NPE
- [x] `./mvnw -pl ui,plugins/misc/projects -am compile` succeeds