### PR TITLE
Issue #7789 : Accept underscores in host names when building the request origin

### DIFF
--- a/core/src/main/java/org/apache/hop/core/util/HttpClientManager.java
+++ b/core/src/main/java/org/apache/hop/core/util/HttpClientManager.java
@@ -19,6 +19,7 @@ package org.apache.hop.core.util;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.URI;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -192,6 +193,49 @@ public class HttpClientManager {
 
       return httpClientBuilder.build();
     }
+  }
+
+  /**
+   * Creates an {@link HttpHost} for the origin of the given URI.
+   *
+   * <p>{@link HttpHost#create(URI)} reads {@link URI#getHost()}, which is {@code null} whenever the
+   * authority is registry-based rather than server-based -- in practice because the host name
+   * contains an underscore. Such names are not strictly legal in DNS, but they are common on
+   * internal networks and resolve perfectly well, and for those URIs {@code getPort()} and {@code
+   * getUserInfo()} are unavailable too. So parse the authority instead of letting {@code
+   * HttpHost.create} fail with a NullPointerException.
+   */
+  public static HttpHost createHttpHost(URI uri) {
+    if (uri.getHost() != null) {
+      return new HttpHost(uri.getScheme(), uri.getHost(), uri.getPort());
+    }
+
+    String authority = uri.getAuthority();
+    if (authority == null) {
+      throw new IllegalArgumentException("The URI does not specify a host: " + uri);
+    }
+
+    // Userinfo is not part of the origin, so drop it.
+    int at = authority.lastIndexOf('@');
+    String hostAndPort = at < 0 ? authority : authority.substring(at + 1);
+
+    String host = hostAndPort;
+    int port = -1;
+    int colon = hostAndPort.lastIndexOf(':');
+    // A colon inside an IPv6 literal is not a port separator.
+    if (colon > -1 && hostAndPort.indexOf(']') < colon) {
+      host = hostAndPort.substring(0, colon);
+      String portText = hostAndPort.substring(colon + 1);
+      if (!portText.isEmpty()) {
+        try {
+          port = Integer.parseInt(portText);
+        } catch (NumberFormatException e) {
+          throw new IllegalArgumentException("The URI does not specify a valid port: " + uri, e);
+        }
+      }
+    }
+
+    return new HttpHost(uri.getScheme(), host, port);
   }
 
   public static SSLContext getSslContextWithTrustStoreFile(

--- a/core/src/test/java/org/apache/hop/core/util/HttpClientManagerTest.java
+++ b/core/src/test/java/org/apache/hop/core/util/HttpClientManagerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.core.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.URI;
+import org.apache.hc.core5.http.HttpHost;
+import org.junit.jupiter.api.Test;
+
+class HttpClientManagerTest {
+
+  @Test
+  void createHttpHostReadsAServerBasedAuthority() {
+    HttpHost host = HttpClientManager.createHttpHost(URI.create("https://example.org:8443/api"));
+
+    assertEquals("https", host.getSchemeName());
+    assertEquals("example.org", host.getHostName());
+    assertEquals(8443, host.getPort());
+  }
+
+  @Test
+  void createHttpHostAcceptsAnUnderscoreInTheHostName() {
+    // java.net.URI treats this authority as registry-based, so getHost(), getPort() and
+    // getUserInfo() are all unavailable and HttpHost.create(URI) fails with a NullPointerException.
+    HttpHost host =
+        HttpClientManager.createHttpHost(URI.create("http://my_service.internal:8080/api"));
+
+    assertEquals("http", host.getSchemeName());
+    assertEquals("my_service.internal", host.getHostName());
+    assertEquals(8080, host.getPort());
+  }
+
+  @Test
+  void createHttpHostDefaultsThePortWhenTheAuthorityOmitsIt() {
+    HttpHost host = HttpClientManager.createHttpHost(URI.create("http://my_service.internal/api"));
+
+    assertEquals("my_service.internal", host.getHostName());
+    assertEquals(-1, host.getPort());
+  }
+
+  @Test
+  void createHttpHostDropsUserInfoFromTheOrigin() {
+    HttpHost host =
+        HttpClientManager.createHttpHost(
+            URI.create("http://user:secret@my_service.internal:8080/"));
+
+    assertEquals("my_service.internal", host.getHostName());
+    assertEquals(8080, host.getPort());
+  }
+
+  @Test
+  void createHttpHostKeepsIpv6LiteralsIntact() {
+    HttpHost host = HttpClientManager.createHttpHost(URI.create("http://[::1]:8080/api"));
+
+    assertEquals("[::1]", host.getHostName());
+    assertEquals(8080, host.getPort());
+  }
+
+  @Test
+  void createHttpHostRejectsAUriWithoutAHost() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> HttpClientManager.createHttpHost(URI.create("file:///tmp/data.json")));
+  }
+
+  @Test
+  void createHttpHostRejectsANonNumericPort() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> HttpClientManager.createHttpHost(URI.create("http://my_service.internal:http/api")));
+  }
+}

