### PR TITLE
issue #7742: flush last batch before marking BlockingBatchingRowSet done

### DIFF
--- a/core/src/main/java/org/apache/hop/core/BlockingBatchingRowSet.java
+++ b/core/src/main/java/org/apache/hop/core/BlockingBatchingRowSet.java
@@ -162,7 +162,8 @@ public class BlockingBatchingRowSet extends BaseRowSet implements Comparable<IRo
 
   @Override
   public void setDone() {
-    super.setDone();
+    // Enqueue the last partial batch before marking done so concurrent consumers that observe
+    // isDone()==true cannot exit before the final rows are available (issue #7742).
     if (putIndex > 0 && putIndex < size && inputBuffer != null) {
       inputBuffer[putIndex] = null; // signal the end of buffer
       for (int i = putIndex + 1; i < size; i++) {
@@ -171,6 +172,7 @@ public class BlockingBatchingRowSet extends BaseRowSet implements Comparable<IRo
       getArray.offer(inputBuffer);
     }
     putArray.clear();
+    super.setDone();
   }
 
   @Override

--- a/core/src/test/java/org/apache/hop/core/BlockingBatchingRowSetTest.java
+++ b/core/src/test/java/org/apache/hop/core/BlockingBatchingRowSetTest.java
@@ -24,8 +24,16 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hop.core.row.IRowMeta;
 import org.apache.hop.core.row.IValueMeta;
 import org.apache.hop.core.row.RowMeta;
@@ -117,5 +125,207 @@ class BlockingBatchingRowSetTest {
     r = set.getRow();
     assertNotNull(r);
     assertArrayEquals(rows.get(2), r);
+  }
+
+  /**
+   * Issue #7742: the last partial batch must be enqueued before the done flag is set, otherwise a
+   * concurrent consumer can observe isDone() and exit before the last rows are available.
+   */
+  @Test
+  void testSetDoneEnqueuesPartialBatchBeforeDoneFlag() throws Exception {
+    BlockingBatchingRowSet set = new BlockingBatchingRowSet(10);
+    IRowMeta rm = createRowMetaInterface();
+
+    // 3 rows with buffer size 5 = partial batch (not flushed by putRow)
+    for (int i = 0; i < 3; i++) {
+      assertTrue(set.putRow(rm, new Object[] {(long) i}));
+    }
+    assertEquals(0, set.size());
+
+    AtomicBoolean offerSeen = new AtomicBoolean(false);
+    AtomicBoolean doneAtOffer = new AtomicBoolean(true); // fail closed if offer never checked
+    instrumentGetArrayOffers(
+        set,
+        () -> {
+          offerSeen.set(true);
+          doneAtOffer.set(set.isDone());
+        });
+
+    set.setDone();
+
+    assertTrue(offerSeen.get(), "partial batch must be offered in setDone()");
+    assertFalse(
+        doneAtOffer.get(),
+        "done flag must not be set before the last batch is offered (issue #7742)");
+    assertTrue(set.isDone());
+  }
+
+  /** When there is nothing left to flush, setDone() should only mark the rowset done. */
+  @Test
+  void testSetDoneWithNoPartialBatchOnlyMarksDone() throws Exception {
+    BlockingBatchingRowSet set = new BlockingBatchingRowSet(10);
+    AtomicBoolean offerSeen = new AtomicBoolean(false);
+    instrumentGetArrayOffers(set, () -> offerSeen.set(true));
+
+    set.setDone();
+
+    assertFalse(offerSeen.get(), "no batch should be offered when nothing was put");
+    assertTrue(set.isDone());
+  }
+
+  /**
+   * When the last put already filled and published a full batch, setDone() must not re-offer; only
+   * the done flag is set.
+   */
+  @Test
+  void testSetDoneAfterFullBatchOnlyMarksDone() throws Exception {
+    BlockingBatchingRowSet set = new BlockingBatchingRowSet(10);
+    IRowMeta rm = createRowMetaInterface();
+
+    // Exactly one full batch (size = maxSize / BATCHSIZE = 5)
+    for (int i = 0; i < 5; i++) {
+      assertTrue(set.putRow(rm, new Object[] {(long) i}));
+    }
+    assertEquals(5, set.size());
+
+    AtomicBoolean offerSeen = new AtomicBoolean(false);
+    instrumentGetArrayOffers(set, () -> offerSeen.set(true));
+
+    set.setDone();
+
+    assertFalse(offerSeen.get(), "full batch was already published; setDone must not re-offer");
+    assertTrue(set.isDone());
+  }
+
+  /**
+   * After setDone() with a partial batch, all non-null rows must be readable (sequential drain).
+   */
+  @Test
+  void testPartialBatchDrainableAfterSetDone() {
+    BlockingBatchingRowSet set = new BlockingBatchingRowSet(10);
+    IRowMeta rm = createRowMetaInterface();
+    final int rowCount = 3;
+
+    for (int i = 0; i < rowCount; i++) {
+      assertTrue(set.putRow(rm, new Object[] {(long) i}));
+    }
+
+    set.setDone();
+    assertTrue(set.isDone());
+
+    List<Object[]> received = drainNonNullRows(set);
+    assertEquals(rowCount, received.size());
+    for (int i = 0; i < rowCount; i++) {
+      assertArrayEquals(new Object[] {(long) i}, received.get(i));
+    }
+  }
+
+  /**
+   * Concurrent producer/consumer using the same done-check pattern as BaseTransform.getRow().
+   * Partial batches must never be lost across repeated runs (issue #7742).
+   */
+  @Test
+  void testNoDataLossOnConcurrentSetDone() throws Exception {
+    final int iterations = 200;
+    final int rowCount = 3;
+    IRowMeta rm = createRowMetaInterface();
+
+    for (int iter = 0; iter < iterations; iter++) {
+      BlockingBatchingRowSet set = new BlockingBatchingRowSet(10);
+      List<Object[]> received = Collections.synchronizedList(new ArrayList<>());
+      CountDownLatch consumerStarted = new CountDownLatch(1);
+      AtomicReference<Throwable> consumerError = new AtomicReference<>();
+
+      Thread consumer =
+          new Thread(
+              () -> {
+                try {
+                  consumerStarted.countDown();
+                  // Mirrors BaseTransform handling when getRowWait returns null
+                  while (true) {
+                    Object[] row = set.getRowWait(20, TimeUnit.MILLISECONDS);
+                    if (row != null) {
+                      received.add(row);
+                    } else if (set.isDone()) {
+                      row = set.getRowWait(1, TimeUnit.MILLISECONDS);
+                      if (row == null) {
+                        break;
+                      }
+                      received.add(row);
+                    }
+                  }
+                } catch (Throwable t) {
+                  consumerError.set(t);
+                }
+              },
+              "batching-rowset-consumer-" + iter);
+
+      consumer.start();
+      assertTrue(consumerStarted.await(5, TimeUnit.SECONDS));
+
+      for (int i = 0; i < rowCount; i++) {
+        assertTrue(set.putRow(rm, new Object[] {(long) i}));
+      }
+      set.setDone();
+
+      consumer.join(10_000);
+      assertFalse(consumer.isAlive(), "consumer did not finish at iteration " + iter);
+      assertNull(consumerError.get(), () -> "consumer failed: " + consumerError.get());
+      assertEquals(
+          rowCount,
+          received.size(),
+          "data loss at iteration " + iter + ", got " + received.size() + " rows");
+      for (int i = 0; i < rowCount; i++) {
+        assertArrayEquals(new Object[] {(long) i}, received.get(i));
+      }
+    }
+  }
+
+  /**
+   * Replace getArray with a queue that invokes {@code onOffer} for every subsequent offer. Existing
+   * batches are preserved without firing the callback.
+   */
+  private static void instrumentGetArrayOffers(BlockingBatchingRowSet set, Runnable onOffer)
+      throws Exception {
+    Field getArrayField = BlockingBatchingRowSet.class.getDeclaredField("getArray");
+    getArrayField.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    BlockingQueue<Object[][]> originalGetArray = (BlockingQueue<Object[][]>) getArrayField.get(set);
+
+    AtomicBoolean logOffers = new AtomicBoolean(false);
+    BlockingQueue<Object[][]> loggingGetArray =
+        new ArrayBlockingQueue<>(Math.max(2, originalGetArray.size() + 2), true) {
+          @Override
+          public boolean offer(Object[][] e) {
+            if (logOffers.get()) {
+              onOffer.run();
+            }
+            return super.offer(e);
+          }
+
+          @Override
+          public boolean offer(Object[][] e, long timeout, TimeUnit unit)
+              throws InterruptedException {
+            if (logOffers.get()) {
+              onOffer.run();
+            }
+            return super.offer(e, timeout, unit);
+          }
+        };
+    // Preserve any batches already published (drainTo uses offer; logging still off)
+    originalGetArray.drainTo(loggingGetArray);
+    getArrayField.set(set, loggingGetArray);
+    logOffers.set(true);
+  }
+
+  private static List<Object[]> drainNonNullRows(BlockingBatchingRowSet set) {
+    List<Object[]> received = new ArrayList<>();
+    Object[] row;
+    // Partial batches pad with null sentinels; stop after the first null once we have started
+    // seeing data, but keep polling while empty before setDone flush visibility in sequential use.
+    while ((row = set.getRowWait(100, TimeUnit.MILLISECONDS)) != null) {
+      received.add(row);
+    }
+    return received;
   }
 }


