### PR TITLE
fix(execution): exclude parameterValues from Execution JSON serialization

### DIFF
--- a/engine/src/main/java/org/apache/hop/execution/Execution.java
+++ b/engine/src/main/java/org/apache/hop/execution/Execution.java
@@ -81,7 +81,7 @@ public class Execution {
   private LogLevel logLevel;
 
   /** The parameters used to execute */
-  private Map<String, String> parameterValues;
+  @JsonIgnore private Map<String, String> parameterValues;
 
   /** Details about the environment */
   private Map<String, String> environmentDetails;

--- a/engine/src/test/java/org/apache/hop/execution/ExecutionTest.java
+++ b/engine/src/test/java/org/apache/hop/execution/ExecutionTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.hop.execution;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.StringWriter;
+import java.util.Map;
+import org.apache.hop.core.json.HopJson;
+import org.junit.jupiter.api.Test;
+
+class ExecutionTest {
+
+  @Test
+  void testParameterValuesNotSerialized() throws Exception {
+    Execution execution = new Execution();
+    execution.setName("test-execution");
+    execution.setParameterValues(Map.of("dbPassword", "shouldNeverLeak"));
+    execution.setVariableValues(Map.of("apiToken", "shouldAlsoNeverLeak"));
+
+    StringWriter writer = new StringWriter();
+    HopJson.newMapper().writeValue(writer, execution);
+    String json = writer.toString();
+
+    assertFalse(
+        json.contains("shouldNeverLeak"),
+        "parameterValues must not appear in serialized JSON, same as variableValues");
+    assertFalse(json.contains("shouldAlsoNeverLeak"), "variableValues must not be serialized");
+    assertFalse(json.contains("parameterValues"), "parameterValues key must not be serialized");
+    assertFalse(json.contains("variableValues"), "variableValues key must not be serialized");
+    assertTrue(json.contains("test-execution"), "other fields must still serialize normally");
+  }
+}


### PR DESCRIPTION
Follow-up from a private report I sent to security@apache.org (forwarded to the Hop PMC). ASF Security's read was that this isn't a vulnerability under Hop's threat model (SECURITY.md §7/§13 — the caller already needs Hop Server credentials, which is out of scope), but they agreed the asymmetry is worth fixing on its own merits and suggested I open it as a normal contribution instead. That's this PR.

## What

`Execution.parameterValues` had no `@JsonIgnore`, while the sibling `variableValues` field is already `@Deprecated @JsonIgnore`'d for the same reason: `Execution` is serialized wholesale to JSON by `GetExecutionInfoServlet` (`GET /hop/getExecInfo`) and the REST `LocationResource`, and pipeline/workflow parameters routinely carry secrets (DB passwords, API tokens).

## Fix

Add `@JsonIgnore` to `parameterValues`, matching the existing `variableValues` protection.

This only affects JSON (de)serialization — in-process consumers (`BaseExecutionViewer`, `WorkflowExecutionViewer`, `PipelineExecutionViewer`) read the values directly via the Java getter and are unaffected.

## Test plan

- [x] Added `ExecutionTest.testParameterValuesNotSerialized`: asserts neither `parameterValues` nor `variableValues` (nor their values) appear in the JSON produced by `HopJson`, while other fields still serialize normally.
- [x] Confirmed fail-before/pass-after locally: reverting the `@JsonIgnore` reproduces the leak (test fails with the plaintext value present in the JSON), reapplying it passes.
- [x] `mvn -pl engine -am test -Dtest=org.apache.hop.execution.*` and `mvn -pl rest -am test` both green.
- [x] `spotless:apply` run.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

This report was prepared with AI coding-agent assistance, independently verified against current source and tests before opening.