--- a/engine/src/main/java/org/apache/hop/core/HttpProtocol.java
+++ b/engine/src/main/java/org/apache/hop/core/HttpProtocol.java
@@ -81,7 +81,7 @@ public class HttpProtocol {
           HttpClientManager.getInstance().createBuilder();
       clientBuilder.setCredentials(username, password);
       httpClient = clientBuilder.build();
-      HttpHost origin = HttpHost.create(URI.create(urlAsString));
+      HttpHost origin = HttpClientManager.createHttpHost(URI.create(urlAsString));
       HttpClientContext preemptive =
           HttpClientUtil.createPreemptiveBasicAuthentication(
               origin.getHostName(), origin.getPort(), username, password, origin.getSchemeName());

--- a/plugins/transforms/http/src/main/java/org/apache/hop/pipeline/transforms/http/Http.java
+++ b/plugins/transforms/http/src/main/java/org/apache/hop/pipeline/transforms/http/Http.java
@@ -141,7 +141,7 @@ public class Http extends BaseTransform<HttpMeta, HttpData> {
         // Preemptive Basic auth: AuthCache must be keyed to the origin host (same as the request
         // target). Proxy routing is configured on the client via RequestConfig — do not pass the
         // proxy as HttpHost here (breaks credentials + preemptive cache matching in HttpClient 5).
-        HttpHost target = HttpHost.create(uri);
+        HttpHost target = HttpClientManager.createHttpHost(uri);
 
         httpResponse =
             httpClient.execute(

--- a/plugins/transforms/httppost/src/main/java/org/apache/hop/pipeline/transforms/httppost/HttpPost.java
+++ b/plugins/transforms/httppost/src/main/java/org/apache/hop/pipeline/transforms/httppost/HttpPost.java
@@ -165,7 +165,7 @@ public class HttpPost extends BaseTransform<HttpPostMeta, HttpPostData> {
         long startTime = System.currentTimeMillis();
 
         // Origin host for routing + preemptive Basic auth cache (proxy is on the client, not here).
-        HttpHost target = HttpHost.create(uri);
+        HttpHost target = HttpClientManager.createHttpHost(uri);
 
         HttpClientContext localContext = HttpClientContext.create();
         if (StringUtils.isNotBlank(data.realHttpLogin)) {

--- a/plugins/transforms/webservices/src/main/java/org/apache/hop/pipeline/transforms/webservices/WebService.java
+++ b/plugins/transforms/webservices/src/main/java/org/apache/hop/pipeline/transforms/webservices/WebService.java
@@ -565,7 +565,7 @@ public class WebService extends BaseTransform<WebServiceMeta, WebServiceData> {
     CloseableHttpClient httpClient = clientBuilder.build();
 
     if (StringUtils.isNotBlank(login)) {
-      HttpHost target = HttpHost.create(URI.create(serviceUrl));
+      HttpHost target = HttpClientManager.createHttpHost(URI.create(serviceUrl));
       AuthCache authCache = new BasicAuthCache();
       BasicScheme basicAuth = new BasicScheme();
       char[] passwordChars = password != null ? password.toCharArray() : new char[0];


### PR DESCRIPTION
Addresses #7789 — with one correction to the scope, which I've also raised on the issue.

### The proxy leg was already fine

Both transforms pass the proxy to `HttpClientManager.HttpClientBuilderFacade#setProxy`, which builds
it with `new HttpHost(scheme, host, port)` and sets it on `RequestConfig`. That constructor takes the
host name verbatim, so `my_proxy.internal` survives it. Verified against httpcore5 5.4.

### The request target was not

`Http#processRow` and `HttpPost#processRow` call `HttpHost.create(uri)`, and that overload reads
`URI.getHost()`. When a host name contains an underscore, `java.net.URI` classifies the authority as
registry-based rather than server-based, and the parsed components are simply not available:

```
http://my_service.internal:8080/api
   URI.getHost()      = null
   URI.getPort()      = -1
   URI.getUserInfo()  = null
   URI.getAuthority() = my_service.internal:8080
```

`HttpHost.create(URI)` then fails with `NullPointerException: Host name`. The same call appears in
`WebService` and in `HttpProtocol`, so four call sites share the defect.

### Change

`HttpClientManager.createHttpHost(URI)` uses `getHost()` when it is available and otherwise parses
the authority — dropping userinfo, taking the port when one is present, and leaving IPv6 literals
intact. All four call sites now go through it.

Underscores are not legal in host names per RFC 1123, which the reporter rightly notes. But they are
common in internal and container DNS and they resolve, so failing with a `NullPointerException`
rather than either working or reporting a clear error seems the wrong outcome either way.

### Tests

Seven tests in a new `HttpClientManagerTest`:

  - a normal server-based authority
  - an underscored host with a port, and without one
  - userinfo dropped from the origin
  - an IPv6 literal kept intact
  - a URI with no host at all, and a non-numeric port — both rejected with `IllegalArgumentException`
    rather than an NPE

Five of the seven fail with `NullPointerException: Host name` if `createHttpHost` is changed to
delegate back to `HttpHost.create(uri)`.

### Verification

  - `mvn -pl core,plugins/transforms/http,plugins/transforms/httppost,plugins/transforms/webservices -Pskip-uitest test`
    — core 1138, http 37, httppost 25, webservices 6, all passing, 0 failures
  - `mvn spotless:check` and `mvn apache-rat:check` pass on the five touched modules

If it turns out the reporter really did hit the proxy path rather than the target, then this is still
a genuine fix for the four call sites above but the issue would need to stay open — I've asked them
to confirm.

------------------------

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
