### PR TITLE
Fix#7753  intermittent AIOOBE when recording empty position undo in Hop GUI

### DIFF
--- a/engine/src/main/java/org/apache/hop/base/AbstractMeta.java
+++ b/engine/src/main/java/org/apache/hop/base/AbstractMeta.java
@@ -502,6 +502,10 @@ public abstract class AbstractMeta
       default:
         break;
     }
+    // Skip entries that were rejected (e.g. empty selection / length mismatch)
+    if (ta.getType() == ChangeAction.ActionType.None) {
+      return;
+    }
     undo.add(ta);
     undoPosition++;
 

--- a/engine/src/main/java/org/apache/hop/core/undo/ChangeAction.java
+++ b/engine/src/main/java/org/apache/hop/core/undo/ChangeAction.java
@@ -117,6 +117,10 @@ public class ChangeAction {
   }
 
   public void setDelete(Object[] prev, int[] idx) {
+    if (prev == null || prev.length == 0) {
+      return;
+    }
+
     current = prev;
     currentIndex = idx;
 
@@ -141,6 +145,10 @@ public class ChangeAction {
   }
 
   public void setChanged(Object[] prev, Object[] curr, int[] idx) {
+    if (prev == null || prev.length == 0) {
+      return;
+    }
+
     previous = prev;
     current = curr;
     currentIndex = idx;
@@ -167,7 +175,7 @@ public class ChangeAction {
   }
 
   public void setNew(Object[] prev, int[] position) {
-    if (prev.length == 0) {
+    if (prev == null || prev.length == 0) {
       return;
     }
 
@@ -196,7 +204,14 @@ public class ChangeAction {
   }
 
   public void setPosition(Object[] obj, int[] idx, Point[] prev, Point[] curr) {
-    if (prev.length != curr.length) {
+    // Nothing to record: empty selection, or mouse-down/up selection size mismatch
+    if (obj == null
+        || obj.length == 0
+        || prev == null
+        || curr == null
+        || prev.length == 0
+        || prev.length != curr.length
+        || obj.length != prev.length) {
       return;
     }
 

--- a/engine/src/test/java/org/apache/hop/base/AbstractMetaTest.java
+++ b/engine/src/test/java/org/apache/hop/base/AbstractMetaTest.java
@@ -187,12 +187,57 @@ class AbstractMetaTest {
     assertNotNull(meta.viewPreviousUndo());
     assertNotNull(meta.viewNextUndo());
     meta.addUndo(from, to, pos, prev, curr, AbstractMeta.TYPE_UNDO_DELETE, false);
-    meta.addUndo(from, to, pos, prev, curr, AbstractMeta.TYPE_UNDO_POSITION, false);
+    Point[] prevPos = new Point[] {new Point(10, 20)};
+    Point[] currPos = new Point[] {new Point(30, 40)};
+    meta.addUndo(from, to, pos, prevPos, currPos, AbstractMeta.TYPE_UNDO_POSITION, false);
     assertNotNull(meta.previousUndo());
     assertNotNull(meta.nextUndo());
     meta.setMaxUndo(1);
     assertEquals(1, meta.getUndoSize());
     meta.addUndo(from, to, pos, prev, curr, AbstractMeta.TYPE_UNDO_NEW, false);
+  }
+
+  @Test
+  void testAddUndoPositionSkipsEmptyOrMismatched() {
+    meta.clearUndo();
+    meta.setMaxUndo(10);
+    TransformMeta transformMeta = mock(TransformMeta.class);
+    Object[] from = new Object[] {transformMeta};
+    int[] pos = new int[] {0};
+
+    // Empty location arrays must not be recorded (and must not throw)
+    meta.addUndo(
+        new Object[0],
+        null,
+        new int[0],
+        new Point[0],
+        new Point[0],
+        AbstractMeta.TYPE_UNDO_POSITION,
+        false);
+    assertEquals(0, meta.getUndoSize());
+
+    // Length mismatch between previous/current locations
+    meta.addUndo(
+        from,
+        null,
+        pos,
+        new Point[] {new Point(1, 1)},
+        new Point[0],
+        AbstractMeta.TYPE_UNDO_POSITION,
+        false);
+    assertEquals(0, meta.getUndoSize());
+
+    // Valid position undo is recorded
+    meta.addUndo(
+        from,
+        null,
+        pos,
+        new Point[] {new Point(1, 1)},
+        new Point[] {new Point(2, 2)},
+        AbstractMeta.TYPE_UNDO_POSITION,
+        false);
+    assertEquals(1, meta.getUndoSize());
+    assertEquals(ChangeAction.ActionType.PositionTransform, meta.viewThisUndo().getType());
   }
 
   @Test

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/HopGuiPipelineGraph.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/HopGuiPipelineGraph.java
@@ -1280,7 +1280,9 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
                 pipelineMeta.getSelectedNoteLocations(),
                 also);
           }
-          if (selectedTransforms != null && previousTransformLocations != null) {
+          if (selectedTransforms != null
+              && !selectedTransforms.isEmpty()
+              && previousTransformLocations != null) {
             int[] indexes = pipelineMeta.getTransformIndexes(selectedTransforms);
             hopGui.undoDelegate.addUndoPosition(
                 pipelineMeta,


### PR DESCRIPTION
Fix https://github.com/apache/hop/issues/7753


## Summary

- Fix intermittent `ArrayIndexOutOfBoundsException` in Hop GUI when a position undo is recorded with an empty selection after a slight transform drag/`mouseUp`.
- Guard `ChangeAction` undo setters against null/empty or length-mismatched inputs; skip rejected (`None`) undo entries in `AbstractMeta.addUndo`.
- Align `HopGuiPipelineGraph.mouseUp` empty-selection check with the existing note/workflow paths, and add unit coverage for empty/mismatched position undo.