### PR TITLE
Fix #7183: MongoDB Output ObjectId match field regression after BSON 5.x upgrade

### DIFF
--- a/plugins/tech/mongodb/src/main/java/org/apache/hop/pipeline/transforms/mongodboutput/MongoDbOutputData.java
+++ b/plugins/tech/mongodb/src/main/java/org/apache/hop/pipeline/transforms/mongodboutput/MongoDbOutputData.java
@@ -45,7 +45,10 @@ import org.apache.hop.mongo.wrapper.cursor.MongoCursorWrapper;
 import org.apache.hop.mongo.wrapper.field.MongoField;
 import org.apache.hop.pipeline.transform.BaseTransformData;
 import org.apache.hop.pipeline.transform.ITransformData;
+import org.bson.BsonType;
 import org.bson.Document;
+import org.bson.json.JsonReader;
+import org.bson.types.ObjectId;
 
 /** Data class for the MongoDbOutput transform */
 @Getter
@@ -815,7 +818,7 @@ public class MongoDbOutputData extends BaseTransformData implements ITransformDa
         {
           String val = hopType.getString(hopValue);
           if (hopValueIsJSON) {
-            valueToSet = Document.parse(val);
+            valueToSet = parseMongoJsonValue(val);
           } else {
             valueToSet = val;
           }
@@ -881,6 +884,32 @@ public class MongoDbOutputData extends BaseTransformData implements ITransformDa
       return true;
     }
     return false;
+  }
+
+  /**
+   * Parse an incoming JSON string that will be written to MongoDB as a BSON value.
+   *
+   * <p>Historically this was a straight {@code Document.parse(val)}. BSON 5.x's parser rejects
+   * top-level BSON extended JSON for non-DOCUMENT types — most notably {@code {"$oid": "..."}} —
+   * with a {@code BsonInvalidOperationException}, because the top-level type is OBJECT_ID rather
+   * than DOCUMENT. That regressed the ability to use {@code _id} (or any ObjectId-typed field) as
+   * an Update match field in the MongoDB Output transform (Apache Hop #7183).
+   *
+   * <p>Detect top-level ObjectId extended JSON and return an {@link ObjectId} directly so the value
+   * is stored with the correct BSON type. Anything else falls through to {@code Document.parse},
+   * preserving prior behaviour for regular embedded documents.
+   *
+   * <p>Package-private for unit testing.
+   */
+  static Object parseMongoJsonValue(String val) {
+    try (JsonReader reader = new JsonReader(val)) {
+      if (reader.readBsonType() == BsonType.OBJECT_ID) {
+        return reader.readObjectId();
+      }
+    } catch (RuntimeException ignore) {
+      // fall through to Document.parse which will surface a consistent error message
+    }
+    return Document.parse(val);
   }
 
   @SuppressWarnings("unchecked")

--- a/plugins/tech/mongodb/src/test/java/org/apache/hop/pipeline/transforms/mongodboutput/MongoDbOutputDataTest.java
+++ b/plugins/tech/mongodb/src/test/java/org/apache/hop/pipeline/transforms/mongodboutput/MongoDbOutputDataTest.java
@@ -267,4 +267,30 @@ class MongoDbOutputDataTest {
     data.setOutputRowMeta(rowMeta);
     assertThat(data.getOutputRowMeta(), equalTo(rowMeta));
   }
+
+  /**
+   * Regression test for #7183. BSON 5.x's Document.parse rejects top-level extended-JSON typed
+   * values like {@code {"$oid": "..."}}. parseMongoJsonValue must recognise that shape and return
+   * an ObjectId with the right value so update match fields on _id continue to work.
+   */
+  @Test
+  void parseMongoJsonValue_topLevelObjectIdExtendedJson_returnsObjectId() {
+    String hex = "6a15efdd0a93aa5ed3b4b947";
+    Object result = MongoDbOutputData.parseMongoJsonValue("{\"$oid\": \"" + hex + "\"}");
+    assertThat(result, instanceOf(org.bson.types.ObjectId.class));
+    assertEquals(hex, ((org.bson.types.ObjectId) result).toHexString());
+  }
+
+  /**
+   * Regression test for #7183. Regular JSON documents (the pre-existing behaviour) must still flow
+   * through Document.parse and produce a Document.
+   */
+  @Test
+  void parseMongoJsonValue_regularDocument_returnsDocument() {
+    Object result = MongoDbOutputData.parseMongoJsonValue("{\"foo\": 1, \"bar\": \"baz\"}");
+    assertThat(result, instanceOf(Document.class));
+    Document doc = (Document) result;
+    assertEquals(1, doc.get("foo"));
+    assertEquals("baz", doc.get("bar"));
+  }
 }


### PR DESCRIPTION
Fixes #7183.

## Problem

Since the BSON driver 5.x upgrade in Hop 2.17, the MongoDB Output transform can no longer use `_id` (or any ObjectId-typed field) as an Update match field.

`MongoDbOutputData.setMongoValueFromHopValue()` calls `Document.parse()` on the incoming JSON string when `json_field=Y`. For an ObjectId field the value is BSON extended JSON of the form `{"$oid": "6a15efdd0a93aa5ed3b4b947"}`. In BSON 4.x, `Document.parse()` accepted this at the top level; in BSON 5.x the parser recognises it as the OBJECT_ID BSON type and rejects it with:

```
BsonInvalidOperationException: readStartDocument can only be called when
CurrentBSONType is DOCUMENT, not when CurrentBSONType is OBJECT_ID.
```

Existing workarounds are unattractive: `json_field=N` produces a `String` that won't match an ObjectId in MongoDB (different BSON types → updates silently match zero documents), and matching on non-`_id` fields sacrifices the built-in `_id` index.

## Fix

Extract the JSON parsing in `setMongoValueFromHopValue()` into a small helper `parseMongoJsonValue(String)` that:

- Peeks the top-level BSON type via a `JsonReader`.
- If it's `OBJECT_ID`, returns a real `ObjectId` so the value is stored with the correct BSON type and the update match works against Mongo's native `_id`.
- Otherwise falls through to `Document.parse(val)`, preserving pre-existing behaviour and the error surface for regular embedded documents.

The helper is package-private for testing.

## Test

Adds two unit tests in `MongoDbOutputDataTest`:

1. `parseMongoJsonValue_topLevelObjectIdExtendedJson_returnsObjectId` — reproduces the exact input from the issue's stack trace and asserts an `ObjectId` with the expected hex is returned (rather than throwing `BsonInvalidOperationException`).
2. `parseMongoJsonValue_regularDocument_returnsDocument` — asserts that regular embedded-JSON documents still flow through `Document.parse` unchanged.

Neither test needs a live MongoDB. Ran `./mvnw spotless:apply` — no formatting changes required.