### PR TITLE
Fix Hop GUI startup failure on Windows after SWT 3.134 upgrade

### DIFF
--- a/assemblies/static/src/main/resources/hop-gui-nolog.bat
+++ b/assemblies/static/src/main/resources/hop-gui-nolog.bat
@@ -112,7 +112,9 @@ echo.
 echo ===[Starting Hop]=========================================================
 
 REM Empty title "" is required: start treats the first quoted argument as the window title.
-start "" "%_HOP_JAVA%" -classpath %CLASSPATH% -Dswt.autoScale=false -Djava.library.path=%LIBSPATH% %HOP_OPTIONS% org.apache.hop.ui.hopgui.HopGui
+REM SWT 3.134+ enables monitor-specific scaling by default on Windows; only
+REM "quarter" and "exact" are compatible. Do not set -Dswt.autoScale=false.
+start "" "%_HOP_JAVA%" -classpath %CLASSPATH% -Djava.library.path=%LIBSPATH% %HOP_OPTIONS% org.apache.hop.ui.hopgui.HopGui
 
 :End
 endlocal

--- a/assemblies/static/src/main/resources/hop-gui.bat
+++ b/assemblies/static/src/main/resources/hop-gui.bat
@@ -119,7 +119,9 @@ echo %_HOP_JAVA% -classpath %CLASSPATH% -Djava.library.path=%LIBSPATH% %HOP_OPTI
 echo.
 echo ===[Starting Hop]=========================================================
 
-%_HOP_JAVA% -classpath %CLASSPATH% -Dswt.autoScale=false -Djava.library.path=%LIBSPATH% %HOP_OPTIONS% org.apache.hop.ui.hopgui.HopGui
+REM SWT 3.134+ enables monitor-specific scaling by default on Windows; only
+REM "quarter" and "exact" are compatible. Do not set -Dswt.autoScale=false.
+%_HOP_JAVA% -classpath %CLASSPATH% -Djava.library.path=%LIBSPATH% %HOP_OPTIONS% org.apache.hop.ui.hopgui.HopGui
 if ERRORLEVEL 1 (pause)
 
 :End


### PR DESCRIPTION

## Summary
- Remove `-Dswt.autoScale=false` from `hop-gui.bat` and `hop-gui-nolog.bat`.
- SWT 3.134+ enables monitor-specific scaling by default on Windows and only allows `quarter` / `exact` for `swt.autoScale`.
- The previous `false` setting  now conflicts with that default and prevents the GUI from starting:

```text
===[Starting Hop]=========================================================
Error starting the Hop GUI: monitor-specific scaling is only implemented for auto-scale values "quarter", "exact", but "false" has been specified
org.eclipse.swt.SWTError: monitor-specific scaling is only implemented for auto-scale values "quarter", "exact", but "false" has been specified
        at org.eclipse.swt.internal.DPIUtil.updateAutoScaleValue(DPIUtil.java:118)
        at org.eclipse.swt.internal.DPIUtil.<clinit>(DPIUtil.java:106)
        at org.eclipse.swt.widgets.Display.retrieveDefaultIconSize(Display.java:537)
        at org.eclipse.swt.widgets.Display.<clinit>(Display.java:534)
        at org.apache.hop.ui.hopgui.HopGui.setupDisplay(HopGui.java:1030)
        at org.apache.hop.ui.hopgui.HopGui.main(HopGui.java:418)
```