### PR TITLE
issue #2753 : make default run configuration flag exclusive

### DIFF
--- a/engine/src/main/java/org/apache/hop/pipeline/config/PipelineRunConfiguration.java
+++ b/engine/src/main/java/org/apache/hop/pipeline/config/PipelineRunConfiguration.java
@@ -19,6 +19,7 @@ package org.apache.hop.pipeline.config;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hop.core.exception.HopException;
 import org.apache.hop.core.variables.DescribedVariable;
@@ -31,6 +32,7 @@ import org.apache.hop.metadata.api.HopMetadataProperty;
 import org.apache.hop.metadata.api.HopMetadataPropertyType;
 import org.apache.hop.metadata.api.IHopMetadata;
 import org.apache.hop.metadata.api.IHopMetadataProvider;
+import org.apache.hop.metadata.api.IHopMetadataSerializer;
 
 @HopMetadata(
     key = "pipeline-run-configuration",
@@ -232,5 +234,27 @@ public class PipelineRunConfiguration extends HopMetadataBase implements Cloneab
     }
 
     return null;
+  }
+
+  /**
+   * Clear the default flag on every pipeline run configuration except the one named {@code
+   * keepName}, and save those updates. Ensures at most one default after the named configuration is
+   * saved as default.
+   *
+   * @param metadataProvider the metadata provider
+   * @param keepName name of the run configuration that should remain (or become) the default
+   * @throws HopException if metadata cannot be loaded or saved
+   */
+  public static void clearDefaultFlagFromOthers(
+      IHopMetadataProvider metadataProvider, String keepName) throws HopException {
+    IHopMetadataSerializer<PipelineRunConfiguration> serializer =
+        metadataProvider.getSerializer(PipelineRunConfiguration.class);
+    for (PipelineRunConfiguration runConfiguration : serializer.loadAll()) {
+      if (runConfiguration.isDefaultSelection()
+          && !Objects.equals(runConfiguration.getName(), keepName)) {
+        runConfiguration.setDefaultSelection(false);
+        serializer.save(runConfiguration);
+      }
+    }
   }
 }

--- a/engine/src/main/java/org/apache/hop/workflow/config/WorkflowRunConfiguration.java
+++ b/engine/src/main/java/org/apache/hop/workflow/config/WorkflowRunConfiguration.java
@@ -17,6 +17,7 @@
 
 package org.apache.hop.workflow.config;
 
+import java.util.Objects;
 import org.apache.hop.core.exception.HopException;
 import org.apache.hop.metadata.api.HopMetadata;
 import org.apache.hop.metadata.api.HopMetadataBase;
@@ -25,6 +26,7 @@ import org.apache.hop.metadata.api.HopMetadataProperty;
 import org.apache.hop.metadata.api.HopMetadataPropertyType;
 import org.apache.hop.metadata.api.IHopMetadata;
 import org.apache.hop.metadata.api.IHopMetadataProvider;
+import org.apache.hop.metadata.api.IHopMetadataSerializer;
 
 @HopMetadata(
     key = "workflow-run-configuration",
@@ -167,5 +169,27 @@ public class WorkflowRunConfiguration extends HopMetadataBase implements Cloneab
     }
 
     return null;
+  }
+
+  /**
+   * Clear the default flag on every workflow run configuration except the one named {@code
+   * keepName}, and save those updates. Ensures at most one default after the named configuration is
+   * saved as default.
+   *
+   * @param metadataProvider the metadata provider
+   * @param keepName name of the run configuration that should remain (or become) the default
+   * @throws HopException if metadata cannot be loaded or saved
+   */
+  public static void clearDefaultFlagFromOthers(
+      IHopMetadataProvider metadataProvider, String keepName) throws HopException {
+    IHopMetadataSerializer<WorkflowRunConfiguration> serializer =
+        metadataProvider.getSerializer(WorkflowRunConfiguration.class);
+    for (WorkflowRunConfiguration runConfiguration : serializer.loadAll()) {
+      if (runConfiguration.isDefaultSelection()
+          && !Objects.equals(runConfiguration.getName(), keepName)) {
+        runConfiguration.setDefaultSelection(false);
+        serializer.save(runConfiguration);
+      }
+    }
   }
 }

