### PR TITLE
Fix metadata tree full reload on editor dirty, fixes #7791

### DIFF
--- a/core/src/main/java/org/apache/hop/metadata/api/IHopMetadataSerializer.java
+++ b/core/src/main/java/org/apache/hop/metadata/api/IHopMetadataSerializer.java
@@ -68,6 +68,24 @@ public interface IHopMetadataSerializer<T extends IHopMetadata> {
   List<String> listObjectNames() throws HopException;
 
   /**
+   * Read only the virtual path of the named object. Implementations should prefer a cheap path
+   * (e.g. streaming a single JSON field) over a full {@link #load(String)} when possible. Used by
+   * the metadata perspective tree to avoid deserializing every object on refresh.
+   *
+   * @param name The name of the object
+   * @return The virtual path, never {@code null} (empty string when unset)
+   * @throws HopException if the object does not exist or cannot be read
+   */
+  default String readVirtualPath(String name) throws HopException {
+    T object = load(name);
+    if (object == null) {
+      throw new HopException("Object '" + name + "' does not exist");
+    }
+    String virtualPath = object.getVirtualPath();
+    return virtualPath == null ? "" : virtualPath;
+  }
+
+  /**
    * See if an object with the given name exists.
    *
    * @param name The name of the object to check

--- a/core/src/main/java/org/apache/hop/metadata/serializer/json/JsonMetadataSerializer.java
+++ b/core/src/main/java/org/apache/hop/metadata/serializer/json/JsonMetadataSerializer.java
@@ -303,4 +303,64 @@ public class JsonMetadataSerializer<T extends IHopMetadata> implements IHopMetad
     }
     return HopVfs.fileExists(calculateFilename(name));
   }
+
+  /**
+   * Stream-parse the JSON file and extract only the top-level {@code virtualPath} field without
+   * constructing the managed metadata type. Used by the metadata perspective tree refresh so large
+   * projects do not fully deserialize every object (issue #7791).
+   */
+  @Override
+  public String readVirtualPath(String name) throws HopException {
+    if (name == null) {
+      throw new HopException("Error: you need to specify the name of the metadata object to load");
+    }
+    validateBaseFolder(false);
+    if (!baseFolderExists || !exists(name)) {
+      throw new HopException("Object '" + name + "' does not exist");
+    }
+
+    String filename = calculateFilename(name);
+    try (InputStream fileInputStream = HopVfs.getInputStream(filename)) {
+      JsonFactory jsonFactory = new JsonFactory();
+      try (com.fasterxml.jackson.core.JsonParser jsonParser =
+          jsonFactory.createParser(fileInputStream)) {
+        if (jsonParser.nextToken() != com.fasterxml.jackson.core.JsonToken.START_OBJECT) {
+          throw new HopException("Expected a JSON object in file '" + filename + "'");
+        }
+        while (jsonParser.nextToken() != com.fasterxml.jackson.core.JsonToken.END_OBJECT
+            && jsonParser.currentToken() != null) {
+          if (jsonParser.currentToken() != com.fasterxml.jackson.core.JsonToken.FIELD_NAME) {
+            continue;
+          }
+          String fieldName = jsonParser.currentName();
+          jsonParser.nextToken(); // move to value
+          if ("virtualPath".equals(fieldName)) {
+            if (jsonParser.currentToken() == com.fasterxml.jackson.core.JsonToken.VALUE_NULL) {
+              return "";
+            }
+            if (jsonParser.currentToken() == com.fasterxml.jackson.core.JsonToken.VALUE_STRING) {
+              return Const.NVL(jsonParser.getText(), "");
+            }
+            // Unexpected type for virtualPath — treat as empty rather than failing the tree.
+            jsonParser.skipChildren();
+            return "";
+          }
+          // Skip nested objects/arrays for other fields; scalars are no-ops for skipChildren.
+          jsonParser.skipChildren();
+        }
+        // Field absent: same as HopMetadataBase default.
+        return "";
+      }
+    } catch (HopException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new HopException(
+          "Error reading virtualPath of metadata object '"
+              + name
+              + "' from file '"
+              + filename
+              + "'",
+          e);
+    }
+  }
 }

