### PR TITLE
Issue #3270 : Restrict external access when building XSD validator schemas

### DIFF
--- a/core/src/main/java/org/apache/hop/core/xml/XmlParserFactoryProducer.java
+++ b/core/src/main/java/org/apache/hop/core/xml/XmlParserFactoryProducer.java
@@ -21,6 +21,7 @@ import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
+import javax.xml.validation.SchemaFactory;
 import org.apache.hop.core.Const;
 import org.apache.hop.core.logging.LogChannel;
 import org.apache.hop.core.util.EnvUtil;
@@ -28,6 +29,14 @@ import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
 
 public class XmlParserFactoryProducer {
+
+  /**
+   * Value for {@link XMLConstants#ACCESS_EXTERNAL_SCHEMA} that keeps schema resolution on the local
+   * file system. {@code xs:include} and {@code xs:import} of a local schema document still resolve,
+   * while a fetch over http, https or ftp is refused.
+   */
+  private static final String LOCAL_FILE_ACCESS_ONLY = "file";
+
   private XmlParserFactoryProducer() {
     // Static class
   }
@@ -105,6 +114,32 @@ public class XmlParserFactoryProducer {
     factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
     factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
     factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+
+    return factory;
+  }
+
+  /**
+   * Creates an instance of {@link SchemaFactory} class with enabled {@link
+   * XMLConstants#FEATURE_SECURE_PROCESSING} property, external DTD access denied and external
+   * schema access restricted to the local file system.
+   *
+   * <p>Hardening the factory matters separately from hardening the {@link
+   * javax.xml.validation.Validator} it produces: the factory is what resolves the schema document
+   * itself, so without these restrictions a schema is free to pull in a DTD or another schema over
+   * the network before any validation begins.
+   *
+   * @param schemaLanguage the schema language URI, e.g. {@link XMLConstants#W3C_XML_SCHEMA_NS_URI}
+   * @throws SAXNotRecognizedException When the underlying parser does not recognize the property
+   *     name.
+   * @throws SAXNotSupportedException When the underlying parser recognizes the property name but
+   *     doesn't support the property.
+   */
+  public static SchemaFactory createSecureSchemaFactory(String schemaLanguage)
+      throws SAXNotRecognizedException, SAXNotSupportedException {
+    SchemaFactory factory = SchemaFactory.newInstance(schemaLanguage);
+    factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, LOCAL_FILE_ACCESS_ONLY);
 
     return factory;
   }

--- a/core/src/test/java/org/apache/hop/core/xml/XmlUtilsTest.java
+++ b/core/src/test/java/org/apache/hop/core/xml/XmlUtilsTest.java
@@ -17,12 +17,20 @@
 
 package org.apache.hop.core.xml;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.SAXParserFactory;
