### PR TITLE
Replace deprecated expression ${parent.version} with ${project.parent.version}

### DIFF
--- a/lib-p2/tm4e/pom.xml
+++ b/lib-p2/tm4e/pom.xml
@@ -47,7 +47,7 @@
             <dependency>
                 <groupId>org.apache.hop</groupId>
                 <artifactId>hop-libs</artifactId>
-                <version>${parent.version}</version>
+                <version>${project.parent.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Remove maven warning
