### PR TITLE
issue #7727 : document S3 endpoint URL and path-style access options

### DIFF
--- a/docs/hop-user-manual/modules/ROOT/pages/vfs/aws-s3-vfs.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/vfs/aws-s3-vfs.adoc
@@ -56,6 +56,21 @@ You can set the following system environment variables:
 * `AWS_ACCESS_KEY_ID` : set it to your AWS access key
 * `AWS_SECRET_ACCESS_KEY` : set it to your secret access key
 
+== S3-compatible services
+
+Storage services that implement the S3 API can be used through this plugin as well.
+Create an **S3 Connection** metadata item and fill in the following options:
+
+* `Endpoint URL` : the endpoint of the service, for example `https://s3.example-region.example.com`.
+Leave this empty for Amazon S3, where the endpoint is derived from the region.
+* `Path-style access` : check this when the service expects the bucket in the path (`endpoint/bucketName`) instead of in the hostname (`bucketName.endpoint`).
+This option is only applied when an endpoint URL is set.
+
+The name of the connection is registered as a VFS scheme of its own, so a connection named `storage` gives you paths like `storage://bucketName/path/to/file.csv`.
+
+This works with Amazon S3 and with S3-compatible services such as Backblaze B2, Cloudflare R2 and MinIO.
+Check the documentation of your service for the endpoint to use and for whether path-style access is required.
+
 == Part size
 
 You can set the default part size for new files on S3 by setting the following variable:


### PR DESCRIPTION
## Summary

Resolves #7727

The S3 Connection metadata type already supports an `Endpoint URL` and a `Path-style access` option, and both are passed through to the AWS SDK as `endpointOverride` / `forcePathStyle`. The AWS S3 VFS page only covered Amazon credentials, part size and testing, so neither option was documented anywhere in the user manual.

This adds a short `S3-compatible services` section to `docs/hop-user-manual/modules/ROOT/pages/vfs/aws-s3-vfs.adoc` covering the two options, the fact that path-style access is only applied when an endpoint URL is set (`S3CommonFileSystem#getS3Client`), and the fact that the connection name is registered as a VFS scheme of its own (`S3VfsPlugin#getProviders`).

Docs only, no code changes.

## Test plan

- [x] Rendered `docs/hop-user-manual/modules/ROOT/pages/vfs/aws-s3-vfs.adoc` with Asciidoctor at `--failure-level=WARN`, no warnings or errors
- [ ] Review the wording of the new `S3-compatible services` section

------------------------

- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i` (single commit)
- [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable (no existing issue; happy to file one if you prefer)
- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)