--- a/core/src/main/java/org/apache/hop/metadata/serializer/memory/MemoryMetadataSerializer.java
+++ b/core/src/main/java/org/apache/hop/metadata/serializer/memory/MemoryMetadataSerializer.java
@@ -110,6 +110,19 @@ public class MemoryMetadataSerializer<T extends IHopMetadata> implements IHopMet
   }
 
   @Override
+  public String readVirtualPath(String name) throws HopException {
+    if (name == null) {
+      throw new HopException("Error: you need to specify the name of the metadata object to load");
+    }
+    T object = objectMap.get(name);
+    if (object == null) {
+      throw new HopException("Object '" + name + "' does not exist");
+    }
+    String virtualPath = object.getVirtualPath();
+    return virtualPath == null ? "" : virtualPath;
+  }
+
+  @Override
   public boolean exists(String name) throws HopException {
     return objectMap.containsKey(name);
   }

--- a/core/src/main/java/org/apache/hop/metadata/serializer/multi/MultiMetadataSerializer.java
+++ b/core/src/main/java/org/apache/hop/metadata/serializer/multi/MultiMetadataSerializer.java
@@ -141,6 +141,21 @@ public class MultiMetadataSerializer<T extends IHopMetadata> implements IHopMeta
     return new ArrayList<>(set);
   }
 
+  /** Same provider order as {@link #load(String)}: child providers override parent projects. */
+  @Override
+  public String readVirtualPath(String name) throws HopException {
+    List<IHopMetadataProvider> providers = multiProvider.getProviders();
+    ListIterator<IHopMetadataProvider> providerIterator = providers.listIterator(providers.size());
+    while (providerIterator.hasPrevious()) {
+      IHopMetadataProvider provider = providerIterator.previous();
+      IHopMetadataSerializer<T> serializer = provider.getSerializer(managedClass);
+      if (serializer.exists(name)) {
+        return serializer.readVirtualPath(name);
+      }
+    }
+    throw new HopException("Object '" + name + "' does not exist");
+  }
+
   @Override
   public boolean exists(String name) throws HopException {
     for (IHopMetadataProvider provider : multiProvider.getProviders()) {

--- a/core/src/test/java/org/apache/hop/metadata/serializer/json/JsonMetadataSerializerTest.java
+++ b/core/src/test/java/org/apache/hop/metadata/serializer/json/JsonMetadataSerializerTest.java
@@ -138,4 +138,49 @@ class JsonMetadataSerializerTest {
     //
     assertThrows(HopException.class, () -> personSerializer.load("Gardener"));
   }
+
+  /**
+   * Tree refresh only needs name + virtualPath. readVirtualPath must not fully deserialize and must
+   * return the path (or empty) even for complex objects (issue #7791).
+   */
+  @Test
+  void testReadVirtualPath(@TempDir Path folder) throws Exception {
+    JsonMetadataProvider provider =
+        new JsonMetadataProvider(
+            new HopTwoWayPasswordEncoder(),
+            folder.toString(),
+            Variables.getADefaultVariableSpace());
+
+    Occupation occupation = new Occupation("Occupation1", "Description of occupation1", 2001);
+    occupation.setVirtualPath("jobs/tech");
+    provider.getSerializer(Occupation.class).save(occupation);
+
+    IHopMetadataSerializer<Occupation> serializer = provider.getSerializer(Occupation.class);
+    assertEquals("jobs/tech", serializer.readVirtualPath("Occupation1"));
+
+    // Field absent → empty string (HopMetadataBase default).
+    Occupation noPath = new Occupation("NoPath", "desc", 2002);
+    serializer.save(noPath);
+    assertEquals("", serializer.readVirtualPath("NoPath"));
+
+    assertThrows(HopException.class, () -> serializer.readVirtualPath("Missing"));
+  }
+
+  @Test
+  void testReadVirtualPathCorruptFile(@TempDir Path folder) throws Exception {
+    JsonMetadataProvider provider =
+        new JsonMetadataProvider(
+            new HopTwoWayPasswordEncoder(),
+            folder.toString(),
+            Variables.getADefaultVariableSpace());
+
+    IHopMetadataSerializer<Occupation> serializer = provider.getSerializer(Occupation.class);
+    Occupation occupation = new Occupation("Broken", "desc", 2001);
+    serializer.save(occupation);
+
+    Path jsonFile = folder.resolve("occupation").resolve("Broken.json");
+    Files.write(jsonFile, "not-valid-json{".getBytes(UTF_8));
+
+    assertThrows(HopException.class, () -> serializer.readVirtualPath("Broken"));
+  }
 }

--- a/ui/src/main/java/org/apache/hop/ui/core/metadata/MetadataEditor.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/metadata/MetadataEditor.java
@@ -24,7 +24,6 @@ import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hop.core.Const;
 import org.apache.hop.core.exception.HopException;
-import org.apache.hop.core.exception.HopRuntimeException;
 import org.apache.hop.core.extension.ExtensionPointHandler;
 import org.apache.hop.core.extension.HopExtensionPoint;
 import org.apache.hop.core.plugins.IPlugin;
@@ -198,12 +197,9 @@ public abstract class MetadataEditor<T extends IHopMetadata> extends MetadataFil
   public void setChanged() {
     if (!this.isChanged) {
       this.isChanged = true;
+      // Update tab decoration and toolbar only. Do not fire MetadataChanged and do not reload
+      // the metadata tree: dirty is not a persisted store change (see issue #7791).
       MetadataPerspective.getInstance().updateEditor(this);
-      try {
-        hopGui.getEventsHandler().fire(HopGuiEvents.MetadataChanged.name());
-      } catch (HopException e) {
-        throw new HopRuntimeException(e);
-      }
     }
   }
 
@@ -335,6 +331,10 @@ public abstract class MetadataEditor<T extends IHopMetadata> extends MetadataFil
     }
 
     MetadataPerspective.getInstance().updateEditor(this);