--- a/engine/src/test/java/org/apache/hop/pipeline/config/PipelineRunConfigurationDefaultTest.java
+++ b/engine/src/test/java/org/apache/hop/pipeline/config/PipelineRunConfigurationDefaultTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.pipeline.config;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.hop.metadata.api.IHopMetadataSerializer;
+import org.apache.hop.metadata.serializer.memory.MemoryMetadataProvider;
+import org.junit.jupiter.api.Test;
+
+/** Ensures at most one pipeline run configuration keeps the default flag (issue #2753). */
+class PipelineRunConfigurationDefaultTest {
+
+  @Test
+  void clearDefaultFlagFromOthersClearsOtherDefaults() throws Exception {
+    MemoryMetadataProvider metadataProvider = new MemoryMetadataProvider();
+    IHopMetadataSerializer<PipelineRunConfiguration> serializer =
+        metadataProvider.getSerializer(PipelineRunConfiguration.class);
+
+    serializer.save(config("A", true));
+    serializer.save(config("B", true));
+    serializer.save(config("C", false));
+
+    PipelineRunConfiguration.clearDefaultFlagFromOthers(metadataProvider, "B");
+
+    assertFalse(serializer.load("A").isDefaultSelection());
+    assertTrue(serializer.load("B").isDefaultSelection());
+    assertFalse(serializer.load("C").isDefaultSelection());
+  }
+
+  @Test
+  void clearDefaultFlagFromOthersLeavesMatchingDefault() throws Exception {
+    MemoryMetadataProvider metadataProvider = new MemoryMetadataProvider();
+    IHopMetadataSerializer<PipelineRunConfiguration> serializer =
+        metadataProvider.getSerializer(PipelineRunConfiguration.class);
+
+    serializer.save(config("only-default", true));
+
+    PipelineRunConfiguration.clearDefaultFlagFromOthers(metadataProvider, "only-default");
+
+    assertTrue(serializer.load("only-default").isDefaultSelection());
+  }
+
+  @Test
+  void clearDefaultFlagFromOthersDoesNotTouchNonDefaults() throws Exception {
+    MemoryMetadataProvider metadataProvider = new MemoryMetadataProvider();
+    IHopMetadataSerializer<PipelineRunConfiguration> serializer =
+        metadataProvider.getSerializer(PipelineRunConfiguration.class);
+
+    serializer.save(config("A", false));
+    serializer.save(config("B", false));
+
+    PipelineRunConfiguration.clearDefaultFlagFromOthers(metadataProvider, "B");
+
+    assertFalse(serializer.load("A").isDefaultSelection());
+    assertFalse(serializer.load("B").isDefaultSelection());
+  }
+
+  private static PipelineRunConfiguration config(String name, boolean defaultSelection) {
+    PipelineRunConfiguration configuration = new PipelineRunConfiguration();
+    configuration.setName(name);
+    configuration.setDefaultSelection(defaultSelection);
+    return configuration;
+  }
+}