+import javax.xml.validation.SchemaFactory;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.xml.sax.SAXException;
 
 /** Unit test for {@link XmlParserFactoryProducer} */
 class XmlUtilsTest {
@@ -39,5 +47,61 @@ class XmlUtilsTest {
     SAXParserFactory saxParserFactory = XmlParserFactoryProducer.createSecureSAXParserFactory();
 
     assertTrue(saxParserFactory.getFeature(XMLConstants.FEATURE_SECURE_PROCESSING));
+  }
+
+  @Test
+  void secureFeatureEnabledAfterSchemaFactoryCreation() throws Exception {
+    SchemaFactory schemaFactory =
+        XmlParserFactoryProducer.createSecureSchemaFactory(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+
+    assertTrue(schemaFactory.getFeature(XMLConstants.FEATURE_SECURE_PROCESSING));
+  }
+
+  // The accessExternalDTD / accessExternalSchema values cannot be read back from Xerces'
+  // XMLSchemaFactory -- setProperty accepts them but getProperty rejects them as unrecognized -- so
+  // the two tests below assert their effect instead.
+
+  @Test
+  void secureSchemaFactoryRefusesRemoteSchemaReference(@TempDir Path tempDir) throws Exception {
+    // The host is never contacted: access is refused by the accessExternalSchema restriction
+    // before any network I/O is attempted.
+    Path schema = tempDir.resolve("remote-include.xsd");
+    Files.writeString(
+        schema,
+        "<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">"
+            + "<xs:include schemaLocation=\"http://hop.apache.org.invalid/stolen.xsd\"/>"
+            + "</xs:schema>");
+
+    SchemaFactory schemaFactory =
+        XmlParserFactoryProducer.createSecureSchemaFactory(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+
+    SAXException e =
+        assertThrows(SAXException.class, () -> schemaFactory.newSchema(schema.toFile()));
+    assertTrue(
+        e.getMessage().contains("access is not allowed"),
+        "expected an access restriction failure but got: " + e.getMessage());
+  }
+
+  @Test
+  void secureSchemaFactoryStillResolvesLocalSchemaReference(@TempDir Path tempDir)
+      throws Exception {
+    // Restricting external access must not break multi-file schemas on the local file system.
+    Files.writeString(
+        tempDir.resolve("included.xsd"),
+        "<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">"
+            + "<xs:element name=\"included\" type=\"xs:string\"/>"
+            + "</xs:schema>");
+    File including = tempDir.resolve("including.xsd").toFile();
+    Files.writeString(
+        including.toPath(),
+        "<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">"
+            + "<xs:include schemaLocation=\"included.xsd\"/>"
+            + "<xs:element name=\"root\" type=\"xs:string\"/>"
+            + "</xs:schema>");
+
+    SchemaFactory schemaFactory =
+        XmlParserFactoryProducer.createSecureSchemaFactory(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+
+    assertDoesNotThrow(() -> schemaFactory.newSchema(including));
   }
 }

--- a/plugins/actions/xml/src/main/java/org/apache/hop/workflow/actions/xml/xsdvalidator/XsdValidator.java
+++ b/plugins/actions/xml/src/main/java/org/apache/hop/workflow/actions/xml/xsdvalidator/XsdValidator.java
@@ -26,6 +26,7 @@ import static org.apache.hop.workflow.action.validator.AndValidator.putValidator
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import javax.xml.XMLConstants;
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
@@ -43,6 +44,7 @@ import org.apache.hop.core.exception.HopFileException;
 import org.apache.hop.core.util.Utils;
 import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.core.vfs.HopVfs;
+import org.apache.hop.core.xml.XmlParserFactoryProducer;
 import org.apache.hop.i18n.BaseMessages;
 import org.apache.hop.metadata.api.HopMetadataProperty;
 import org.apache.hop.metadata.api.IHopMetadataProvider;
@@ -133,8 +135,14 @@ public class XsdValidator extends ActionBase implements Cloneable, IAction {
       String realxmlfilename = getRealxmlfilename();
       xmlfile = getFile(realxmlfilename);
 
+      // The factory resolves the schema document itself, so it needs the same external-access
+      // restrictions as the validator it produces. Honour the action's own opt-in so a workflow
+      // that deliberately relies on remote schemas keeps working.
       SchemaFactory factorytXSDValidator1 =
-          SchemaFactory.newInstance("http://www.w3.org/2001/XMLSchema");
+          isAllowExternalEntities()
+              ? SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
+              : XmlParserFactoryProducer.createSecureSchemaFactory(
+                  XMLConstants.W3C_XML_SCHEMA_NS_URI);
 
       if (xsdSource.equals(SPECIFY_FILENAME)) {
         validateNonNullFileName(xsdFilename, "ActionXSDValidator.XsdFileNotNull.Label", result);

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xsdvalidator/XsdValidator.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xsdvalidator/XsdValidator.java
@@ -34,6 +34,7 @@ import org.apache.hop.core.exception.HopFileException;
 import org.apache.hop.core.exception.HopTransformException;
 import org.apache.hop.core.row.RowDataUtil;
 import org.apache.hop.core.vfs.HopVfs;
+import org.apache.hop.core.xml.XmlParserFactoryProducer;
 import org.apache.hop.i18n.BaseMessages;
 import org.apache.hop.pipeline.Pipeline;
 import org.apache.hop.pipeline.PipelineMeta;
@@ -132,8 +133,14 @@ public class XsdValidator extends BaseTransform<XsdValidatorMeta, XsdValidatorDa
 
       try {
 
+        // The factory resolves the schema document itself, so it needs the same external-access
+        // restrictions as the validator it produces. Honour the transform's own opt-in so a
+        // pipeline that deliberately relies on remote schemas keeps working.
         SchemaFactory factoryXSDValidator =
-            SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            meta.isAllowExternalEntities()
+                ? SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
+                : XmlParserFactoryProducer.createSecureSchemaFactory(
+                    XMLConstants.W3C_XML_SCHEMA_NS_URI);
 
         // Get XML stream
         Source sourceXML = getSourceXML(getInputRowMeta().getString(row, data.xmlindex));


### PR DESCRIPTION
Addresses #3270.

The XSD validator transform and the XSD validator action both harden the `Validator` they create
against XXE, but neither configures the `SchemaFactory` that produces it. The factory is what
resolves the schema document itself, so before validation even begins a schema was free to pull in
an external DTD or another schema over the network — and in the "no need to specify XSD" mode the
XML document chooses that location itself through `xsi:schemaLocation`.

This adds `XmlParserFactoryProducer.createSecureSchemaFactory(String)` next to the existing
`createSecureDocBuilderFactory` and `createSecureSAXParserFactory` helpers, and uses it from both
call sites.

### Why external schema access is restricted rather than denied

The obvious fix — enable `FEATURE_SECURE_PROCESSING` and set both access properties to `""` — is a
regression. With secure processing on, Xerces refuses *every* external schema reference, including
`xs:include` and `xs:import` of a schema document sitting next to the first one on local disk. Any
multi-file XSD stops compiling.

So `accessExternalSchema` is set to `file` instead of `""`: local schema composition keeps working
while a fetch over http, https or ftp is refused. `accessExternalDTD` is denied outright, since a
DTD reference from inside an XSD has no legitimate use here.

Both call sites keep honouring their existing `allowExternalEntities` option, so a pipeline or
workflow that deliberately relies on remote schemas is unaffected — it opts out exactly as it
already does for the validator.

### Tests

Three tests in `XmlUtilsTest`, which is the existing unit test for `XmlParserFactoryProducer`:

- the factory reports `FEATURE_SECURE_PROCESSING` enabled
- a schema whose `xs:include` points at an http URL is refused, with the access-restriction message,
  without contacting the host
- a schema whose `xs:include` points at a sibling file on disk still compiles

Both behavioural tests fail if the change is reverted, in opposite directions: without the
restrictions the remote reference is fetched instead of refused, and with `accessExternalSchema` set
to `""` rather than `file` the local include stops resolving.

One note for reviewers: Xerces' `XMLSchemaFactory` accepts `setProperty` for `accessExternalDTD` but
rejects `getProperty` for the same name as unrecognized, so the two property values are asserted
through their effect rather than read back.

### Verification

- `mvn -pl core -Dtest=XmlUtilsTest test` — 5/5 pass
- `mvn -pl plugins/transforms/xml,plugins/actions/xml -Pskip-uitest test` — 153 pass, 0 failures,
  including the existing `XsdValidatorIntTest`
- `mvn spotless:check` and `mvn apache-rat:check` pass on the three touched modules

------------------------

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
