### PR TITLE
Add Filter Rows condition isolation regression tests, fixes #7734

### DIFF
--- a/plugins/transforms/filterrows/src/test/java/org/apache/hop/pipeline/transforms/filterrows/FilterRowsMetaTest.java
+++ b/plugins/transforms/filterrows/src/test/java/org/apache/hop/pipeline/transforms/filterrows/FilterRowsMetaTest.java
@@ -16,8 +16,10 @@
  */
 package org.apache.hop.pipeline.transforms.filterrows;
 
+import static org.apache.hop.core.Condition.Function.EQUAL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
@@ -27,6 +29,7 @@ import java.util.Map;
 import org.apache.hop.core.Condition;
 import org.apache.hop.core.HopEnvironment;
 import org.apache.hop.core.plugins.PluginRegistry;
+import org.apache.hop.core.row.ValueMetaAndData;
 import org.apache.hop.pipeline.transform.TransformMeta;
 import org.apache.hop.pipeline.transform.TransformSerializationTestUtil;
 import org.apache.hop.pipeline.transforms.dummy.DummyMeta;
@@ -92,6 +95,48 @@ class FilterRowsMetaTest {
     assertNotNull(clone.getCondition());
     assertEquals("true", clone.getTrueTransformName());
     assertEquals("false", clone.getFalseTransformName());
+  }
+
+  /**
+   * FilterRowsMeta.clone() must deep-copy the condition tree so copy/paste and undo do not share
+   * mutable Condition / CValue instances with the original meta.
+   */
+  @Test
+  void testCloneDeepCopiesCondition() throws Exception {
+    Condition nameCondition =
+        new Condition("name", EQUAL, null, new ValueMetaAndData("constant", "Alice"));
+    Condition codeCondition =
+        new Condition("code", EQUAL, null, new ValueMetaAndData("constant", "A-1"));
+    Condition condition = new Condition();
+    condition.addCondition(nameCondition);
+    condition.addCondition(codeCondition);
+
+    FilterRowsMeta filterRowsMeta = new FilterRowsMeta();
+    filterRowsMeta.setCondition(condition);
+    filterRowsMeta.setTrueTransformName("true");
+    filterRowsMeta.setFalseTransformName("false");
+
+    FilterRowsMeta clone = filterRowsMeta.clone();
+    assertNotSame(filterRowsMeta, clone);
+    assertNotSame(filterRowsMeta.getCondition(), clone.getCondition());
+    assertNotSame(
+        filterRowsMeta.getCondition().getCondition(0), clone.getCondition().getCondition(0));
+    assertNotSame(
+        filterRowsMeta.getCondition().getCondition(0).getRightValue(),
+        clone.getCondition().getCondition(0).getRightValue());
+    assertEquals("true", clone.getTrueTransformName());
+    assertEquals("false", clone.getFalseTransformName());
+    assertEquals(2, clone.getCondition().nrConditions());
+    assertEquals("Alice", clone.getCondition().getCondition(0).getRightValueString());
+    assertEquals("A-1", clone.getCondition().getCondition(1).getRightValueString());
+
+    clone.getCondition().getCondition(0).getRightValue().setText("Bob");
+    clone.getCondition().getCondition(0).setLeftValueName("other");
+
+    assertEquals("Alice", filterRowsMeta.getCondition().getCondition(0).getRightValueString());
+    assertEquals("name", filterRowsMeta.getCondition().getCondition(0).getLeftValueName());
+    assertEquals("Bob", clone.getCondition().getCondition(0).getRightValueString());
+    assertEquals("other", clone.getCondition().getCondition(0).getLeftValueName());
   }
 
   @Test

--- a/plugins/transforms/filterrows/src/test/java/org/apache/hop/pipeline/transforms/filterrows/FilterRowsTest.java
+++ b/plugins/transforms/filterrows/src/test/java/org/apache/hop/pipeline/transforms/filterrows/FilterRowsTest.java
@@ -21,6 +21,8 @@ import static org.apache.hop.core.Condition.Function.EQUAL;
 import static org.apache.hop.core.Condition.Function.REGEXP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