--- a/engine/src/test/java/org/apache/hop/workflow/config/WorkflowRunConfigurationDefaultTest.java
+++ b/engine/src/test/java/org/apache/hop/workflow/config/WorkflowRunConfigurationDefaultTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.workflow.config;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.hop.metadata.api.IHopMetadataSerializer;
+import org.apache.hop.metadata.serializer.memory.MemoryMetadataProvider;
+import org.junit.jupiter.api.Test;
+
+/** Ensures at most one workflow run configuration keeps the default flag (issue #2753). */
+class WorkflowRunConfigurationDefaultTest {
+
+  @Test
+  void clearDefaultFlagFromOthersClearsOtherDefaults() throws Exception {
+    MemoryMetadataProvider metadataProvider = new MemoryMetadataProvider();
+    IHopMetadataSerializer<WorkflowRunConfiguration> serializer =
+        metadataProvider.getSerializer(WorkflowRunConfiguration.class);
+
+    serializer.save(config("A", true));
+    serializer.save(config("B", true));
+    serializer.save(config("C", false));
+
+    WorkflowRunConfiguration.clearDefaultFlagFromOthers(metadataProvider, "B");
+
+    assertFalse(serializer.load("A").isDefaultSelection());
+    assertTrue(serializer.load("B").isDefaultSelection());
+    assertFalse(serializer.load("C").isDefaultSelection());
+  }
+
+  @Test
+  void clearDefaultFlagFromOthersLeavesMatchingDefault() throws Exception {
+    MemoryMetadataProvider metadataProvider = new MemoryMetadataProvider();
+    IHopMetadataSerializer<WorkflowRunConfiguration> serializer =
+        metadataProvider.getSerializer(WorkflowRunConfiguration.class);
+
+    serializer.save(config("only-default", true));
+
+    WorkflowRunConfiguration.clearDefaultFlagFromOthers(metadataProvider, "only-default");
+
+    assertTrue(serializer.load("only-default").isDefaultSelection());
+  }
+
+  @Test
+  void clearDefaultFlagFromOthersDoesNotTouchNonDefaults() throws Exception {
+    MemoryMetadataProvider metadataProvider = new MemoryMetadataProvider();
+    IHopMetadataSerializer<WorkflowRunConfiguration> serializer =
+        metadataProvider.getSerializer(WorkflowRunConfiguration.class);
+
+    serializer.save(config("A", false));
+    serializer.save(config("B", false));
+
+    WorkflowRunConfiguration.clearDefaultFlagFromOthers(metadataProvider, "B");
+
+    assertFalse(serializer.load("A").isDefaultSelection());
+    assertFalse(serializer.load("B").isDefaultSelection());
+  }
+
+  private static WorkflowRunConfiguration config(String name, boolean defaultSelection) {
+    WorkflowRunConfiguration configuration = new WorkflowRunConfiguration();
+    configuration.setName(name);
+    configuration.setDefaultSelection(defaultSelection);
+    return configuration;
+  }
+}

--- a/ui/src/main/java/org/apache/hop/ui/pipeline/config/PipelineRunConfigurationEditor.java
+++ b/ui/src/main/java/org/apache/hop/ui/pipeline/config/PipelineRunConfigurationEditor.java
@@ -530,6 +530,13 @@ public class PipelineRunConfigurationEditor extends MetadataEditor<PipelineRunCo
   public void save() throws HopException {
     changeWorkingEngineConfiguration(runConfiguration);
 
+    // Make this the exclusive default when the default flag is set (issue #2753).
+    getWidgetsContent(getMetadata());
+    if (getMetadata().isDefaultSelection()) {
+      PipelineRunConfiguration.clearDefaultFlagFromOthers(
+          manager.getMetadataProvider(), getMetadata().getName());
+    }
+
     super.save();
   }
 

--- a/ui/src/main/java/org/apache/hop/ui/workflow/config/WorkflowRunConfigurationEditor.java
+++ b/ui/src/main/java/org/apache/hop/ui/workflow/config/WorkflowRunConfigurationEditor.java
@@ -334,6 +334,13 @@ public class WorkflowRunConfigurationEditor extends MetadataEditor<WorkflowRunCo
   public void save() throws HopException {
     changeWorkingEngineConfiguration(runConfiguration);
 
+    // Make this the exclusive default when the default flag is set (issue #2753).
+    getWidgetsContent(getMetadata());
+    if (getMetadata().isDefaultSelection()) {
+      WorkflowRunConfiguration.clearDefaultFlagFromOthers(
+          manager.getMetadataProvider(), getMetadata().getName());
+    }
+
     super.save();
   }
 


### PR DESCRIPTION
## Summary

- When a pipeline or workflow run configuration is saved with the default flag set, automatically clear that flag on every other configuration of the same type.
- Ensures only one default run configuration remains; no warning dialog is shown because the user already chose the new default.
- Adds unit tests for the exclusive-default clearing logic on both pipeline and workflow run configurations.

Fixes #2753

## Test plan

- [x] Unit tests: `PipelineRunConfigurationDefaultTest` and `WorkflowRunConfigurationDefaultTest`
- [x] Manual: in Hop GUI, create two pipeline run configurations, mark the second as default, reopen the first and confirm default is off
- [x] Manual: same flow for workflow run configurations
- [x] `./mvnw -pl ui -am compile -DskipTests` succeeds