### PR TITLE
Issue #7968 : Isolate SWT UI tests from the interactive display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,10 @@ concise — we will expand the sections below over time.
 - **Requirements:** Java 21 (JDK) and Maven 3.6.3+ — or use the bundled wrapper
   `./mvnw` (no local Maven needed).
 - **Build + unit tests:** `./mvnw clean install` (build with Java 21, otherwise
-  tests are skipped).
+  tests are skipped). On Linux wrap a desktop run with
+  `./tools/with-isolated-display.sh` so SWT UI tests do not steal the
+  interactive session. `-Pskip-uitest` excludes them; `-Puitest` runs *only*
+  those tests.
 
 ## Conventions
 

--- a/docker/ui-tests/Dockerfile
+++ b/docker/ui-tests/Dockerfile
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Sidecar X server for Hop SWT UI tests. Maven, JDK and GTK stay on the host;
+# this image only provides a virtual display the host Surefire JVMs can use.
+FROM debian:bookworm-slim
+
+LABEL maintainer="Apache Hop Team"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    DISPLAY_NUM=99
+
+RUN apt-get update \
+  && apt-get install --no-install-recommends --assume-yes xvfb \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod 755 /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker/ui-tests/compose.yaml
+++ b/docker/ui-tests/compose.yaml
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Virtual X server for host-side Maven/SWT UI tests.
+# Prefer tools/with-isolated-display.sh, which starts this when xvfb-run is not
+# installed. Do not point DISPLAY at the host desktop and do not run xhost.
+services:
+  xvfb:
+    image: hop-ui-test-xvfb:local
+    build: .
+    init: true
+    network_mode: none
+    environment:
+      DISPLAY_NUM: ${DISPLAY_NUM:-99}
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix

--- a/docker/ui-tests/docker-entrypoint.sh
+++ b/docker/ui-tests/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+# Virtual framebuffer only: unix socket, no TCP, no MIT-SHM (host JVM and this
+# process do not share an IPC namespace). -ac is local-only because we do not
+# listen on the network; it is not xhost on the developer's interactive seat.
+DISPLAY_NUM="${DISPLAY_NUM:-99}"
+mkdir -p /tmp/.X11-unix
+exec Xvfb ":${DISPLAY_NUM}" -ac -screen 0 1280x1024x24 -nolisten tcp -extension MIT-SHM

--- a/docs/hop-dev-manual/modules/ROOT/pages/setup-dev-environment.adoc
+++ b/docs/hop-dev-manual/modules/ROOT/pages/setup-dev-environment.adoc
@@ -81,6 +81,17 @@ Run the following command to build Hop and run all unit tests:
 [source]
 mvn clean install
 
+On Linux a full reactor run also executes the SWT UI tests (`@Tag("uitest")`). Those tests open real dialogs; pointed at your desktop they steal keyboard focus for many minutes. Jenkins already wraps Maven in `xvfb-run`. Locally do the same with the helper, which uses host `xvfb-run` when installed and otherwise starts a tiny Xvfb Docker sidecar (Maven and GTK stay on the host):
+
+[source]
+----
+./tools/with-isolated-display.sh ./mvnw clean install
+----
+
+`-Puitest` means *only* UI tests, not "also enable them". `-Pskip-uitest` is the explicit escape hatch that excludes them. Failed UI tests already write a PNG under `screenshots/` while the shell is still up; do not add success-path screenshot capture.
+
+On macOS the SWT tests use Cocoa (`-XstartOnFirstThread` from the `swt-mac` profile). The helper cannot isolate those windows: a host Cocoa JVM has no X11 socket, and the Linux Xvfb sidecar is not visible to macOS SWT. The script prints a warning and runs the command on the interactive session. Use `-Pskip-uitest` for a focus-free local Mac build. Reviewing the sidecar itself is a Docker image/compose check; running the Linux GTK suite from a Mac host JVM is out of scope.
+
 Please make sure all the files you added or changed have the proper license header.
 You can run the following command to verify this:
 

