### PR TITLE
fixes #7748: stop Docker Hop Web COPY of removed lib-beam path

### DIFF
--- a/assemblies/static/src/main/resources/hop
+++ b/assemblies/static/src/main/resources/hop
@@ -108,8 +108,9 @@ if [ -n "${HOP_SPARK_CLIENT_VERSION:-}" ] && [ -d "lib/spark-clients/${HOP_SPARK
   CLASSPATH="${CLASSPATH}:lib/spark-clients/${HOP_SPARK_CLIENT_VERSION}/*"
 fi
 
-# Beam SDKs/runners live with the optional Beam plugin (not lib/beam).
-# Only on the system classpath when marketplace (or -Pbeam) has installed them.
+# Beam plugin jar (and any legacy lib-beam/ tree). Current marketplace packaging (#7721/#7722)
+# unpacks Beam SDKs into lib/core (already on CLASSPATH above); lib-beam is kept only for older
+# installs that still have that layout.
 if [ -d "plugins/engines/beam/lib-beam" ]; then
   CLASSPATH="${CLASSPATH}:plugins/engines/beam/lib-beam/*"
 fi

--- a/docker/unified.Dockerfile
+++ b/docker/unified.Dockerfile
@@ -243,7 +243,8 @@ RUN mkdir -p /build/hop-web-prepared/webapps/ROOT && \
     cp -r /build/assemblies/client/target/hop/config /build/hop-web-prepared/webapps/ROOT/ && \
     cp -r /build/assemblies/client/target/hop/plugins /build/hop-web-prepared/ && \
     cp -r /build/assemblies/client/target/hop/lib/jdbc/ /build/hop-web-prepared/jdbc-drivers && \
-    if [ -d /build/assemblies/client/target/hop/plugins/engines/beam/lib-beam ]; then cp -r /build/assemblies/client/target/hop/plugins/engines/beam/lib-beam/* /build/hop-web-prepared/webapps/ROOT/WEB-INF/lib/; fi && \
+    # Beam SDKs unpack under lib/core when the marketplace Beam plugin is installed (#7721/#7722).
+    # Legacy plugins/engines/beam/lib-beam is no longer produced; do not require it (apache/hop#7748).
     cp -r /build/assemblies/client/target/hop/lib/core/* /build/hop-web-prepared/webapps/ROOT/WEB-INF/lib/ && \
     rm /build/hop-web-prepared/webapps/ROOT/WEB-INF/lib/hop-ui-rcp* && \
     cp /build/docker/resources/run-web.sh /build/hop-web-prepared/run-web.sh && \

--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -74,10 +74,13 @@ RUN groupadd -r hop -g ${HOP_GID} \
     && mkdir "${HOP_AUDIT_FOLDER}"
 
 # Copy resources
+# lib/core includes Beam SDKs when the Beam marketplace plugin is installed into the client
+# (e.g. tools/install-wave1-plugins.sh). Do not COPY plugins/engines/beam/lib-beam: that path
+# was removed in #7721 / #7722 (SDKs now unpack under lib/core). An unconditional COPY fails
+# docker buildx when the directory is missing (apache/hop#7748).
 COPY ./assemblies/web/target/webapp/ "${CATALINA_HOME}"/webapps/ROOT/
 COPY ./assemblies/client/target/hop/config "${CATALINA_HOME}"/webapps/ROOT/config
 COPY ./assemblies/client/target/hop/lib/core "${CATALINA_HOME}"/webapps/ROOT/WEB-INF/lib
-COPY ./assemblies/client/target/hop/plugins/engines/beam/lib-beam "${CATALINA_HOME}"/webapps/ROOT/WEB-INF/lib
 COPY ./assemblies/client/target/hop/plugins "${CATALINA_HOME}"/plugins
 COPY ./assemblies/client/target/hop/lib/jdbc/ "${CATALINA_HOME}"/jdbc-drivers
 COPY --chown=hop ./docker/resources/run-web.sh /tmp/

--- a/docs/hop-dev-manual/modules/ROOT/pages/hopweb/index.adoc
+++ b/docs/hop-dev-manual/modules/ROOT/pages/hopweb/index.adoc
@@ -74,22 +74,21 @@ unzip -o assemblies/client/target/hop-client-*.zip -d /tmp/hop-client/
 cp -r /tmp/hop-client/hop/config $CATALINA_HOME/webapps/ROOT/
 
 # Step 4: Copy core libraries
+# lib/core already includes Beam SDKs when the Beam marketplace plugin is installed into the
+# client (plugins/engines/beam/lib-beam is a legacy path and is no longer created).
 cp -r /tmp/hop-client/hop/lib/core/* $CATALINA_HOME/webapps/ROOT/WEB-INF/lib/
 
 # Step 4b: Remove RCP jar (RCP is for desktop GUI, not web)
 rm -f $CATALINA_HOME/webapps/ROOT/WEB-INF/lib/hop-ui-rcp-*.jar
 
-# Step 5: Copy beam libraries
-cp -r /tmp/hop-client/hop/plugins/engines/beam/lib-beam/* $CATALINA_HOME/webapps/ROOT/WEB-INF/lib/
-
-# Step 6: Copy plugins
+# Step 5: Copy plugins
 cp -r /tmp/hop-client/hop/plugins $CATALINA_HOME/
 
-# Step 7: Copy JDBC drivers
+# Step 6: Copy JDBC drivers
 mkdir -p $CATALINA_HOME/jdbc-drivers
 cp -r /tmp/hop-client/hop/lib/jdbc/* $CATALINA_HOME/jdbc-drivers/
 
-# Step 8: Cleanup
+# Step 7: Cleanup
 rm -rf /tmp/hop-client
 ----
 
@@ -200,7 +199,7 @@ sed -i '' 's&lib/core/*&../../lib/*:WEB-INF/lib/*:lib/core/*&g' ${CATALINA_HOME}
 
 The `CLASSPATH` lines in the various scripts should look similar to the one below after editing: 
 
-`CLASSPATH="../../lib/*:WEB-INF/lib/*:lib/core/**:plugins/engines/beam/lib-beam/*:lib/swt/osx/arm64/*"`
+`CLASSPATH="../../lib/*:WEB-INF/lib/*:lib/core/**:lib/swt/osx/arm64/*"`
 
 Once the classpaths have been updated, make sure to make the scripts executable: 
 

--- a/docs/hop-user-manual/modules/ROOT/pages/hop-tools/hop-marketplace.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/hop-tools/hop-marketplace.adoc
@@ -46,7 +46,7 @@ cd /path/to/hop
 * Do *NOT* pass `--prune` unless you also want other marketplace installs removed.
 * `full-client-env.yaml` is generated at build time from marketplace plugin source file `optional-plugins.yaml` (source of truth).
 
-Beam SDKs/runners live under `plugins/engines/beam/lib-beam` (installed with the Beam plugin), not under `lib/beam`. Launch scripts add that folder to the classpath only when it exists. Developers who want Beam baked into a local hop-client build can use Maven profile `-Pbeam` (for example `./mvnw -pl assemblies/client -am package -Pbeam`).
+Beam SDKs/runners install with the Beam marketplace plugin into top-level `lib/core` (and Spark client jars into `lib/spark-client`). The older `plugins/engines/beam/lib-beam` layout is no longer produced. Developers who want Beam baked into a local hop-client build can use Maven profile `-Pbeam` (for example `./mvnw -pl assemblies/client -am package -Pbeam`).
 
 == Defaults
 
@@ -364,7 +364,7 @@ plugins:
   - groupId: org.apache.hop    # optional; default org.apache.hop
     artifactId: hop-engines-spark
     version: "2.19.0"
-  # Beam engine plugin only (Beam SDKs ship under plugins/engines/beam/lib-beam with the plugin):
+  # Beam engine plugin only (Beam SDKs unpack into lib/core with the plugin):
   # - artifactId: hop-engines-beam
   #   version: "2.19.0"
 

--- a/plugins/misc/marketplace/src/main/resources/org/apache/hop/marketplace/optional-plugins.yaml
+++ b/plugins/misc/marketplace/src/main/resources/org/apache/hop/marketplace/optional-plugins.yaml
@@ -32,7 +32,7 @@ plugins:
   - artifactId: hop-engines-beam
     name: Apache Beam engine
     category: Engines
-    description: Beam pipeline engine and transforms; SDKs under plugins/engines/beam/lib-beam.
+    description: Beam pipeline engine and transforms; SDKs unpack into lib/core with the plugin.
     installPath: plugins/engines/beam
     modulePath: plugins/engines/beam
   #

--- a/plugins/misc/marketplace/src/main/samples/hop-env.example.yaml
+++ b/plugins/misc/marketplace/src/main/samples/hop-env.example.yaml
@@ -42,7 +42,7 @@ plugins:
     version: "2.19.0-SNAPSHOT"
   - artifactId: hop-engines-spark
     version: "2.19.0-SNAPSHOT"
-  # Beam engine plugin only (Beam SDKs ship under plugins/engines/beam/lib-beam with the plugin):
+  # Beam engine plugin only (Beam SDKs unpack into lib/core with the plugin):
   # - artifactId: hop-engines-beam
   #   version: "2.19.0-SNAPSHOT"
 

--- a/tools/install-wave1-plugins.sh
+++ b/tools/install-wave1-plugins.sh
@@ -67,4 +67,4 @@ for entry in ${PLUGINS[@]+"${PLUGINS[@]}"}; do
 done
 
 echo "Marketplace plugins: installed=${installed} skipped=${skipped} into ${INSTALL_DIR}"
-# Note: beam plugin zip includes lib-beam (Beam SDKs).
+# Note: the Beam plugin zip unpacks SDKs into lib/core (and Spark client jars into lib/spark-client).


### PR DESCRIPTION
## What

`docker/web.Dockerfile` unconditionally copied `plugins/engines/beam/lib-beam` into Hop Web. That path is **no longer produced** after #7721 / #7722 (Beam marketplace packaging puts SDKs under top-level `lib/core`). Docker Buildx fails when the source directory is missing:

```
"/assemblies/client/target/hop/plugins/engines/beam/lib-beam": not found
```

That failure aborts the main pipeline before **Deploy**, so ASF SNAPSHOTs stop updating.

## Changes

- Remove the obsolete `lib-beam` `COPY` from `docker/web.Dockerfile` (Beam SDKs are already included via the existing `lib/core` copy when the Beam plugin is installed, e.g. `install-wave1-plugins.sh`).
- Drop the dead optional `lib-beam` copy from `docker/unified.Dockerfile` (same reason; `lib/core` is already copied next).
- Update Hop Web / marketplace docs and comments to describe the current layout; keep a legacy `lib-beam` classpath hook in the `hop` launcher for old installs only.

## Why this appeared

PR #7722 intentionally moved Beam SDKs from `plugins/engines/beam/lib-beam` → `lib/core` but left the Hop Web Dockerfile on the old path. Main builds #1105/#1106 fail at the Docker Web stage for that reason (not because of Markdown notes).

## Testing

- Review-only for Docker/docs alignment with assembly layout after #7722.
- After merge, a green main build should again run Deploy and publish a current `2.19.0-SNAPSHOT`.

Fixes #7748