### PR TITLE
fixes #7743: stop overwriting workflow parentId with Spark variable name

### DIFF
--- a/engine/src/main/java/org/apache/hop/workflow/engines/local/LocalWorkflowEngine.java
+++ b/engine/src/main/java/org/apache/hop/workflow/engines/local/LocalWorkflowEngine.java
@@ -61,6 +61,12 @@ import org.apache.hop.workflow.engine.WorkflowEnginePlugin;
     description = "Executes your workflow locally")
 public class LocalWorkflowEngine extends Workflow implements IWorkflowEngine<WorkflowMeta> {
 
+  /**
+   * Must stay in sync with {@code org.apache.hop.spark.util.SparkConst#VAR_TRANSFORM_OWNER_ID}.
+   * Engine cannot depend on the spark plugin.
+   */
+  static final String VAR_SPARK_TRANSFORM_OWNER_ID = "Internal.Spark.TransformOwnerId";
+
   private ExecutionInfoLocation executionInfoLocation;
   private Timer executionInfoTimer;
 
@@ -325,25 +331,43 @@ public class LocalWorkflowEngine extends Workflow implements IWorkflowEngine<Wor
    * When this workflow is nested under a Native Spark mapPartitions transform (Workflow Executor),
    * the parent transform is registered under a synthetic id {@code pipelineId|name|copy}. Rebind so
    * the execution perspective can drill down from that transform node.
+   *
+   * <p>Uses {@link IVariables#getVariable(String)} (not {@link IVariables#resolve(String)}):
+   * resolve only substitutes {@code ${...}} tokens and returns a bare name unchanged, which would
+   * always overwrite parentId with the literal variable name (issue #7743).
    */
-  private void rebindSparkTransformOwnerParent(Execution execution) {
+  /** Package-private for unit tests. */
+  void rebindSparkTransformOwnerParent(Execution execution) {
     if (execution == null) {
       return;
     }
-    String sparkOwner = resolve("Internal.Spark.TransformOwnerId");
+    String sparkOwner = sparkTransformOwnerId(this);
     if (StringUtils.isNotEmpty(sparkOwner)) {
       execution.setParentId(sparkOwner);
     }
   }
 
-  private void rebindSparkTransformOwnerParent(ExecutionState state) {
+  /** Package-private for unit tests. */
+  void rebindSparkTransformOwnerParent(ExecutionState state) {
     if (state == null) {
       return;
     }
-    String sparkOwner = resolve("Internal.Spark.TransformOwnerId");
+    String sparkOwner = sparkTransformOwnerId(this);
     if (StringUtils.isNotEmpty(sparkOwner)) {
       state.setParentId(sparkOwner);
     }
+  }
+
+  /**
+   * Returns the Spark transform owner id when set on the variable space; otherwise null.
+   *
+   * <p>Package-private for unit tests.
+   */
+  static String sparkTransformOwnerId(IVariables variables) {
+    if (variables == null) {
+      return null;
+    }
+    return variables.getVariable(VAR_SPARK_TRANSFORM_OWNER_ID);
   }
 
   public void startExecutionInfoTimer() {

--- a/engine/src/test/java/org/apache/hop/workflow/engines/local/LocalWorkflowEngineSparkParentRebindTest.java
+++ b/engine/src/test/java/org/apache/hop/workflow/engines/local/LocalWorkflowEngineSparkParentRebindTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.workflow.engines.local;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.apache.hop.core.variables.Variables;
+import org.apache.hop.execution.Execution;
+import org.apache.hop.execution.ExecutionState;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression for issue #7743: parentId must not be overwritten with the literal variable name
+ * {@code Internal.Spark.TransformOwnerId} when the Spark owner variable is unset.
+ */
+class LocalWorkflowEngineSparkParentRebindTest {
+
+  @Test
+  void sparkTransformOwnerId_nullWhenUnset() {
+    Variables vars = new Variables();
+    vars.initializeFrom(null);
+    assertNull(LocalWorkflowEngine.sparkTransformOwnerId(vars));
+  }
+
+  @Test
+  void sparkTransformOwnerId_returnsValueWhenSet() {
+    Variables vars = new Variables();
+    vars.initializeFrom(null);
+    vars.setVariable(LocalWorkflowEngine.VAR_SPARK_TRANSFORM_OWNER_ID, "pipe|Workflow Executor|0");
+    assertEquals("pipe|Workflow Executor|0", LocalWorkflowEngine.sparkTransformOwnerId(vars));
+  }
+
+  @Test
+  void sparkTransformOwnerId_nullVariables() {
+    assertNull(LocalWorkflowEngine.sparkTransformOwnerId(null));
+  }
+
+  @Test
+  void rebind_doesNotOverwriteParentWhenSparkVariableUnset() {
+    LocalWorkflowEngine engine = new LocalWorkflowEngine();
+    engine.initializeFrom(null);
+
+    Execution execution = new Execution();
+    execution.setParentId("parent-workflow-uuid");
+    engine.rebindSparkTransformOwnerParent(execution);
+    assertEquals("parent-workflow-uuid", execution.getParentId());
+
+    Execution root = new Execution();
+    root.setParentId(null);
+    engine.rebindSparkTransformOwnerParent(root);
+    assertNull(root.getParentId());
+  }
+
+  @Test
+  void rebind_setsSparkOwnerWhenVariablePresent() {
+    LocalWorkflowEngine engine = new LocalWorkflowEngine();
+    engine.initializeFrom(null);
+    engine.setVariable(
+        LocalWorkflowEngine.VAR_SPARK_TRANSFORM_OWNER_ID, "spark-pipe|Workflow Executor|0");
+
+    Execution execution = new Execution();
+    execution.setParentId("would-be-overwritten");
+    engine.rebindSparkTransformOwnerParent(execution);
+    assertEquals("spark-pipe|Workflow Executor|0", execution.getParentId());
+
+    ExecutionState state = new ExecutionState();
+    state.setParentId("state-parent");
+    engine.rebindSparkTransformOwnerParent(state);
+    assertEquals("spark-pipe|Workflow Executor|0", state.getParentId());
+  }
+
+  @Test
+  void rebind_ignoresEmptySparkOwner() {
+    LocalWorkflowEngine engine = new LocalWorkflowEngine();
+    engine.initializeFrom(null);
+    engine.setVariable(LocalWorkflowEngine.VAR_SPARK_TRANSFORM_OWNER_ID, "");
+
+    Execution execution = new Execution();
+    execution.setParentId("keep-me");
+    engine.rebindSparkTransformOwnerParent(execution);
+    assertEquals("keep-me", execution.getParentId());
+  }
+
+  /**
+   * Documents the bug: {@code resolve(bareName)} returns the name unchanged and must not be used
+   * for variable lookup.
+   */
+  @Test
+  void resolveBareName_returnsLiteral_notVariableValue() {
+    Variables vars = new Variables();
+    vars.initializeFrom(null);
+    // Unset: resolve leaves the bare token as-is (no ${} markers)
+    assertEquals(
+        LocalWorkflowEngine.VAR_SPARK_TRANSFORM_OWNER_ID,
+        vars.resolve(LocalWorkflowEngine.VAR_SPARK_TRANSFORM_OWNER_ID));
+    // Set: resolve still returns the bare name (it is not a ${var} expression)
+    vars.setVariable(LocalWorkflowEngine.VAR_SPARK_TRANSFORM_OWNER_ID, "actual-owner");
+    assertEquals(
+        LocalWorkflowEngine.VAR_SPARK_TRANSFORM_OWNER_ID,
+        vars.resolve(LocalWorkflowEngine.VAR_SPARK_TRANSFORM_OWNER_ID));
+    assertEquals(
+        "actual-owner", vars.getVariable(LocalWorkflowEngine.VAR_SPARK_TRANSFORM_OWNER_ID));
+  }
+}


### PR DESCRIPTION
## Summary

Fixes [#7743](https://github.com/apache/hop/issues/7743) (thanks @nadment for the report and repro).

With Caching Database execution info location, workflow rows were stored with:

`parent_id = Internal.Spark.TransformOwnerId`

instead of:

- `null` for a top-level parent workflow
- the parent workflow’s log-channel id for a nested child workflow

### Root cause

This is **not** a bug in the Caching Database location. The denormalized `parent_id` column only made a registration bug obvious.

In `LocalWorkflowEngine` (from the Native Spark engine work), parent rebind used:

```java
resolve("Internal.Spark.TransformOwnerId")
```

`IVariables.resolve()` only expands `${...}` / `%%...%%` tokens. A bare name is returned unchanged, so **every** local workflow execution overwrote the correct parent id with that literal string.

Spark is supposed to set the real owner id via `HopMapPartitionsFn` when a workflow runs nested under a mapPartitions Workflow Executor. Rebind should only run when that variable is actually set.

### Fix

- Look up with `getVariable(...)` (returns `null` when unset) instead of `resolve(...)`
- Centralize the variable name as `VAR_SPARK_TRANSFORM_OWNER_ID` (kept in sync with `SparkConst` in the spark plugin; engine cannot depend on that plugin)
- Unit tests for unset / set / empty variable, and documenting the `resolve` vs `getVariable` distinction

### Expected after fix

| Scenario | Before | After |
|----------|--------|--------|
| Top-level workflow | `parent_id = Internal.Spark.TransformOwnerId` | `null` |
| Child workflow (local) | same literal | parent log-channel id |
| Nested under Spark Workflow Executor | same literal | synthetic `pipeId\|name\|copy` |

## Test plan

- [x] `LocalWorkflowEngineSparkParentRebindTest` (7 tests)
- [ ] Repro from #7743 (`workflows.zip`): parent → child local workflows, Caching Database execution info location, hop-gui
  - Parent row: `parent_id` null/empty
  - Child row: `parent_id` = parent’s `id`
- [ ] Optional: nested workflow under Spark Workflow Executor still parents to synthetic owner id