### PR TITLE
Fix for displaying plain text file types in dark mode Windows #7670

### DIFF
--- a/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/types/TextExplorerFileTypeHandler.java
+++ b/plugins/transforms/textfile/src/main/java/org/apache/hop/pipeline/transforms/types/TextExplorerFileTypeHandler.java
@@ -29,4 +29,9 @@ public class TextExplorerFileTypeHandler extends BaseTextExplorerFileTypeHandler
       HopGui hopGui, ExplorerPerspective perspective, ExplorerFile explorerFile) {
     super(hopGui, perspective, explorerFile);
   }
+
+  @Override
+  protected String getLanguageId() {
+    return "plaintext";
+  }
 }

--- a/rcp/src/main/java/org/apache/hop/ui/hopgui/ContentEditorTm4eSupport.java
+++ b/rcp/src/main/java/org/apache/hop/ui/hopgui/ContentEditorTm4eSupport.java
@@ -51,6 +51,7 @@ final class ContentEditorTm4eSupport {
   private static final boolean TRACE_SCOPES = Boolean.getBoolean("hop.contenteditor.trace.scopes");
 
   private static final String SCOPE_JSON = "source.json";
+  private static final String SCOPE_TEXT = "text.plain";
   private static final String SCOPE_XML = "text.xml";
   private static final String SCOPE_SQL = "source.sql";
   private static final String SCOPE_PYTHON = "source.python";
@@ -64,6 +65,7 @@ final class ContentEditorTm4eSupport {
           SCOPE_JSON, "json.json",
           SCOPE_XML, "xml.json",
           SCOPE_SQL, "sql.json",
+          SCOPE_TEXT, "text.json",
           SCOPE_PYTHON, "python.json",
           SCOPE_YAML, "yaml.json",
           SCOPE_SHELL, "shell.json",
@@ -120,6 +122,7 @@ final class ContentEditorTm4eSupport {
       case "yaml", "yml" -> SCOPE_YAML;
       case "shell", "bash", "sh" -> SCOPE_SHELL;
       case "bat", "cmd", "batch" -> SCOPE_BATCH;
+      case "plaintext" -> SCOPE_TEXT;
       default -> null;
     };
   }

--- a/rcp/src/main/resources/org/apache/hop/ui/hopgui/grammars/text.json
+++ b/rcp/src/main/resources/org/apache/hop/ui/hopgui/grammars/text.json
@@ -1,0 +1,5 @@
+{
+	"name": "Plain Text Custom",
+	"scopeName": "text.plain",
+	"fileTypes": ["txt", "text"]
+}

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/ExplorerPerspective.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/explorer/ExplorerPerspective.java
@@ -120,6 +120,7 @@ import org.apache.hop.ui.hopgui.perspective.explorer.file.ExplorerFileType;
 import org.apache.hop.ui.hopgui.perspective.explorer.file.IExplorerFileTypeHandler;
 import org.apache.hop.ui.hopgui.perspective.explorer.file.types.FolderFileType;
 import org.apache.hop.ui.hopgui.perspective.explorer.file.types.GenericFileType;
+import org.apache.hop.ui.hopgui.perspective.explorer.file.types.raw.RawExplorerFileType;
 import org.apache.hop.ui.hopgui.perspective.metadata.MetadataPerspective;
 import org.apache.hop.ui.hopgui.search.HopGuiPipelineSearchable;
 import org.apache.hop.ui.hopgui.search.HopGuiWorkflowSearchable;
@@ -470,8 +471,7 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
               Control c = focusControl;
               while (c != null) {
                 Object data = c.getData(KEY_TAB_FOLDER);
-                if (data instanceof CTabFolder && isEditorTabFolder((Control) data)) {
-                  CTabFolder folder = (CTabFolder) data;
+                if (data instanceof CTabFolder folder && isEditorTabFolder((Control) data)) {
                   for (CTabItem item : folder.getItems()) {
                     if (item.getControl() == c) {
                       if (activeTabFolder != folder || folder.getSelection() != item) {
@@ -507,6 +507,7 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
       }
     }
     // Keep as last in the list...
+    fileTypes.add(new RawExplorerFileType());
     fileTypes.add(new GenericFileType());
     indexFileTypes();
   }
@@ -4824,7 +4825,7 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
       return;
     }
     List<CTabFolder> docked = getDockedTabFolders();
-    CTabFolder target = docked.isEmpty() ? null : docked.get(0);
+    CTabFolder target = docked.isEmpty() ? null : docked.getFirst();
     if (target != null) {
       for (CTabItem item : detached.getItems()) {
         moveTabToFolder(item, target);
@@ -4844,7 +4845,7 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
     detachedFolders.remove(folder);
     if (activeTabFolder == folder) {
       List<CTabFolder> docked = getDockedTabFolders();
-      activeTabFolder = docked.isEmpty() ? null : docked.get(0);
+      activeTabFolder = docked.isEmpty() ? null : docked.getFirst();
     }
     Shell shell = folder.getShell();
     if (shell != null && !shell.isDisposed()) {
@@ -4992,7 +4993,7 @@ public class ExplorerPerspective implements IHopPerspective, TabClosable, IFileD
     root.setLayoutData(new FormDataBuilder().fullSize().result());
     editorRoot = root;
     List<CTabFolder> leaves = getDockedTabFolders();
-    activeTabFolder = leaves.isEmpty() ? null : leaves.get(0);
+    activeTabFolder = leaves.isEmpty() ? null : leaves.getFirst();
     tabFolderWrapper.layout(true, true);
   }
 


### PR DESCRIPTION
- Add text.json grammar definition for plain text files
- Register RawExplorerFileType in file type handlers to display editor icon
- Override getLanguageId() in TextExplorerFileTypeHandler to return "plaintext"
- Replace list.get(0) with list.getFirst() for better readability
- Simplify instanceof pattern matching in ExplorerPerspective