@@ -113,6 +115,89 @@ class FilterRowsTest {
     rowMeta.addValueMeta(new ValueMetaString("code"));
     assertTrue(runtimeCondition.evaluate(rowMeta, new Object[] {"Alice", "A-123"}));
     assertFalse(runtimeCondition.evaluate(rowMeta, new Object[] {"Alice", "B-123"}));
+  }
+
+  /**
+   * Regression for #7734: after init(), the engine must keep evaluating a private clone of the
+   * condition. Mutating shared transform metadata (as the GUI does when OK is pressed on a running
+   * pipeline) must not change routing for the active execution.
+   */
+  @Test
+  void runtimeConditionIsIsolatedFromMetadataMutationAfterInit() throws Exception {
+    Condition metadataCondition =
+        new Condition("name", EQUAL, null, new ValueMetaAndData("constant", "Alice"));
+    FilterRows transform = createTransform(metadataCondition);
+    FilterRowsMeta meta = transform.getMeta();
+
+    assertTrue(transform.init());
+    Condition runtimeCondition = transform.getData().condition;
+    assertNotNull(runtimeCondition);
+    assertNotSame(meta.getCondition(), runtimeCondition);
+
+    RowMeta rowMeta = new RowMeta();
+    rowMeta.addValueMeta(new ValueMetaString("name"));
+    Object[] aliceRow = new Object[] {"Alice"};
+    Object[] bobRow = new Object[] {"Bob"};
+
+    assertTrue(runtimeCondition.evaluate(rowMeta, aliceRow));
+    assertFalse(runtimeCondition.evaluate(rowMeta, bobRow));
+
+    // Simulate a GUI edit while the pipeline is still running: replace the meta condition.
+    Condition editedCondition =
+        new Condition("name", EQUAL, null, new ValueMetaAndData("constant", "Bob"));
+    meta.setCondition(editedCondition);
+
+    assertNotSame(meta.getCondition(), runtimeCondition);
+    assertTrue(
+        runtimeCondition.evaluate(rowMeta, aliceRow),
+        "Runtime condition must keep the rule captured at init()");
+    assertFalse(runtimeCondition.evaluate(rowMeta, bobRow));
+    assertFalse(
+        meta.getCondition().evaluate(rowMeta, aliceRow),
+        "Metadata condition really changed to the edited rule");
+    assertTrue(meta.getCondition().evaluate(rowMeta, bobRow));
+  }
+
+  /**
+   * Same isolation guarantee for nested conditions: editing a child on the meta condition after
+   * init must not affect the runtime clone.
+   */
+  @Test
+  void nestedRuntimeConditionIsIsolatedFromMetadataMutationAfterInit() throws Exception {
+    Condition nameCondition =
+        new Condition("name", EQUAL, null, new ValueMetaAndData("constant", "Alice"));
+    Condition codeCondition =
+        new Condition("code", EQUAL, null, new ValueMetaAndData("constant", "A-1"));
+    Condition metadataCondition = new Condition();
+    metadataCondition.addCondition(nameCondition);
+    metadataCondition.addCondition(codeCondition);
+
+    FilterRows transform = createTransform(metadataCondition);
+    FilterRowsMeta meta = transform.getMeta();
+
+    assertTrue(transform.init());
+    Condition runtimeCondition = transform.getData().condition;
+    assertNotNull(runtimeCondition);
+    assertNotSame(meta.getCondition(), runtimeCondition);
+    assertNotSame(meta.getCondition().getCondition(0), runtimeCondition.getCondition(0));
+
+    RowMeta rowMeta = new RowMeta();
+    rowMeta.addValueMeta(new ValueMetaString("name"));
+    rowMeta.addValueMeta(new ValueMetaString("code"));
+    Object[] matchingRow = new Object[] {"Alice", "A-1"};
+
+    assertTrue(runtimeCondition.evaluate(rowMeta, matchingRow));
+
+    // Mutate nested meta condition in place (also possible via shared Condition graphs).
+    meta.getCondition().getCondition(0).getRightValue().setText("Bob");
+    meta.getCondition().getCondition(0).clearFieldPositions();
+
+    assertTrue(
+        runtimeCondition.evaluate(rowMeta, matchingRow),
+        "Nested runtime condition must not observe meta mutations after init()");
+    assertEquals("Alice", runtimeCondition.getCondition(0).getRightValueString());
+    assertEquals("Bob", meta.getCondition().getCondition(0).getRightValueString());
+    assertFalse(meta.getCondition().evaluate(rowMeta, matchingRow));
   }
 
   private static Stream<Arguments> variableValueTypes() throws Exception {


### PR DESCRIPTION
## What

Adds unit tests that lock in Filter Rows runtime isolation of the filter `Condition` from shared transform metadata.

## Why

Issue #7734 reported that editing a Filter Rows condition in Hop GUI while a Local Pipeline Engine run was active could change True/False routing mid-execution.

That behavior was already fixed by #7686, which clones the condition into `data.condition` at `init()` and evaluates that private copy instead of `meta.getCondition()`. The reporter's build (`hop-client-2.19.0-20260724`) predated that change.

This PR does not change production code; it adds regression coverage so the isolation contract cannot regress:

- After `init()`, replacing or mutating the meta condition must not change runtime evaluation (atomic and nested cases).
- `FilterRowsMeta.clone()` deep-copies the condition tree / `CValue` instances for copy-paste and undo safety.

## How

- `FilterRowsTest`: simulate GUI meta mutation after `init()` and assert `data.condition` keeps the original rule.
- `FilterRowsMetaTest`: assert deep clone independence for nested conditions.

## Testing

```bash
./mvnw -pl plugins/transforms/filterrows -am test -Dtest=FilterRowsTest,FilterRowsMetaTest -Dsurefire.failIfNoSpecifiedTests=false
```

All 14 Filter Rows unit tests pass.

Fixes #7734