### PR DESCRIPTION
## Summary

Fixes [#7742](https://github.com/apache/hop/issues/7742): potential data loss in `BlockingBatchingRowSet.setDone()` due to a race between setting the done flag and enqueueing the last partial batch.

### What was wrong

`BlockingBatchingRowSet` batches rows into buffers and only exposes full buffers on `getArray`. When the producer finishes with a **partial** buffer, `setDone()` must flush that last batch. The previous order was:

1. `super.setDone()` → `done` becomes `true` immediately
2. Then offer the last partial batch to `getArray`

Downstream consumers (`BaseTransform.getRow()`) treat `isDone() == true` plus an empty poll as end-of-stream and remove the rowset. Under concurrency a consumer could therefore exit **before** the last rows were offered, dropping them.

This only applies when batching rowsets are enabled (`HOP_BATCHING_ROWSET=Y`); the default path uses `BlockingRowSet`, which does not defer rows in the same way.

### Fix

Reorder `setDone()` so that:

1. The last partial batch is offered to `getArray` (same null-padding as before)
2. `putArray` is cleared
3. Only then is `super.setDone()` called

Any thread that observes `isDone()==true` is then guaranteed that the final partial batch (if any) was already published.

## How it was reproduced / tested

### Deterministic reproduction (unit test)

`BlockingBatchingRowSetTest.testSetDoneEnqueuesPartialBatchBeforeDoneFlag` instruments `getArray.offer` via reflection and asserts that when the last partial batch is offered, `isDone()` is still **false**.

- With the **old** order: test fails (`done` is already true at offer time)
- With the **new** order: test passes

### Additional coverage

| Test | What it checks |
|------|----------------|
| `testSetDoneEnqueuesPartialBatchBeforeDoneFlag` | Ordering invariant for issue #7742 |
| `testSetDoneWithNoPartialBatchOnlyMarksDone` | No spurious offer when nothing was put |
| `testSetDoneAfterFullBatchOnlyMarksDone` | No re-offer when the last put already published a full batch |
| `testPartialBatchDrainableAfterSetDone` | All partial-batch rows are readable after `setDone()` |
| `testNoDataLossOnConcurrentSetDone` | Producer + BaseTransform-style consumer over 200 iterations; row count always matches |

```bash
./mvnw -pl core -Dtest=BlockingBatchingRowSetTest test
```

## Reviewer notes

1. **Scope is intentionally small** — only `BlockingBatchingRowSet.setDone()` ordering and tests. No changes to `BaseTransform` or `BlockingRowSet`.
2. **Please focus review on** happens-before semantics: after `setDone()`, `isDone()==true` must imply the last partial batch is already in `getArray` (or there was nothing to flush).
3. The white-box ordering test is the strongest regression guard; the concurrent test is belt-and-suspenders and models the real consumer loop (`getRowWait` → if null and `isDone`, short retry → exit).
4. Optional manual stress: enable `HOP_BATCHING_ROWSET=Y` and run a multi-copy pipeline that ends on a non-multiple of the batch size under load. Default installs do not use this rowset.

## Related issue

Closes #7742