### PR TITLE
Fix#6122  Give Get files from result a distinct icon

### DIFF
--- a/docs/hop-user-manual/modules/ROOT/assets/images/transforms/icons/filesfromresult.svg
+++ b/docs/hop-user-manual/modules/ROOT/assets/images/transforms/icons/filesfromresult.svg
@@ -1,23 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 17.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px"
      width="42px" height="42px" viewBox="0 0 42 42" enable-background="new 0 0 42 42">
     <g>
-        <polygon fill="#0E3A5A" points="37.309,32.756 37.309,35.839 32.084,30.615 30.74,31.958 35.966,37.183 32.82,37.184 32.82,39.084
-		39.21,39.083 39.21,32.756 	"/>
-        <path fill="#C9E8FB" d="M25.725,9.674V5.416h-13.38v20.339h-1.699h-0.007v1.203h3.082h6.137v2.046v2.523h2.309v-0.002v-1.699h4.28
-		l3.583-3.583l-0.047-16.57H25.725z M18.444,21.405h-3.201v-0.801h3.201V21.405z M27.145,18.022H15.243v-0.801h11.902V18.022z
-		 M27.145,14.639H15.243v-0.801h11.902V14.639z"/>
-        <polygon fill="#0E3A5A" points="22.167,31.526 24.748,31.526 26.447,29.826 22.167,29.826 	"/>
-        <polygon fill="#0E3A5A" points="31.682,9.684 29.973,7.975 27.425,7.975 27.425,5.427 25.715,3.717 10.646,3.717 10.646,25.755
-		12.346,25.755 12.346,5.416 25.725,5.416 25.725,9.674 29.982,9.674 30.03,26.244 31.725,24.548 	"/>
-        <rect x="15.243" y="13.838" fill="#0E3A5A" width="11.902" height="0.801"/>
-        <rect x="15.243" y="17.221" fill="#0E3A5A" width="11.902" height="0.801"/>
-        <rect x="15.243" y="20.604" fill="#0E3A5A" width="3.201" height="0.801"/>
-        <path fill="#C9E8FB" d="M5.444,33.371h13.414v-5.413H5.444V33.371z M6.85,30.264h10.601v0.801H6.85V30.264z"/>
-        <path fill="#0E3A5A" d="M19.858,26.958h-6.137h-3.082H4.444v7.413h15.414v-2.844v-2.523V26.958z M18.858,33.371H5.444v-5.413
-		h13.414V33.371z"/>
-        <rect x="6.85" y="30.264" fill="#0E3A5A" width="10.601" height="0.801"/>
+        <!-- folder -->
+        <path fill="#0E3A5A" d="M4,19 L15,19 L17.5,21.5 L31,21.5 L31,35.5 L4,35.5 Z"/>
+        <path fill="#C9E8FB" d="M5.5,23 L29.5,23 L29.5,34 L5.5,34 Z"/>
+        <!-- generic files inside folder -->
+        <rect x="8.5" y="26.2" fill="#0E3A5A" width="17" height="1.4"/>
+        <rect x="8.5" y="29.6" fill="#0E3A5A" width="11" height="1.4"/>
+        <!-- result table (rows/columns grid) -->
+        <g fill="#0E3A5A">
+            <rect x="24" y="4" width="6.2" height="3.4"/>
+            <rect x="31.2" y="4" width="6.2" height="3.4"/>
+            <rect x="24" y="8.4" width="6.2" height="3.4"/>
+            <rect x="31.2" y="8.4" width="6.2" height="3.4"/>
+        </g>
+        <!-- arrow from result table down into folder -->
+        <rect x="26" y="12.5" width="2.2" height="4.5" fill="#0E3A5A"/>
+        <polygon fill="#0E3A5A" points="23.3,17 30.9,17 27.1,21.3"/>
     </g>
 </svg>

