### PR TITLE
Fix Multi Mapping metadata injection test keys

### DIFF
--- a/plugins/transforms/mapping/src/test/java/org/apache/hop/pipeline/transforms/multimapping/MultiMappingMetaInjectionTest.java
+++ b/plugins/transforms/mapping/src/test/java/org/apache/hop/pipeline/transforms/multimapping/MultiMappingMetaInjectionTest.java
@@ -18,6 +18,7 @@ package org.apache.hop.pipeline.transforms.multimapping;
 
 import org.apache.hop.core.injection.BaseMetadataInjectionTestJunit5;
 import org.apache.hop.junit.rules.RestoreHopEngineEnvironmentExtension;
+import org.apache.hop.pipeline.transforms.mapping.MappingVariableMapping;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -34,6 +35,7 @@ class MultiMappingMetaInjectionTest extends BaseMetadataInjectionTestJunit5<Mult
     meta.getInputMappings().get(0).getValueRenames().add(new MultiMappingInputRename());
     meta.getOutputMappings().add(new MultiMappingOutputDefinition());
     meta.getOutputMappings().get(0).getValueRenames().add(new MultiMappingOutputRename());
+    meta.getMappingParameters().getVariableMappings().add(new MappingVariableMapping());
     setup(meta);
   }
 
@@ -53,16 +55,12 @@ class MultiMappingMetaInjectionTest extends BaseMetadataInjectionTestJunit5<Mult
     check("OUTPUT_DESCRIPTION", () -> meta.getOutputMappings().get(0).getDescription());
     check("OUTPUT_MAIN_PATH", () -> meta.getOutputMappings().get(0).isMainDataPath());
     check("OUTPUT_RENAME_ON_OUTPUT", () -> meta.getOutputMappings().get(0).isRenamingOnOutput());
-    check("inherit_all_vars", () -> meta.getMappingParameters().isInheritingAllVariables());
-    skipPropertyTest("variable");
-    skipPropertyTest("input");
+    check("INHERIT_ALL_VARIABLES", () -> meta.getMappingParameters().isInheritingAllVariables());
+    check("VARIABLE", () -> meta.getMappingParameters().getVariableMappings().get(0).getName());
+    check("VALUE", () -> meta.getMappingParameters().getVariableMappings().get(0).getValue());
     skipPropertyTest("INPUT_RENAME_SOURCE");
     skipPropertyTest("INPUT_RENAME_TARGET");
     skipPropertyTest("OUTPUT_RENAME_SOURCE");
     skipPropertyTest("OUTPUT_RENAME_TARGET");
-    skipPropertyTest("mappings");
-    skipPropertyTest("parameters");
-    skipPropertyTest("mapping");
-    skipPropertyTest("connector");
   }
 }


### PR DESCRIPTION
## Summary

The Multi Mapping transform landed on `main` in #7958 with a broken metadata-injection unit test. `MultiMappingMetaInjectionTest` injects the XML key `inherit_all_vars` and skips the XML names `variable` / `input`. `BeanInjectionInfo` only registers the injection keys from `MappingParameters` / `MappingVariableMapping`:

- `INHERIT_ALL_VARIABLES`
- `VARIABLE`
- `VALUE`

CI on any PR based on current `main` therefore fails in `hop-transform-mapping`:

```
Property 'inherit_all_vars' not found for injection to class ...MultiMappingMeta
Some properties where not tested: [VALUE, VARIABLE, INHERIT_ALL_VARIABLES]
```

This is a one-file test fix. It unblocks #7967, #7969, and any other open PR that is otherwise green.

Same change is already on #7970. I will cherry-pick it onto #7969. #7967 is on @hansva's fork so that branch needs this commit or a rebase once this merges.

## Test plan

- [x] `./mvnw -pl plugins/transforms/mapping -Dtest=MultiMappingMetaInjectionTest test` — Tests run: 1, Failures: 0

Fixes the CI failure introduced by #7958.

------------------------

- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).