### PR TITLE
Fix#5321  field insertion over selected text in FormulaEditor

### DIFF
--- a/plugins/transforms/formula/src/main/java/org/apache/hop/pipeline/transforms/formula/editor/FormulaEditor.java
+++ b/plugins/transforms/formula/src/main/java/org/apache/hop/pipeline/transforms/formula/editor/FormulaEditor.java
@@ -210,25 +210,8 @@ public class FormulaEditor extends Dialog implements KeyListener {
                         : functionLib.getFunctionDescription(item.getText()).getSyntax();
               }
 
-              String oldFormula = expressionEditor.getText();
-              int caretPosition = expressionEditor.getCaretPosition();
-              int textLength = expressionEditor.getText().length();
-              int selectionsize = expressionEditor.getSelectionCount();
-
-              // No text in editor yet, just add text
-              if (textLength == 0) {
-                expressionEditor.setText(partToInsert);
-              } else if (textLength == caretPosition) {
-                // we are at the end of the text, append new text
-                expressionEditor.setText(oldFormula + partToInsert);
-              } else {
-                // Adding text somewhere between other text
-                // if selectionsize is > 0 then we are writing over other text
-                expressionEditor.setText(
-                    oldFormula.substring(0, caretPosition)
-                        + partToInsert
-                        + oldFormula.substring(caretPosition + selectionsize));
-              }
+              // insert() replaces selection regardless of caret direction (fixes #5321)
+              expressionEditor.insert(partToInsert);
             }
           }
         });

--- a/plugins/transforms/janino/src/main/java/org/apache/hop/pipeline/transforms/janino/editor/FormulaEditor.java
+++ b/plugins/transforms/janino/src/main/java/org/apache/hop/pipeline/transforms/janino/editor/FormulaEditor.java
@@ -211,25 +211,8 @@ public class FormulaEditor extends Dialog implements KeyListener {
                         : functionLib.getFunctionDescription(item.getText()).getSyntax();
               }
 
-              String oldFormula = expressionEditor.getText();
-              int caretPosition = expressionEditor.getCaretPosition();
-              int textLength = expressionEditor.getText().length();
-              int selectionsize = expressionEditor.getSelectionCount();
-
-              // No text in editor yet, just add text
-              if (textLength == 0) {
-                expressionEditor.setText(partToInsert);
-              } else if (textLength == caretPosition) {
-                // we are at the end of the text, append new text
-                expressionEditor.setText(oldFormula + partToInsert);
-              } else {
-                // Adding text somewhere between other text
-                // if selectionsize is > 0 then we are writing over other text
-                expressionEditor.setText(
-                    oldFormula.substring(0, caretPosition)
-                        + partToInsert
-                        + oldFormula.substring(caretPosition + selectionsize));
-              }
+              // insert() replaces selection regardless of caret direction (fixes #5321)
+              expressionEditor.insert(partToInsert);
             }
           }
         });


### PR DESCRIPTION
Fix https://github.com/apache/hop/issues/5321

## Summary
- Fix double-click field/function insertion in the expression editor so a selected range is replaced correctly regardless of selection direction (left-to-right vs right-to-left).
- Replace the caret/`substring`/`setText` logic with `StyledText.insert()`, which handles selection replacement properly and avoids wiping undo history.
- Apply the same fix to both User Defined Java Expression (`janino`) and Formula editor dialogs.

## Root cause
The double-click handler treated `getCaretPosition()` as the start of the selection. When text is selected left-to-right, the caret is at the *end* of the selection, so the inserted field name was appended after the selection instead of replacing it.

Example:
- Expression: `isOk? 1: 0`
- Select `1` left → right, double-click field `name` → `isOk? 1name: 0` (wrong)
- Select `1` right → left, double-click field `name` → `isOk? name: 0` (correct)
