### PR TITLE
Issue #7250 : Document that UNC paths are not reliably supported

### DIFF
--- a/docs/hop-user-manual/modules/ROOT/pages/vfs.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/vfs.adoc
@@ -86,7 +86,7 @@ a|URI Format
 `+[file://] absolute-path+`
 
 Where `absolute-path` is a valid absolute file name for the local platform.
-UNC names are supported under Windows.
+UNC paths are accepted by Apache VFS, but are not reliably supported in Hop — see <<windows-unc-paths, Windows UNC paths>>.
 
 Examples
 
@@ -270,6 +270,30 @@ Examples
 //
 |Zip|see 'jar'|
 |===
+
+[#windows-unc-paths]
+== Windows UNC paths
+
+The table above describes the file system types provided by Apache VFS itself.
+Apache VFS accepts UNC paths such as `+file://///somehost/someshare/afile.txt+`, but **UNC paths are not reliably supported in Hop**.
+They work in some cases and fail in others, and which transforms work is not predictable: the same file may be readable through one transform and not another, because different transforms reach the file system by different routes.
+
+WARNING: Do not rely on UNC paths in pipelines or workflows you intend to run unattended.
+
+Use a mounted drive or folder instead, and point Hop at the mount:
+
+* On Windows, map the share to a drive letter and use that letter, for example `+file:///Z:/somedir/afile.txt+`.
+* On Linux and macOS, mount the share and use the local path, for example `+file:///mnt/someshare/afile.txt+`.
+
+Referring to the mount through a variable keeps the pipeline portable across operating systems:
+
+[source]
+----
+# Windows
+NETWORK_PATH=Z:
+# Linux, macOS
+NETWORK_PATH=/mnt/someshare
+----
 
 == Supported operations
 


### PR DESCRIPTION
Closes #7250

@hansva you asked on that issue for this to be documented ("I don't think it is properly documented, let's keep this ticket to do that"). While writing it I found the docs were not silent on UNC — they claimed the opposite:

```asciidoc
Where `absolute-path` is a valid absolute file name for the local platform.
UNC names are supported under Windows.
```

That sentence is accurate about **Apache VFS**, which the surrounding table is taken from ("The table below lists the file system types provided by the default Apache VFS implementation"), but not about Hop. So a user following the docs had every reason to expect `\\some.network.folder\my_excel.xlsx` to work, which is how #7250 happened.

Two changes:

**1. Correct the claim** rather than leave a true-of-upstream statement that misleads in context, pointing at the new section instead.

**2. Add a `Windows UNC paths` section** covering what the issue actually revealed:

- UNC paths are accepted by Apache VFS but are not reliably supported in Hop
- **why it looks inconsistent** — the reporter's confusion was that Excel Input failed while another transform read the same file. Different transforms reach the file system by different routes, so "it works over there" is not evidence it will work here. That seemed worth stating, since it is the part that costs people time.
- a warning against relying on it in unattended runs
- the mounted-drive workaround you recommended, for Windows and for Linux/macOS, with a variable example so the same pipeline is portable

Docs only, no code. Cross-reference uses the `<<id, Text>>` form to match the rest of the manual, and `**bold**` as used elsewhere in these pages.

If you would rather this were phrased as a flat "not supported" with no explanation of the inconsistency, say so and I will trim it — I erred toward explaining the failure mode because that is what the reporter was missing.