--- a/plugins/transforms/filesfromresult/src/main/resources/filesfromresult.svg
+++ b/plugins/transforms/filesfromresult/src/main/resources/filesfromresult.svg
@@ -1,23 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 17.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px"
      width="42px" height="42px" viewBox="0 0 42 42" enable-background="new 0 0 42 42">
     <g>
-        <polygon fill="#0E3A5A" points="37.309,32.756 37.309,35.839 32.084,30.615 30.74,31.958 35.966,37.183 32.82,37.184 32.82,39.084
-		39.21,39.083 39.21,32.756 	"/>
-        <path fill="#C9E8FB" d="M25.725,9.674V5.416h-13.38v20.339h-1.699h-0.007v1.203h3.082h6.137v2.046v2.523h2.309v-0.002v-1.699h4.28
-		l3.583-3.583l-0.047-16.57H25.725z M18.444,21.405h-3.201v-0.801h3.201V21.405z M27.145,18.022H15.243v-0.801h11.902V18.022z
-		 M27.145,14.639H15.243v-0.801h11.902V14.639z"/>
-        <polygon fill="#0E3A5A" points="22.167,31.526 24.748,31.526 26.447,29.826 22.167,29.826 	"/>
-        <polygon fill="#0E3A5A" points="31.682,9.684 29.973,7.975 27.425,7.975 27.425,5.427 25.715,3.717 10.646,3.717 10.646,25.755
-		12.346,25.755 12.346,5.416 25.725,5.416 25.725,9.674 29.982,9.674 30.03,26.244 31.725,24.548 	"/>
-        <rect x="15.243" y="13.838" fill="#0E3A5A" width="11.902" height="0.801"/>
-        <rect x="15.243" y="17.221" fill="#0E3A5A" width="11.902" height="0.801"/>
-        <rect x="15.243" y="20.604" fill="#0E3A5A" width="3.201" height="0.801"/>
-        <path fill="#C9E8FB" d="M5.444,33.371h13.414v-5.413H5.444V33.371z M6.85,30.264h10.601v0.801H6.85V30.264z"/>
-        <path fill="#0E3A5A" d="M19.858,26.958h-6.137h-3.082H4.444v7.413h15.414v-2.844v-2.523V26.958z M18.858,33.371H5.444v-5.413
-		h13.414V33.371z"/>
-        <rect x="6.85" y="30.264" fill="#0E3A5A" width="10.601" height="0.801"/>
+        <!-- folder -->
+        <path fill="#0E3A5A" d="M4,19 L15,19 L17.5,21.5 L31,21.5 L31,35.5 L4,35.5 Z"/>
+        <path fill="#C9E8FB" d="M5.5,23 L29.5,23 L29.5,34 L5.5,34 Z"/>
+        <!-- generic files inside folder -->
+        <rect x="8.5" y="26.2" fill="#0E3A5A" width="17" height="1.4"/>
+        <rect x="8.5" y="29.6" fill="#0E3A5A" width="11" height="1.4"/>
+        <!-- result table (rows/columns grid) -->
+        <g fill="#0E3A5A">
+            <rect x="24" y="4" width="6.2" height="3.4"/>
+            <rect x="31.2" y="4" width="6.2" height="3.4"/>
+            <rect x="24" y="8.4" width="6.2" height="3.4"/>
+            <rect x="31.2" y="8.4" width="6.2" height="3.4"/>
+        </g>
+        <!-- arrow from result table down into folder -->
+        <rect x="26" y="12.5" width="2.2" height="4.5" fill="#0E3A5A"/>
+        <polygon fill="#0E3A5A" points="23.3,17 30.9,17 27.1,21.3"/>
     </g>
 </svg>


### PR DESCRIPTION
Fix https://github.com/apache/hop/issues/6122

## Changes
- Updated the Get files from result (`filesfromresult.svg`) transform icon in the plugin and the user manual.
- The previous icon was almost identical to Get file names (`getfilenames.svg`), which made the two transforms hard to tell apart in Hop Gui.
- The new icon uses a result table with an arrow into a folder, so it better represents reading files from the pipeline result.
- No functional changes were made.