+
+    // Notify the GUI that the metadata store changed (tree refresh, plugins). Fire only after a
+    // successful persist — not when the editor is merely marked dirty (issue #7791).
+    hopGui.getEventsHandler().fire(HopGuiEvents.MetadataChanged.name());
   }
 
   @Override

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/metadata/MetadataPerspective.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/metadata/MetadataPerspective.java
@@ -742,8 +742,8 @@ public class MetadataPerspective implements IHopPerspective, TabClosable, IMetad
                   hopGui.getVariables(),
                   HopExtensionPoint.HopGuiMetadataObjectUpdated.id,
                   metadata);
+              // Listener on MetadataChanged refreshes the tree once.
               hopGui.getEventsHandler().fire(HopGuiEvents.MetadataChanged.name());
-              refresh();
             } catch (Exception e) {
               new ErrorDialog(
                   getShell(),
@@ -760,7 +760,7 @@ public class MetadataPerspective implements IHopPerspective, TabClosable, IMetad
     try {
       MetadataManager<IHopMetadata> manager = getMetadataManager(objectKey);
       manager.editWithEditor(name);
-      hopGui.getEventsHandler().fire(HopGuiEvents.MetadataChanged.name());
+      // Opening an editor is not a store change — do not fire MetadataChanged (issue #7791).
     } catch (Exception e) {
       new ErrorDialog(
           getShell(),
@@ -1331,8 +1331,7 @@ public class MetadataPerspective implements IHopPerspective, TabClosable, IMetad
         try {
           MetadataManager<IHopMetadata> manager = getMetadataManager(objectKey);
           manager.editWithEditor(objectName);
-
-          hopGui.getEventsHandler().fire(HopGuiEvents.MetadataChanged.name());
+          // Opening an editor is not a store change — do not fire MetadataChanged (issue #7791).
         } catch (Exception e) {
           new ErrorDialog(getShell(), ERROR, "Error editing metadata", e);
         }
@@ -2286,7 +2285,9 @@ public class MetadataPerspective implements IHopPerspective, TabClosable, IMetad
 
     if (editor == null || !isInitialized()) return;
 
-    // Update TabItem
+    // Update TabItem title and dirty font only. Do not reload the metadata tree here:
+    // that is expensive on large projects and dirty ≠ a persisted store change (issue #7791).
+    // Tree content is refreshed via MetadataChanged after save/delete/rename/etc.
     //
     for (CTabItem item : tabFolder.getItems()) {
       if (editor.equals(item.getData())) {
@@ -2296,10 +2297,6 @@ public class MetadataPerspective implements IHopPerspective, TabClosable, IMetad
         break;
       }
     }
-
-    // Update TreeItem
-    //
-    this.refresh();
 
     // Update HOP GUI menu and toolbar...
     //
@@ -2384,9 +2381,9 @@ public class MetadataPerspective implements IHopPerspective, TabClosable, IMetad
 
   /**
    * Loads the metadata model from disk into memory: one {@link MetadataTypeModel} per metadata type
-   * with its items (name + virtual path). This is the only place that reads metadata objects from
-   * the provider, so search filtering (handled entirely by {@link #renderTree()}) never touches
-   * disk.
+   * with its items (name + virtual path via {@link IHopMetadataSerializer#readVirtualPath(String)},
+   * not a full object load). Search filtering (handled entirely by {@link #renderTree()}) never
+   * touches disk.
    */
   private void reloadModel() {
     typeModels.clear();
@@ -2419,7 +2416,9 @@ public class MetadataPerspective implements IHopPerspective, TabClosable, IMetad
         for (String name : names) {
           String virtualPath;
           try {
-            virtualPath = Const.NVL(serializer.load(name).getVirtualPath(), "");
+            // Cheap path: name + virtualPath only (JSON peeks a single field). Avoid full
+            // serializer.load() for every object on each tree refresh (issue #7791).
+            virtualPath = Const.NVL(serializer.readVirtualPath(name), "");
           } catch (Exception e) {
             // We can't load this one: a missing plugin, corrupt JSON, ... .  Rather than hiding it,
             // we list it under the "Unknown" category where it can be inspected and deleted.


### PR DESCRIPTION
## Summary

- Marking a metadata editor dirty no longer triggers a full metadata perspective reload or `MetadataChanged`. Only the tab title/font and toolbar update, so large projects stay responsive on first keystroke.
- `MetadataChanged` is fired after a successful save (and continues to fire on rename/drag-drop move), not when merely opening an editor or marking it dirty.
- Tree refresh uses `IHopMetadataSerializer.readVirtualPath()` so JSON metadata can stream a single field instead of fully deserializing every object.

## Details

**Dirty path (before):** `setChanged()` → `updateEditor()` → `refresh()`/`reloadModel()` + fire `MetadataChanged` → listener `refresh()` again.

**After:** `setChanged()` only updates tab decoration; save fires `MetadataChanged` once for a single tree refresh.

Also removes redundant `MetadataChanged` when opening editors and the double `fire`+`refresh` on drag-drop move.

## Test plan

- [x] `JsonMetadataSerializerTest` / `MultiMetadataSerializerTest` (including new `readVirtualPath` cases)
- [x] `core` + `ui` compile
- [x] Manual: first keystroke in metadata name field stays snappy on large project; tab bolds; tree does not rebuild
- [ ] Manual: save updates tree once; rename/delete/drag-drop/F5/project switch still work
- [ ] Manual: corrupt/unreadable metadata files still appear under Unknown when virtual path cannot be read

Fixes #7791