### PR TITLE
Avoid SWT Invalid thread access on GetFields from lineage, fixes #7896

### DIFF
--- a/engine/src/main/java/org/apache/hop/lineage/LineageTransformSchemaEmitter.java
+++ b/engine/src/main/java/org/apache/hop/lineage/LineageTransformSchemaEmitter.java
@@ -20,7 +20,6 @@ package org.apache.hop.lineage;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.hop.core.IRowSet;
-import org.apache.hop.core.exception.HopException;
 import org.apache.hop.core.row.IRowMeta;
 import org.apache.hop.core.row.IValueMeta;
 import org.apache.hop.core.row.value.ValueMetaFactory;
@@ -200,7 +199,9 @@ public final class LineageTransformSchemaEmitter {
     }
     try {
       return pipelineMeta.getPrevTransformFields(pipeline, transformMeta);
-    } catch (HopException ignored) {
+    } catch (Exception ignored) {
+      // Includes HopException and unexpected runtime failures from GetFields extension points
+      // (e.g. SWT access from a worker thread); design-graph schema is best-effort only.
       return null;
     }
   }
@@ -233,7 +234,8 @@ public final class LineageTransformSchemaEmitter {
     }
     try {
       return pipelineMeta.getTransformFields(pipeline, transformMeta);
-    } catch (HopException ignored) {
+    } catch (Exception ignored) {
+      // Best-effort design-graph fallback; see resolveInputRowMetaFromGraph.
       return null;
     }
   }

--- a/plugins/misc/testing/src/main/java/org/apache/hop/testing/gui/TestingGuiPlugin.java
+++ b/plugins/misc/testing/src/main/java/org/apache/hop/testing/gui/TestingGuiPlugin.java
@@ -87,8 +87,10 @@ import org.apache.hop.ui.testing.EditRowsDialog;
 import org.apache.hop.workflow.WorkflowMeta;
 import org.apache.hop.workflow.action.ActionMeta;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.SWTException;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.TableItem;
 
@@ -1344,26 +1346,38 @@ public class TestingGuiPlugin {
    * <p>Prefers the active pipeline graph when it matches, then scans explorer tabs. Matching is by
    * identity first, then {@link PipelineMeta#equals(Object)} (filename/name).
    *
+   * <p>Must only be called from the UI thread: looking up the active tab touches SWT widgets.
+   * Background callers (e.g. lineage GetFields from a transform thread) get {@code null}.
+   *
    * @param pipelineMeta the pipeline metadata
-   * @return the graph, or null when the pipeline is not open in the GUI
+   * @return the graph, or null when the pipeline is not open in the GUI or the caller is not on the
+   *     UI thread
    */
   public static HopGuiPipelineGraph getPipelineGraph(PipelineMeta pipelineMeta) {
-    HopGuiPipelineGraph active = HopGui.getActivePipelineGraph();
-    if (active != null && pipelineMetaMatches(active.getPipelineMeta(), pipelineMeta)) {
-      return active;
-    }
-    if (pipelineMeta == null || HopGui.getExplorerPerspective() == null) {
+    // Tab / graph lookup may touch SWT widgets; only safe on the UI thread (issue #7896).
+    if (Display.getCurrent() == null) {
       return null;
     }
-    for (TabItemHandler item : HopGui.getExplorerPerspective().getItems()) {
-      if (!(item.getTypeHandler() instanceof HopGuiPipelineGraph pipelineGraph)) {
-        continue;
+    try {
+      HopGuiPipelineGraph active = HopGui.getActivePipelineGraph();
+      if (active != null && pipelineMetaMatches(active.getPipelineMeta(), pipelineMeta)) {
+        return active;
       }
-      if (pipelineMetaMatches(pipelineGraph.getPipelineMeta(), pipelineMeta)) {
-        return pipelineGraph;
+      if (pipelineMeta == null || HopGui.getExplorerPerspective() == null) {
+        return null;
       }
+      for (TabItemHandler item : HopGui.getExplorerPerspective().getItems()) {
+        if (!(item.getTypeHandler() instanceof HopGuiPipelineGraph pipelineGraph)) {
+          continue;
+        }
+        if (pipelineMetaMatches(pipelineGraph.getPipelineMeta(), pipelineMeta)) {
+          return pipelineGraph;
+        }
+      }
+      return null;
+    } catch (SWTException e) {
+      return null;
     }
-    return null;
   }
 
   private static boolean pipelineMetaMatches(PipelineMeta a, PipelineMeta b) {
@@ -1377,6 +1391,10 @@ public class TestingGuiPlugin {
     // When rendering a pipeline on a server status page we never have a current unit test
     //
     if (!"GUI".equalsIgnoreCase(Const.getHopPlatformRuntime())) {
+      return null;
+    }
+    // Same rule as getPipelineGraph: never access HopGui/SWT from a worker thread (issue #7896).
+    if (Display.getCurrent() == null) {
       return null;
     }
     Map<String, Object> stateMap = getStateMap(pipelineMeta);

--- a/plugins/misc/testing/src/test/java/org/apache/hop/testing/gui/TestingGuiPluginTweakTest.java
+++ b/plugins/misc/testing/src/test/java/org/apache/hop/testing/gui/TestingGuiPluginTweakTest.java
@@ -77,6 +77,16 @@ class TestingGuiPluginTweakTest {
     assertTrue(targets.isEmpty());
   }
 
+  /**
+   * getCurrentUnitTest must not touch SWT from a non-UI thread (issue #7896). Unit tests have no
+   * Display, so Display.getCurrent() is null and the method returns null without throwing.
+   */
+  @Test
+  void getCurrentUnitTestReturnsNullOffUiThread() {
+    assertNull(TestingGuiPlugin.getCurrentUnitTest(new PipelineMeta()));
+    assertNull(TestingGuiPlugin.getStateMap(new PipelineMeta()));
+  }
+
   @Test
   void applyTweakEnableAddsBypass() {
     PipelineUnitTest unitTest = new PipelineUnitTest();


### PR DESCRIPTION
## What

Stop console spam from `SWTException: Invalid thread access` when `GetFieldsExtension` runs on a pipeline worker thread (lineage design-graph fallback on transform finish).

## How

- `TestingGuiPlugin.getStateMap` / `getCurrentUnitTest`: return `null` when not on the UI thread (`Display.getCurrent() == null`); catch `SWTException` as a last resort.
- `LineageTransformSchemaEmitter`: catch `Exception` on design-graph field resolution (best-effort only).

Design-time Get Fields / unit-test dataset overrides on the UI thread are unchanged.

## Test plan

- [x] `TestingGuiPluginTweakTest` (includes off-UI-thread null check)
- [x] `LineageTransformSchemaEmitterTest`
- [ ] Manual: run a pipeline in Hop GUI → no GetFieldsExtension / Invalid thread access in Console

Fixes #7896