### PR TITLE
Fix #8054: decrypt trustStorePassword in REST transform init

### DIFF
--- a/plugins/transforms/rest/src/main/java/org/apache/hop/pipeline/transforms/rest/Rest.java
+++ b/plugins/transforms/rest/src/main/java/org/apache/hop/pipeline/transforms/rest/Rest.java
@@ -2254,7 +2254,13 @@ public class Rest extends BaseTransform<RestMeta, RestData> {
       }
 
       data.trustStoreFile = resolve(meta.getTrustStoreFile());
-      data.trustStorePassword = resolve(meta.getTrustStorePassword());
+      // Decrypt the resolved trust store password like every other password field in Hop
+      // (see RestConnection.java, OracleDatabaseMeta.java, LdapSslProtocol.java, and the
+      // httpPassword branch a dozen lines above). Without this, an encrypted value that
+      // reaches the field through a variable is passed to the trust store loader verbatim
+      // and the SSL context cannot be built. See Apache Hop #8054.
+      data.trustStorePassword =
+          Encr.decryptPasswordOptionallyEncrypted(resolve(meta.getTrustStorePassword()));
 
       String applicationType = NVL(meta.getApplicationType(), "");
       switch (applicationType) {

--- a/plugins/transforms/rest/src/test/java/org/apache/hop/pipeline/transforms/rest/RestInitAndProcessTest.java
+++ b/plugins/transforms/rest/src/test/java/org/apache/hop/pipeline/transforms/rest/RestInitAndProcessTest.java
@@ -343,4 +343,60 @@ class RestInitAndProcessTest {
     assertEquals(3000, data.realConnectionTimeout);
     assertEquals(7000, data.realReadTimeout);
   }
+
+  /**
+   * Regression test for Apache Hop #8054.
+   *
+   * <p>Every password field in Hop is decrypted with {@link
+   * Encr#decryptPasswordOptionallyEncrypted} after being resolved, including the {@code
+   * httpPassword} field a dozen lines above the trust store in {@link Rest#init()}. Before this
+   * fix, {@code trustStorePassword} was resolved but not decrypted, so an encrypted value that
+   * reached the field through a variable was passed to the trust store loader verbatim and the SSL
+   * context could not be built.
+   *
+   * <p>This test resolves an encrypted trust store password from a variable and asserts the value
+   * stored on {@link RestData} is the plaintext, matching the treatment {@code httpPassword} has
+   * always received.
+   */
+  @Test
+  void testInitDecryptsTrustStorePasswordFromVariable() {
+    String plaintext = "trustpass";
+    String encrypted = Encr.encryptPasswordIfNotUsingVariables(plaintext);
+    // Sanity check: the plugin only decrypts values with the standard "Encrypted " prefix.
+    assertTrue(
+        encrypted.startsWith("Encrypted "),
+        "test setup precondition: encryptPasswordIfNotUsingVariables should return a prefixed value");
+
+    TransformMeta transformMeta = new TransformMeta();
+    transformMeta.setName("TestRest");
+    PipelineMeta pipelineMeta = new PipelineMeta();
+    pipelineMeta.setName("TestRest");
+    pipelineMeta.addTransform(transformMeta);
+
+    RestMeta meta = new RestMeta();
+    meta.setMethod(RestMeta.HTTP_METHOD_GET);
+    meta.setUrl("http://example.com");
+    meta.setApplicationType(RestMeta.APPLICATION_TYPE_JSON);
+    meta.setResultField(new ResultField());
+    // Same shape as an httpPassword coming through a variable: the caller passes the
+    // encrypted value indirectly and expects the transform to decrypt on init.
+    meta.setHttpPassword("${HTTP_PWD}");
+    meta.setTrustStoreFile("/tmp/does-not-need-to-exist.jks");
+    meta.setTrustStorePassword("${TRUST_PWD}");
+
+    RestData data = new RestData();
+
+    Rest rest =
+        new Rest(transformMeta, meta, data, 1, pipelineMeta, spy(new LocalPipelineEngine()));
+    rest.setMetadataProvider(mock(IHopMetadataProvider.class));
+    rest.setVariable("HTTP_PWD", encrypted);
+    rest.setVariable("TRUST_PWD", encrypted);
+
+    rest.init();
+
+    // httpPassword has always been decrypted here; asserting alongside trustStorePassword
+    // makes the parity with the pre-existing branch explicit.
+    assertEquals(plaintext, data.realHttpPassword);
+    assertEquals(plaintext, data.trustStorePassword);
+  }
 }


### PR DESCRIPTION
Fixes #8054.

## Problem

The REST transform's `init()` reads the trust store password with `resolve()` only, missing the `Encr.decryptPasswordOptionallyEncrypted(...)` call that every other password field in Hop wraps around `resolve()`. This includes the `httpPassword` branch a dozen lines above it in the very same method:

```java
data.realHttpPassword =
    Encr.decryptPasswordOptionallyEncrypted(resolve(meta.getHttpPassword()));  // decrypted
...
data.trustStorePassword = resolve(meta.getTrustStorePassword());               // NOT decrypted
```

Both fields are declared identically in `RestMeta`:

```java
@HopMetadataProperty(key = "httpPassword", injectionKey = "HTTP_PASSWORD", password = true)
@HopMetadataProperty(key = "trustStorePassword", injectionKey = "TRUSTSTORE_PASSWORD", password = true)
```

Every peer usage decrypts:

| Location | Handling |
| --- | --- |
| `plugins/misc/rest/.../RestConnection.java:566` (same field name) | `Encr.decryptPasswordOptionallyEncrypted(resolve(trustStorePassword))` |
| `plugins/databases/oracle/.../OracleDatabaseMeta.java:561` | `decrypt(variables, trustStorePassword)` |
| `plugins/transforms/ldap/.../LdapSslProtocol.java:41` | `Utils.resolvePassword(variables, ...)` (resolve + decrypt) |
| `plugins/transforms/rest/.../Rest.java:2258` (before this PR) | `resolve(...)` only |

As a result, an encrypted value that reaches the field through a variable is passed to the trust store loader verbatim and the SSL context cannot be built.

## Why it's not visible in the simple case

A password typed straight into the dialog works, because `XmlMetadataUtil` already decrypts `password = true` properties on deserialization (`core/src/main/java/org/apache/hop/metadata/serializer/xml/XmlMetadataUtil.java:1211`). The bug only surfaces on the **variable path** — which is the whole point of `password = true` fields being encryptable in the first place.

## Fix

One-line change to `Rest.java`: wrap `resolve(meta.getTrustStorePassword())` in `Encr.decryptPasswordOptionallyEncrypted(...)`, matching the peer pattern. The `Encr` import is already present in the file. Added a short comment tying the pattern to the peer locations and to this issue.

## Test

New `testInitDecryptsTrustStorePasswordFromVariable` in `RestInitAndProcessTest`:

- Encrypts a known plaintext with `Encr.encryptPasswordIfNotUsingVariables`
- Puts the encrypted value behind a `${TRUST_PWD}` variable
- Runs `init()` and asserts `data.trustStorePassword` equals the original plaintext
- Also asserts `data.realHttpPassword` on the same run for parity with the pre-existing `httpPassword` handling — makes the equivalence explicit for future readers

## Verified locally

- `./mvnw test` on `plugins/transforms/rest` — **168 tests, 0 failures, 0 errors**
- `./mvnw spotless:apply` — no formatting changes
- Java 21 build