### PR TITLE
Fix#8010  NPE when opening Search plugin options in Configuration perspective

### DIFF
--- a/ui/src/main/java/org/apache/hop/ui/core/gui/GuiCompositeWidgets.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/gui/GuiCompositeWidgets.java
@@ -1200,7 +1200,7 @@ public class GuiCompositeWidgets {
             break;
           case CHECKBOX:
             Button button = (Button) control;
-            button.setSelection((Boolean) value);
+            button.setSelection(Boolean.TRUE.equals(value));
             break;
           case COMBO:
             if (guiElements.isVariablesEnabled()) {

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/search/config/SearchConfigPlugin.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/search/config/SearchConfigPlugin.java
@@ -17,6 +17,8 @@
 
 package org.apache.hop.ui.hopgui.search.config;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.hop.core.config.plugin.ConfigPlugin;
 import org.apache.hop.core.config.plugin.IConfigOptions;
 import org.apache.hop.core.exception.HopException;
@@ -36,6 +38,8 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Control;
 import picocli.CommandLine;
 
+@Getter
+@Setter
 @ConfigPlugin(
     id = "SearchConfigPlugin",
     description = "Configuration options for Hop GUI search",


### PR DESCRIPTION
Fix https://github.com/apache/hop/issues/8010

## Summary

Opening **Configuration → Plugins → Search** crashed the GUI with:

`SearchConfigPlugin` exposed `@GuiWidgetElement` fields but had no JavaBean getters. 

## Changes

- Add Lombok `@Getter` / `@Setter` on `SearchConfigPlugin`, matching other config plugins such as `ExplorerPerspectiveConfigPlugin`.
- Treat a null checkbox value as unselected (`Boolean.TRUE.equals(value)`) in `GuiCompositeWidgets`, so a missing getter cannot take down the whole options page.