### PR TITLE
Issue #6111 : Avoid scientific notation when converting Number to BigNumber

### DIFF
--- a/core/src/main/java/org/apache/hop/core/row/value/ValueMetaBase.java
+++ b/core/src/main/java/org/apache/hop/core/row/value/ValueMetaBase.java
@@ -1624,6 +1624,28 @@ public class ValueMetaBase implements IValueMeta {
     }
   }
 
+  /**
+   * Converts a double into a BigDecimal that does not carry a negative scale.
+   *
+   * <p>{@link BigDecimal#valueOf(double)} is built from {@link Double#toString(double)}, which
+   * switches to scientific notation from 10<sup>7</sup> onwards. The resulting string "5.54874E7"
+   * parses into an unscaled value of 554874 with a scale of -2, and it is that negative scale which
+   * makes {@link BigDecimal#toString()} render the value as "5.54874E+7" again. Every consumer that
+   * serializes the value through toString() - JDBC drivers that inline statement parameters, {@link
+   * #writeBigNumber(java.io.DataOutputStream, BigDecimal)} and {@link #getDataXml(Object)} - then
+   * emits scientific notation for a value that started out as plain digits.
+   *
+   * <p>Rescaling to zero is exact whenever the scale is negative, so the numeric value is left
+   * untouched and no rounding can occur.
+   *
+   * @param number the double to convert
+   * @return the value as a BigDecimal, rescaled to zero when the scale would be negative
+   */
+  protected static BigDecimal convertDoubleToBigNumber(double number) {
+    BigDecimal bigDecimal = BigDecimal.valueOf(number);
+    return bigDecimal.scale() < 0 ? bigDecimal.setScale(0) : bigDecimal;
+  }
+
   protected synchronized BigDecimal convertStringToBigNumber(String string)
       throws HopValueException {
     string = Const.trimToType(string, getTrimType()); // see if trimming needs
@@ -1658,7 +1680,7 @@ public class ValueMetaBase implements IValueMeta {
       //            If the Number is not a BigDecimal.
       //
       if (number instanceof Double) {
-        return BigDecimal.valueOf(number.doubleValue());
+        return convertDoubleToBigNumber(number.doubleValue());
       } else if (number instanceof Long) {
         return BigDecimal.valueOf(number.longValue());
       }
@@ -2605,11 +2627,11 @@ public class ValueMetaBase implements IValueMeta {
           };
         case TYPE_NUMBER:
           return switch (storageType) {
-            case STORAGE_TYPE_NORMAL -> BigDecimal.valueOf((Double) object);
+            case STORAGE_TYPE_NORMAL -> convertDoubleToBigNumber((Double) object);
             case STORAGE_TYPE_BINARY_STRING ->
-                BigDecimal.valueOf((Double) convertBinaryStringToNativeType((byte[]) object));
+                convertDoubleToBigNumber((Double) convertBinaryStringToNativeType((byte[]) object));
             case STORAGE_TYPE_INDEXED ->
-                BigDecimal.valueOf((Double) index[((Integer) object).intValue()]);
+                convertDoubleToBigNumber((Double) index[((Integer) object).intValue()]);
             default ->
                 throw new HopValueException(
                     this

--- a/core/src/test/java/org/apache/hop/core/row/value/ValueMetaBaseTest.java
+++ b/core/src/test/java/org/apache/hop/core/row/value/ValueMetaBaseTest.java
@@ -444,6 +444,112 @@ class ValueMetaBaseTest {
   }
 
   @Test
+  void testGetBigNumberFromNumberKeepsPlainNotation() throws HopValueException {
+    // BigDecimal.valueOf(55487400.0) is built from Double.toString(), which returns "5.54874E7".
+    // The resulting BigDecimal has an unscaled value of 554874 and a scale of -2, so rendering it
+    // with toString() yields "5.54874E+7" rather than "55487400".
+    ValueMetaBase valueMeta = new ValueMetaNumber("float53");
+
+    BigDecimal bigNumber = valueMeta.getBigNumber(55487400.0d);
+
+    assertEquals(0, bigNumber.compareTo(new BigDecimal("55487400")));
+    assertTrue(bigNumber.scale() >= 0, "unexpected negative scale: " + bigNumber.scale());
+    assertEquals("55487400", bigNumber.toString());
+  }
+
+  @Test
+  void testGetBigNumberFromNumberKeepsPlainNotationAcrossMagnitudes() throws HopValueException {
+    ValueMetaBase valueMeta = new ValueMetaNumber("float53");
+    double[] values = {1.0e7, 5.54874e7, 1.23456789e8, 1.5e10, 9.007199254740992e15, -5.54874e7};
+
+    for (double value : values) {
+      BigDecimal bigNumber = valueMeta.getBigNumber(value);
+
+      assertTrue(bigNumber.scale() >= 0, "negative scale for " + value + ": " + bigNumber.scale());
+      assertEquals(
+          bigNumber.toPlainString(), bigNumber.toString(), "scientific notation for " + value);
+      assertEquals(0, bigNumber.compareTo(BigDecimal.valueOf(value)), "value changed for " + value);
+    }
+  }
+
+  @Test
+  void testGetBigNumberFromNumberLeavesNonNegativeScalesUntouched() throws HopValueException {
+    // Values that already convert to a non-negative scale must keep the exact BigDecimal they
+    // produced before, scale included. BigDecimal.equals() is scale sensitive, so this pins that
+    // down rather than only comparing numeric values.
+    ValueMetaBase valueMeta = new ValueMetaNumber("number");
+    double[] values = {0.0, 0.1, 123.45, 1.0e-7, 55487400.5};
+
+    for (double value : values) {
+      assertEquals(BigDecimal.valueOf(value), valueMeta.getBigNumber(value), "changed " + value);
+    }
+  }
+
+  @Test
+  void testConvertNumberToBigNumberKeepsPlainNotation() throws HopValueException {
+    // The metadata change a Select Values transform performs when a Number field is turned into a
+    // BigNumber field.
+    IValueMeta source = new ValueMetaNumber("float53");
+    IValueMeta target = new ValueMetaBigNumber("decimal");
+
+    BigDecimal converted = (BigDecimal) target.convertData(source, 55487400.0d);
+
+    assertEquals("55487400", converted.toString());
+  }
+
+  @Test
+  void testGetBigNumberFromStringKeepsPlainNotation() throws HopValueException {
+    ValueMetaBase valueMeta = new ValueMetaString("float53");
+
+    BigDecimal bigNumber = valueMeta.getBigNumber("55487400");
+
+    assertTrue(bigNumber.scale() >= 0, "unexpected negative scale: " + bigNumber.scale());
+    assertEquals(0, bigNumber.compareTo(new BigDecimal("55487400")));
+  }
+
+  @Test
+  void testWriteBigNumberConvertedFromNumberUsesPlainNotation() throws Exception {
+    // writeBigNumber() serializes with BigDecimal.toString(), so a negative scale would put
+    // scientific notation on the wire as well.
+    BigDecimal bigNumber = new ValueMetaNumber("float53").getBigNumber(55487400.0d);
+    ValueMetaBase valueMeta = new ValueMetaBigNumber("decimal");
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (DataOutputStream outputStream = new DataOutputStream(out)) {
+      valueMeta.writeData(outputStream, bigNumber);
+    }
+
+    BigDecimal restored;
+    try (DataInputStream inputStream =
+        new DataInputStream(new ByteArrayInputStream(out.toByteArray()))) {
+      restored = (BigDecimal) valueMeta.readData(inputStream);
+    }
+
+    // readBigNumber() keeps whatever scale was written, so a plain result proves a plain wire form.
+    assertEquals("55487400", restored.toString());
+  }
+
+  @Test
+  void testGetDataXmlForBigNumberConvertedFromNumberUsesPlainNotation() throws Exception {
+    BigDecimal bigNumber = new ValueMetaNumber("float53").getBigNumber(55487400.0d);
+    ValueMetaBase valueMeta = new ValueMetaBigNumber("decimal");
+
+    String xml = valueMeta.getDataXml(bigNumber);
+
+    assertTrue(xml.contains("55487400"), xml);
+    assertFalse(xml.contains("E+"), xml);
+  }
+
+  @Test
+  void testConvertNumberToStringDoesNotUseScientificNotation() throws HopValueException {
+    // Guards the string conversion path, which formats through DecimalFormat and was already
+    // correct, against a regression from the BigDecimal change.
+    assertFalse(new ValueMetaNumber("float53").getString(55487400.0d).contains("E"));
+    assertFalse(
+        new ValueMetaBigNumber("decimal").getString(new BigDecimal("5.54874E+7")).contains("E"));
+  }
+
+  @Test
   void testGetIntegerThrowsHopValueException() {
     ValueMetaBase valueMeta = new ValueMetaInteger();
     assertThrows(HopValueException.class, () -> valueMeta.getInteger("1234567890"));


### PR DESCRIPTION
Addresses #6111.

`BigDecimal.valueOf(double)` is specified as `new BigDecimal(Double.toString(val))`, and `Double.toString()` switches to scientific notation from 10<sup>7</sup> onwards. For `55487400.0` it returns `"5.54874E7"`, which parses into an unscaled value of 554874 with a scale of `-2`. It is that negative scale which makes `BigDecimal.toString()` render the value as `5.54874E+7` again:

```java
BigDecimal bd = BigDecimal.valueOf(55487400.0);
bd.scale();          // -2
bd.toString();       // "5.54874E+7"
bd.toPlainString();  // "55487400"
```

So every consumer that serializes a BigNumber through `toString()` emits scientific notation for a value that started out as plain digits:

- JDBC drivers that inline statement parameters — the Table Output `INSERT` in the reported case
- `writeBigNumber()`, used by the binary row serialization
- `getDataXml()`, used by the XML data serialization

The formatting layer is not involved: both default masks (`####0.0#########` and `######0.0###################`) render the value as `55487400.0` correctly.

### Change

The four `Double` to `BigDecimal` conversions in `ValueMetaBase` — `getBigNumber()` for `TYPE_NUMBER` across its three storage types, and `convertStringToBigNumber()` — now go through a single helper:

```java
protected static BigDecimal convertDoubleToBigNumber(double number) {
  BigDecimal bigDecimal = BigDecimal.valueOf(number);
  return bigDecimal.scale() < 0 ? bigDecimal.setScale(0) : bigDecimal;
}
```

Rescaling upwards from a negative scale is exact, so no rounding mode is required, no `ArithmeticException` is possible, and the numeric value is unchanged.

### Compatibility

- Values that already convert to a non-negative scale are returned untouched, scale included.
- The string conversion paths format through `DecimalFormat` and never emitted scientific notation. Their output is unchanged, and a regression test pins that down.
- BigNumber comparison in `ValueMetaBase` uses `compareTo()`, which is scale-insensitive, so ordering and equality semantics are unaffected.
- The XML and binary serialized forms do change for affected values, from `5.54874E+7` to `55487400`. Both round-trip correctly, since `readBigNumber()` parses whatever was written.

### Tests

Eight tests added to `ValueMetaBaseTest`:

- the reported value, and a range of magnitudes including negatives and 2<sup>53</sup>
- the untouched-scale guarantee, asserted with scale-sensitive `equals()` rather than `compareTo()`
- the `convertData()` metadata-change path a Select Values transform performs
- the `writeBigNumber()` / `readBigNumber()` round trip
- `getDataXml()`
- a regression guard on the `DecimalFormat` string path

### Verification

`./mvnw -pl core test` — 1039 tests, 0 failures, 0 errors. `spotless:check` and `apache-rat:check` both pass. The full `mvn clean install` was not run locally; relying on CI for the complete build.

### Note for reviewers

`ValueDataUtil.ceil()`, `floor()`, `abs()` and `sqrt()` build BigNumber results with `BigDecimal.valueOf(Math.xxx(...))` and can produce the same negative scale. I left them out to keep this change focused, since sharing the helper across packages would mean widening its visibility. Happy to follow up in a separate PR if you would like that covered.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically. *(see Verification above for exactly what was run locally)*
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
