### PR TITLE
Update Oracle LIMIT clause to use FETCH FIRST syntax #7726

### DIFF
--- a/plugins/databases/oracle/src/main/java/org/apache/hop/databases/oracle/OracleDatabaseMeta.java
+++ b/plugins/databases/oracle/src/main/java/org/apache/hop/databases/oracle/OracleDatabaseMeta.java
@@ -318,7 +318,8 @@ public class OracleDatabaseMeta extends BaseDatabaseMeta
    */
   @Override
   public String getLimitClause(int nrRows) {
-    return " WHERE ROWNUM <= " + nrRows;
+    // Minimum version Oracle 12c Release 1 (released in 2013)
+    return " FETCH FIRST " + nrRows + " ROWS ONLY";
   }
 
   /**

--- a/plugins/databases/oracle/src/test/java/org/apache/hop/databases/oracle/OracleDatabaseMetaTest.java
+++ b/plugins/databases/oracle/src/test/java/org/apache/hop/databases/oracle/OracleDatabaseMetaTest.java
@@ -245,7 +245,7 @@ class OracleDatabaseMetaTest {
 
   @Test
   void testOverriddenSqlStatements() {
-    assertEquals(" WHERE ROWNUM <= 5", nativeMeta.getLimitClause(5));
+    assertEquals(" FETCH FIRST 5 ROWS ONLY", nativeMeta.getLimitClause(5));
     String reusedFieldsQuery = "SELECT * FROM FOO WHERE 1=0";
     assertEquals(reusedFieldsQuery, nativeMeta.getSqlQueryFields("FOO"));
     assertEquals(reusedFieldsQuery, nativeMeta.getSqlTableExists("FOO"));


### PR DESCRIPTION
Minimum version Oracle 12c Release 1 (released in 2013)