--- a/plugins/engines/beam/src/test/java/org/apache/hop/beam/transforms/bq/BeamBQOutputDialogTest.java
+++ b/plugins/engines/beam/src/test/java/org/apache/hop/beam/transforms/bq/BeamBQOutputDialogTest.java
@@ -35,8 +35,9 @@ import org.junit.jupiter.api.Test;
 /**
  * SWTBot coverage for {@link BeamBQOutputDialog}. The dialog runs its own blocking event loop in
  * {@code open()}, so {@link SwtBotTestBase#withDialog} pumps it on the UI thread while assertions
- * drive it from a worker. Tagged {@code uitest} so it is excluded from the normal build (needs a
- * display); run with {@code mvn -pl plugins/engines/beam -Puitest test}.
+ * drive it from a worker. Tagged {@code uitest} so it is skipped when there is no display. The
+ * default reactor run still includes it on a desktop; wrap Maven with {@code
+ * tools/with-isolated-display.sh} so the dialog does not steal focus.
  */
 @Tag("uitest")
 class BeamBQOutputDialogTest extends SwtBotTestBase {

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -138,8 +138,9 @@
     </dependencies>
 
     <!-- The SWTBot UI-test stack above is on every plugin's test classpath. The @Tag("uitest")
-         gating and the uitest / swtbot-mac profiles are inherited from the root pom, so a plugin
-         needs no extra config to add a UI test extending org.apache.hop.ui.testing.SwtBotTestBase. -->
+         gating and the uitest / skip-uitest / swt-mac profiles are inherited from the root pom, so
+         a plugin needs no extra config to add a UI test extending
+         org.apache.hop.ui.testing.SwtBotTestBase. -->
 
     <build>
         <plugins>

--- a/plugins/transforms/abort/src/test/java/org/apache/hop/pipeline/transforms/abort/AbortDialogTest.java
+++ b/plugins/transforms/abort/src/test/java/org/apache/hop/pipeline/transforms/abort/AbortDialogTest.java
@@ -38,8 +38,9 @@ import org.junit.jupiter.api.Test;
  * SwtBotTestBase#withDialog} pumps it on the UI thread while the assertions drive it from a worker
  * thread.
  *
- * <p>Tagged {@code uitest} so it is excluded from the normal build (it needs a display); run with
- * {@code mvn -pl plugins/transforms/abort -Puitest test}.
+ * <p>Tagged {@code uitest} so it is skipped when there is no display. The default reactor run still
+ * includes it on a desktop; wrap Maven with {@code tools/with-isolated-display.sh} so the dialog
+ * does not steal focus.
  */
 @Tag("uitest")
 class AbortDialogTest extends SwtBotTestBase {

--- a/plugins/transforms/constant/src/test/java/org/apache/hop/pipeline/transforms/constant/ConstantDialogTest.java
+++ b/plugins/transforms/constant/src/test/java/org/apache/hop/pipeline/transforms/constant/ConstantDialogTest.java
@@ -51,8 +51,9 @@ import org.junit.jupiter.api.Test;
  * real OK/Cancel buttons are clicked so the dialog's own {@code ok()}/{@code cancel()} logic is
  * what gets exercised.
  *
- * <p>Tagged {@code uitest} so it is skipped on headless machines; run with {@code mvn -pl
- * plugins/transforms/constant -Puitest test}.
+ * <p>Tagged {@code uitest} so it is skipped when there is no display. The default reactor run still
+ * includes it on a desktop; wrap Maven with {@code tools/with-isolated-display.sh} so the dialog
+ * does not steal focus.
  */
 @Tag("uitest")
 class ConstantDialogTest extends SwtBotTestBase {

--- a/plugins/transforms/fake/src/test/java/org/apache/hop/pipeline/transforms/fake/FakeDialogTest.java
+++ b/plugins/transforms/fake/src/test/java/org/apache/hop/pipeline/transforms/fake/FakeDialogTest.java
@@ -37,8 +37,9 @@ import org.junit.jupiter.api.Test;
  * {@link SwtBotTestBase#withDialog} pumps it on the UI thread while the assertions drive it from a
  * worker thread.
  *
- * <p>Tagged {@code uitest} so it is only run with a display; run with {@code mvn -pl
- * plugins/transforms/fake -Puitest test}.
+ * <p>Tagged {@code uitest} so it is skipped when there is no display. The default reactor run still
+ * includes it on a desktop; wrap Maven with {@code tools/with-isolated-display.sh} so the dialog
+ * does not steal focus.
  */
 @Tag("uitest")
 class FakeDialogTest extends SwtBotTestBase {

--- a/plugins/transforms/fake/src/test/java/org/apache/hop/pipeline/transforms/fake/FakerBrowserDialogTest.java
+++ b/plugins/transforms/fake/src/test/java/org/apache/hop/pipeline/transforms/fake/FakerBrowserDialogTest.java
@@ -41,8 +41,9 @@ import org.junit.jupiter.api.Test;
  * runs its own blocking event loop in {@code open()}, so {@link SwtBotTestBase#withDialog} pumps it
  * on the UI thread while the assertions drive it from a worker thread.
  *
- * <p>Tagged {@code uitest} so it is only run with a display; run with {@code mvn -pl
- * plugins/transforms/fake -Puitest test}.
+ * <p>Tagged {@code uitest} so it is skipped when there is no display. The default reactor run still
+ * includes it on a desktop; wrap Maven with {@code tools/with-isolated-display.sh} so the dialog
+ * does not steal focus.
  */
 @Tag("uitest")
 class FakerBrowserDialogTest extends SwtBotTestBase {

--- a/plugins/transforms/httppost/src/test/java/org/apache/hop/pipeline/transforms/httppost/HttpPostDialogTest.java
+++ b/plugins/transforms/httppost/src/test/java/org/apache/hop/pipeline/transforms/httppost/HttpPostDialogTest.java
@@ -40,8 +40,9 @@ import org.junit.jupiter.api.Test;
  * loop in {@code open()}, so {@link SwtBotTestBase#withDialog} pumps it on the UI thread while the
  * assertions drive it from a worker thread.
  *
- * <p>Tagged {@code uitest} so it is excluded from the normal build (it needs a display); run with
- * {@code mvn -pl plugins/transforms/httppost -Puitest test}.
+ * <p>Tagged {@code uitest} so it is skipped when there is no display. The default reactor run still
+ * includes it on a desktop; wrap Maven with {@code tools/with-isolated-display.sh} so the dialog
+ * does not steal focus.
  */
 @Tag("uitest")
 class HttpPostDialogTest extends SwtBotTestBase {

--- a/plugins/transforms/selectvalues/src/test/java/org/apache/hop/pipeline/transforms/selectvalues/SelectValuesDialogMetaTabTest.java
+++ b/plugins/transforms/selectvalues/src/test/java/org/apache/hop/pipeline/transforms/selectvalues/SelectValuesDialogMetaTabTest.java
@@ -62,8 +62,9 @@ import org.junit.jupiter.api.Test;
  * #editingTheTypeCellStaysInTheTypeColumn()} is the same scene on a plain CCOMBO column, which is
  * committed correctly today.
  *
- * <p>Tagged {@code uitest} so it is skipped on headless machines; run with {@code mvn -pl
- * plugins/transforms/selectvalues -Puitest test}.
+ * <p>Tagged {@code uitest} so it is skipped when there is no display. The default reactor run still
+ * includes it on a desktop; wrap Maven with {@code tools/with-isolated-display.sh} so the dialog
+ * does not steal focus.
  */
 @Tag("uitest")
 class SelectValuesDialogMetaTabTest extends SwtBotTestBase {

--- a/plugins/transforms/update/src/test/java/org/apache/hop/pipeline/transforms/update/UpdateDialogTest.java
+++ b/plugins/transforms/update/src/test/java/org/apache/hop/pipeline/transforms/update/UpdateDialogTest.java
@@ -54,8 +54,9 @@ import org.junit.jupiter.api.Test;
  * the UI thread) the way {@code ConstantDialogTest} does it. The real OK/Cancel buttons are then
  * clicked so the dialog's own {@code ok()}/{@code cancel()} logic is what gets exercised.
  *
- * <p>Tagged {@code uitest} so it is skipped on headless machines; run with {@code mvn -pl
- * plugins/transforms/update -Puitest test}.
+ * <p>Tagged {@code uitest} so it is skipped when there is no display. The default reactor run still
+ * includes it on a desktop; wrap Maven with {@code tools/with-isolated-display.sh} so the dialog
+ * does not steal focus.
  */
 @Tag("uitest")
 class UpdateDialogTest extends SwtBotTestBase {

--- a/pom.xml
+++ b/pom.xml
@@ -769,11 +769,22 @@
                 </dependencies>
             </dependencyManagement>
         </profile>
+        <!-- uitest: run ONLY @Tag("uitest") classes (needs a display).
+             skip-uitest: exclude them from the reactor run.
+             Default (neither): include them whenever a display is available.
+             On a desktop wrap Maven with tools/with-isolated-display.sh so the
+             shells do not steal the interactive session. -->
         <profile>
             <id>uitest</id>
             <properties>
                 <ui.test.excludedGroups></ui.test.excludedGroups>
                 <ui.test.includedGroups>uitest</ui.test.includedGroups>
+            </properties>
+        </profile>
+        <profile>
+            <id>skip-uitest</id>
+            <properties>
+                <ui.test.excludedGroups>uitest</ui.test.excludedGroups>
             </properties>
         </profile>
         <profile>

--- a/rcp/src/test/java/org/apache/hop/ui/core/database/JdbcDriverDownloadDialogTest.java
+++ b/rcp/src/test/java/org/apache/hop/ui/core/database/JdbcDriverDownloadDialogTest.java
@@ -41,8 +41,9 @@ import org.junit.jupiter.api.Test;
  * SwtBotTestBase#withDialog} pumps it on the UI thread while the assertions drive it from a worker
  * thread. Both tests Cancel before any download, so nothing is fetched over the network.
  *
- * <p>Tagged {@code uitest} so it is excluded from the normal headless build (it needs a display);
- * run with {@code mvn -pl rcp -Puitest test}.
+ * <p>Tagged {@code uitest} so it is skipped when there is no display. The default reactor run still
+ * includes it on a desktop; wrap Maven with {@code tools/with-isolated-display.sh} so the dialog
+ * does not steal focus.
  */
 @Tag("uitest")
 class JdbcDriverDownloadDialogTest extends SwtBotTestBase {

--- a/rcp/src/test/java/org/apache/hop/ui/core/widget/TableViewLeaveEditorTest.java
+++ b/rcp/src/test/java/org/apache/hop/ui/core/widget/TableViewLeaveEditorTest.java
@@ -49,8 +49,9 @@ import org.junit.jupiter.api.Test;
  * the {@code COLUMN_TYPE_TEXT_BUTTON} one, which is a {@link TextVarButton} - a {@link TextVar},
  * not the plain {@link Text} that the type mismatch makes {@code getTextWidgetValue} cast to.
  *
- * <p>Tagged {@code uitest} so it is skipped on headless machines; run with {@code mvn -pl rcp
- * -Puitest test}.
+ * <p>Tagged {@code uitest} so it is skipped when there is no display. The default reactor run still
+ * includes it on a desktop; wrap Maven with {@code tools/with-isolated-display.sh} so the dialog
+ * does not steal focus.
  */
 @Tag("uitest")
 class TableViewLeaveEditorTest extends SwtBotTestBase {

--- a/tools/with-isolated-display.sh
+++ b/tools/with-isolated-display.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Run a command (typically ./mvnw) against a virtual X display so SWT UI tests
+# do not steal the interactive session. Prefers host xvfb-run (what Jenkins
+# uses). Falls back to the docker/ui-tests Xvfb sidecar when xvfb is not
+# installed. Never points Maven at the current seat unless
+# HOP_ALLOW_INTERACTIVE_DISPLAY=1 is set as a last resort.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="${ROOT}/docker/ui-tests/compose.yaml"
+SCREEN_ARGS="${HOP_XVFB_SCREEN:-1280x1024x24}"
+
+usage() {
+  cat <<'EOF'
+Usage: tools/with-isolated-display.sh COMMAND [ARGS...]
+
+Run COMMAND with SWT/GTK talking to a virtual framebuffer instead of the
+interactive X/Wayland session. Example:
+
+  tools/with-isolated-display.sh ./mvnw clean install
+
+Host xvfb-run is used when installed (same as Jenkins). Otherwise a tiny
+Xvfb Docker sidecar is started and DISPLAY is pointed at its unix socket.
+
+Environment:
+  HOP_ALLOW_INTERACTIVE_DISPLAY=1  run on the current DISPLAY if no Xvfb
+                                   or Docker sidecar can be started
+  HOP_XVFB_SCREEN=1280x1024x24     Xvfb screen geometry
+EOF
+}
+
+die() {
+  echo "with-isolated-display: $*" >&2
+  exit 1
+}
+
+warn() {
+  echo "with-isolated-display: $*" >&2
+}
+
+if [[ $# -eq 0 ]]; then
+  usage
+  exit 2
+fi
+
+# Force GTK/SWT onto X11 so a Wayland session does not keep sending windows
+# to the seat we are trying to leave alone.
+isolate_env() {
+  export GDK_BACKEND=x11
+  unset WAYLAND_DISPLAY || true
+}
+
+run_on_interactive_display() {
+  warn "running on the interactive display; SWT shells will steal focus"
+  exec "$@"
+}
+
+if command -v xvfb-run >/dev/null 2>&1; then
+  isolate_env
+  exec env -u WAYLAND_DISPLAY GDK_BACKEND=x11 \
+    xvfb-run -a --server-args="-screen 0 ${SCREEN_ARGS}" "$@"
+fi
+
+# xvfb-run is a Linux/X11 tool. A Cocoa or Win32 SWT JVM cannot use this
+# sidecar; say so and run the command as-is rather than pretending.
+os="$(uname -s || echo unknown)"
+if [[ "${os}" != "Linux" ]]; then
+  warn "isolated X11 display is Linux-only (${os}); SWT will use the interactive session"
+  exec "$@"
+fi
+
+have_docker=0
+if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+  have_docker=1
+fi
+
+if [[ "${have_docker}" -ne 1 ]]; then
+  if [[ "${HOP_ALLOW_INTERACTIVE_DISPLAY:-}" == "1" ]]; then
+    run_on_interactive_display "$@"
+  fi
+  die "neither xvfb-run nor Docker is available. Install xvfb (preferred) or Docker, or set HOP_ALLOW_INTERACTIVE_DISPLAY=1"
+fi
+
+display_busy() {
+  local n="$1"
+  [[ -e "/tmp/.X11-unix/X${n}" || -e "/tmp/.X${n}-lock" ]]
+}
+
+pick_display() {
+  local n
+  for n in $(seq 99 199); do
+    if ! display_busy "${n}"; then
+      echo "${n}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+DISPLAY_NUM="$(pick_display)" || die "no free X display in :99-:199"
+
+SIDECAR_COMPOSE=0
+SIDECAR_CID=""
+COMPOSE_PROJECT="hop-xvfb-$$-${DISPLAY_NUM}"
+
+compose_bin() {
+  if docker compose version >/dev/null 2>&1; then
+    echo "docker compose"
+    return 0
+  fi
+  if command -v docker-compose >/dev/null 2>&1; then
+    echo "docker-compose"
+    return 0
+  fi
+  return 1
+}
+
+stop_sidecar() {
+  if [[ "${SIDECAR_COMPOSE}" -eq 1 ]]; then
+    # shellcheck disable=SC2086
+    DISPLAY_NUM="${DISPLAY_NUM}" ${COMPOSE} -f "${COMPOSE_FILE}" -p "${COMPOSE_PROJECT}" \
+      down --remove-orphans >/dev/null 2>&1 || true
+  elif [[ -n "${SIDECAR_CID}" ]]; then
+    docker stop "${SIDECAR_CID}" >/dev/null 2>&1 || true
+  fi
+}
+
+start_sidecar() {
+  local compose_cmd
+  if compose_cmd="$(compose_bin)"; then
+    COMPOSE="${compose_cmd}"
+    # shellcheck disable=SC2086
+    DISPLAY_NUM="${DISPLAY_NUM}" ${COMPOSE} -f "${COMPOSE_FILE}" -p "${COMPOSE_PROJECT}" \
+      up -d --build
+    SIDECAR_COMPOSE=1
+    return 0
+  fi
+
+  docker build -t hop-ui-test-xvfb:local "${ROOT}/docker/ui-tests"
+  SIDECAR_CID="$(
+    docker run -d --rm --network none --init \
+      -e "DISPLAY_NUM=${DISPLAY_NUM}" \
+      -v /tmp/.X11-unix:/tmp/.X11-unix \
+      --name "${COMPOSE_PROJECT}" \
+      hop-ui-test-xvfb:local
+  )"
+}
+
+sidecar_logs() {
+  if [[ "${SIDECAR_COMPOSE}" -eq 1 ]]; then
+    # shellcheck disable=SC2086
+    DISPLAY_NUM="${DISPLAY_NUM}" ${COMPOSE} -f "${COMPOSE_FILE}" -p "${COMPOSE_PROJECT}" \
+      logs >&2 || true
+  elif [[ -n "${SIDECAR_CID}" ]]; then
+    docker logs "${SIDECAR_CID}" >&2 || true
+  fi
+}
+
+wait_for_display() {
+  local n="$1"
+  local i
+  for i in $(seq 1 100); do
+    if [[ -S "/tmp/.X11-unix/X${n}" ]]; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  sidecar_logs
+  return 1
+}
+
+trap stop_sidecar EXIT INT TERM
+
+warn "xvfb-run not found; starting Docker Xvfb sidecar on :${DISPLAY_NUM}"
+start_sidecar
+wait_for_display "${DISPLAY_NUM}" || die "Xvfb sidecar did not create /tmp/.X11-unix/X${DISPLAY_NUM}"
+
+isolate_env
+export DISPLAY=":${DISPLAY_NUM}"
+"$@"

--- a/ui/src/test/java/org/apache/hop/ui/testing/SwtBotTestBase.java
+++ b/ui/src/test/java/org/apache/hop/ui/testing/SwtBotTestBase.java
@@ -42,6 +42,12 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+/**
+ * Shared SWTBot harness for {@code @Tag("uitest")} tests. The default reactor run includes those
+ * tests whenever a display is available; they are skipped only when the JVM is headless. On a
+ * desktop wrap Maven with {@code tools/with-isolated-display.sh} so the shells do not steal the
+ * interactive session. {@code -Puitest} runs only UI tests; {@code -Pskip-uitest} excludes them.
+ */
 @ExtendWith(SWTBotJunit5Extension.class)
 public abstract class SwtBotTestBase {
 


### PR DESCRIPTION
## Summary

Addresses #7968: a desktop `./mvnw clean install` still runs the SWTBot `@Tag("uitest")` suite on the interactive display, so dialogs steal focus for ~15 minutes.

This does **not** move Maven into Docker. It moves the **display**:

- `tools/with-isolated-display.sh` wraps any command (typically `./mvnw`)
- On Linux it prefers host `xvfb-run` (same as Jenkins)
- If `xvfb-run` is missing, it starts the tiny Xvfb sidecar in `docker/ui-tests/` and points `DISPLAY` at the Unix socket
- `-Pskip-uitest` is the explicit escape hatch
- `-Puitest` still means **only** UI tests

`DISPLAY=docker-host:0` + `xhost` is **not** used. That pattern puts container windows on the host desktop and still steals focus. The sidecar is Unix-socket only (`network_mode: none`, `-nolisten tcp`). MIT-SHM is disabled so the host JVM does not need `ipc: host`.

No success-path screenshots. Failure PNGs already come from `SwtBotTestBase.captureLiveScreenshot`; Jenkins already archives `**/screenshots/**`.

## Test plan

- [x] `tools/with-isolated-display.sh` with no args prints usage (exit 2)
- [x] Host `xvfb-run` path: `DISPLAY` becomes `:99`, `xdpyinfo` works, host `xhost` on `:0` unchanged
- [x] Docker sidecar: `DISPLAY_NUM=143 docker compose -f docker/ui-tests/compose.yaml up --build` creates `/tmp/.X11-unix/X143`, host `xdpyinfo -display :143` works, socket gone after `down`
- [x] `./mvnw -Pskip-uitest -pl plugins/transforms/abort -Dtest=AbortDialogTest test` → Tests run: 0
- [x] `./tools/with-isolated-display.sh ./mvnw -pl plugins/transforms/abort -Dtest=AbortDialogTest test` → 2 tests pass, `_NET_ACTIVE_WINDOW` unchanged
- [x] Spotless check on touched modules
- [x] `./mvnw -N apache-rat:check` (Unapproved: 0)
- [ ] @hansva macOS review (see below)

Fixes #7968

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

## Review notes for @hansva (macOS)

Hans, this isolation is **Linux X11 / GTK only**. On your Mac the SWT artifact is Cocoa (`swt-mac` + `-XstartOnFirstThread`). Please do **not** treat a focus-free full `mvn clean install` as the acceptance test on OSX.

### What this will *not* do on a Mac

- `./tools/with-isolated-display.sh ./mvnw …` prints a warning and runs the command on the interactive session. Cocoa windows will still pop up and steal focus. That is expected.
- Binding a Linux Xvfb socket to the Mac host does **not** give a Mac JVM an X11 display. Docker Desktop does not make `/tmp/.X11-unix` useful to Cocoa SWT.
- XQuartz + `DISPLAY=:0` / `xhost +` is **not** the review path. Even if XQuartz is installed, Hop on macOS is still Cocoa, not `org.eclipse.swt.gtk`.
- `DISPLAY=docker-host:0` + `xhost` was considered and rejected: that is the “show container GUIs on my desktop” pattern.

### What to review on OSX

1. **Script honesty**
   ```bash
   ./tools/with-isolated-display.sh true
   ```
   You should see: `isolated X11 display is Linux-only (Darwin); SWT will use the interactive session`.

2. **Skip profile (this is the Mac focus-free option)**
   ```bash
   ./mvnw -Pskip-uitest -pl plugins/transforms/abort -Dtest=AbortDialogTest test
   ```
   Expected: `Tests run: 0`. Then, if you want to confirm Cocoa still works:
   ```bash
   ./mvnw -pl plugins/transforms/abort -Dtest=AbortDialogTest test
   ```
   Expected: 2 tests pass, and the Abort dialog **will** appear. `-XstartOnFirstThread` should still be applied by `swt-mac`.

3. **Docker image/compose only** (optional)
   ```bash
   docker compose -f docker/ui-tests/compose.yaml up --build
   docker compose -f docker/ui-tests/compose.yaml down
   ```
   Expected: image builds, container stays up. Do **not** expect `DISPLAY=:99 ./mvnw …` on the Mac host to talk to that Xvfb. Running the Linux GTK suite from a Mac host JVM is out of scope here.

4. **Docs** — please read the new paragraph in `docs/hop-dev-manual/modules/ROOT/pages/setup-dev-environment.adoc` and say if the macOS wording is clear enough for other Mac contributors.

Linux GTK isolation was already checked on my machine (`AbortDialogTest` under the wrapper, focus window unchanged). Jenkins is unchanged and already uses `xvfb-run`.