### PR TITLE
issue #3209: preserve Text File Input compression when adding files

### DIFF
--- a/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/fileinput/text/TextFileInputDialog.java
+++ b/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/fileinput/text/TextFileInputDialog.java
@@ -483,31 +483,43 @@ public class TextFileInputDialog extends BaseTransformDialog
     checkCompressedFile();
   }
 
-  /*check the compressed extension of the first file in the archive and change the
-   * compression mode in the content tab depending on it*/
+  /**
+   * Optionally auto-select compression from filename extensions when the user has not already
+   * chosen a non-None compression (issue #3209). Does not override an explicit selection.
+   */
   private void checkCompressedFile() {
-    if (wFilenameList.getItemCount() > 0) {
-      for (int i = 0; i < wFilenameList.getItemCount(); i++) {
-        String[] fileRecord = wFilenameList.getItem(i);
-        String fileExtension = FilenameUtils.getExtension(fileRecord[i]);
-        Collection<ICompressionProvider> compProviders =
-            CompressionProviderFactory.getInstance().getCompressionProviders();
-        for (ICompressionProvider provider : compProviders) {
-          if (provider.getDefaultExtension() != null
-              && provider.getDefaultExtension().equals(fileExtension)) {
-            int toBeSelected = ArrayUtils.indexOf(wCompression.getItems(), provider.getName());
+    // Preserve explicit Compression settings (GZip, Zip, ...). Only auto-detect when None/empty.
+    String current = Const.NVL(wCompression.getText(), "");
+    if (!Utils.isEmpty(current) && !"None".equalsIgnoreCase(current)) {
+      return;
+    }
+
+    if (wFilenameList.getItemCount() <= 0) {
+      return;
+    }
+
+    Collection<ICompressionProvider> compProviders =
+        CompressionProviderFactory.getInstance().getCompressionProviders();
+
+    for (int i = 0; i < wFilenameList.getItemCount(); i++) {
+      String[] fileRecord = wFilenameList.getItem(i);
+      if (fileRecord == null || fileRecord.length == 0 || Utils.isEmpty(fileRecord[0])) {
+        continue;
+      }
+      // Filename is always column 0 (not row index i)
+      String fileExtension = FilenameUtils.getExtension(fileRecord[0]);
+      for (ICompressionProvider provider : compProviders) {
+        if (provider.getDefaultExtension() != null
+            && provider.getDefaultExtension().equals(fileExtension)) {
+          int toBeSelected = ArrayUtils.indexOf(wCompression.getItems(), provider.getName());
+          if (toBeSelected >= 0) {
             wCompression.select(toBeSelected);
-            return;
           }
+          return;
         }
       }
-      wCompression.select(
-          ArrayUtils.indexOf(
-              wCompression.getItems(),
-              CompressionProviderFactory.getInstance()
-                  .getCompressionProviderByName("None")
-                  .getName()));
     }
+    // No matching compressed extension: leave compression as None/empty (do not force select).
   }
 
   private void showFiles() {


### PR DESCRIPTION
## Summary

Fixes [#3209](https://github.com/apache/hop/issues/3209): adding or removing files on the Text File Input **File** tab no longer resets an explicit **Content → Compression** setting (e.g. GZip) back to **None**.

### Root cause
`TextFileInputDialog.checkCompressedFile()` re-derived compression from filename extensions on every Add/Delete. When no extension matched a compression provider, it **forced** the combo to `None`, overwriting the user's choice.

### Fix (GUI only)
Single method change in `TextFileInputDialog` — no meta, runtime, XML, or engine changes:

1. **Skip auto-detect** when Compression is already something other than `None` / empty (preserve explicit user selection).
2. **Auto-detect only when Compression is still `None`**, if a known extension (`.gz`, `.zip`, …) is present.
3. **Do not force** Compression to `None` when no matching extension is found.
4. **Bug fix:** use `fileRecord[0]` (filename column) instead of `fileRecord[i]` when reading the extension.

### Compatibility
Text File Input is widely used. This PR deliberately limits the change to dialog UX so pipeline XML, MDI, Beam, and transform execution are untouched. Runtime continues to use whatever compression is stored after OK.

### Behavior after this change

| Current Compression | File action | Before | After |
|---------------------|-------------|--------|-------|
| GZip | Add plain `.txt` | Reset to None (bug) | Stay GZip |
| None | Add `.gz` | Set GZip | Set GZip (unchanged) |
| None | Add `.txt` | Set None | Stay None |
| GZip | Delete a listed file | Could reset to None | Stay GZip |

Trade-off: with Compression already set to GZip, adding a `.zip` file will **not** auto-switch to Zip. Users can still change Compression on the Content tab. That is preferable to clobbering an explicit choice.

## Test plan

- [x] Module compiles (`plugins/transforms/textfile`)
- [x] Manual: set Compression = GZip, Add non-`.gz` file → Compression stays GZip
- [ ] Manual: Compression = None, Add `file.gz` → auto-selects GZip
- [ ] Manual: Compression = None, Add `file.zip` → auto-selects Zip
- [ ] Manual: open existing transform with GZip + files → dialog shows GZip
- [ ] Manual: after preserving GZip, OK and reopen → value persisted in meta
- [ ] Manual: with GZip set, delete a file from the list → GZip not cleared