### PR TITLE
Fix#8096  pipeline variable resolver using server default metadata on remote export

### DIFF
--- a/core/src/main/java/org/apache/hop/core/variables/IVariables.java
+++ b/core/src/main/java/org/apache/hop/core/variables/IVariables.java
@@ -160,4 +160,23 @@ public interface IVariables {
   default IHopMetadataProvider getMetadataProvider() {
     return null;
   }
+
+  /**
+   * Walk this variable space and its parents to find the metadata provider of the current execution
+   * (an execution engine exposes its own provider through {@link #getMetadataProvider()}).
+   *
+   * @return the first non-null metadata provider found, or {@code null} if none.
+   */
+  default IHopMetadataProvider findExecutionMetadataProvider() {
+    IVariables space = this;
+    int guard = 0;
+    while (space != null && guard++ < 100) {
+      IHopMetadataProvider provider = space.getMetadataProvider();
+      if (provider != null) {
+        return provider;
+      }
+      space = space.getParentVariables();
+    }
+    return null;
+  }
 }

--- a/core/src/main/java/org/apache/hop/core/variables/Variables.java
+++ b/core/src/main/java/org/apache/hop/core/variables/Variables.java
@@ -171,26 +171,6 @@ public class Variables implements IVariables {
     return resolved;
   }
 
-  /**
-   * Walk this variable space and its parents to find the metadata provider of the current execution
-   * (an execution engine exposes its own provider through {@link
-   * IVariables#getMetadataProvider()}).
-   *
-   * @return the first non-null metadata provider found, or {@code null} if none.
-   */
-  private IHopMetadataProvider findExecutionMetadataProvider() {
-    IVariables space = this;
-    int guard = 0;
-    while (space != null && guard++ < 100) {
-      IHopMetadataProvider provider = space.getMetadataProvider();
-      if (provider != null) {
-        return provider;
-      }
-      space = space.getParentVariables();
-    }
-    return null;
-  }
-
   private String substituteVariableResolvers(String input) {
     String resolved = input;
     int startIndex = 0;

--- a/core/src/test/java/org/apache/hop/core/variables/VariablesTest.java
+++ b/core/src/test/java/org/apache/hop/core/variables/VariablesTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.Future;
 import org.apache.hop.core.exception.HopValueException;
 import org.apache.hop.core.row.RowMeta;
 import org.apache.hop.core.row.value.ValueMetaString;
+import org.apache.hop.metadata.api.IHopMetadataProvider;
 import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -171,5 +172,28 @@ class VariablesTest {
     assertEquals("ok", vars.getVariable("valid"));
     assertNull(vars.getVariable(null));
     assertNull(vars.getVariable(""));
+  }
+
+  /**
+   * Transform variable spaces do not expose a metadata provider themselves; the running pipeline
+   * (parent) does. Variable resolvers must walk that parent chain so remote export uses the bundled
+   * metadata rather than the process-global store (#8096).
+   */
+  @Test
+  void findExecutionMetadataProviderWalksParentChain() {
+    IHopMetadataProvider provider = mock(IHopMetadataProvider.class);
+    IVariables parent =
+        new Variables() {
+          @Override
+          public IHopMetadataProvider getMetadataProvider() {
+            return provider;
+          }
+        };
+
+    Variables child = new Variables();
+    child.setParentVariables(parent);
+
+    assertEquals(provider, child.findExecutionMetadataProvider());
+    assertNull(new Variables().findExecutionMetadataProvider());
   }
 }

--- a/engine/src/main/java/org/apache/hop/workflow/action/ActionBase.java
+++ b/engine/src/main/java/org/apache/hop/workflow/action/ActionBase.java
@@ -782,6 +782,7 @@ public abstract class ActionBase
   @Override
   public void setParentWorkflow(IWorkflowEngine<WorkflowMeta> parentWorkflow) {
     this.parentWorkflow = parentWorkflow;
+    this.variables.setParentVariables(parentWorkflow);
     this.logLevel = parentWorkflow.getLogLevel();
     this.log = new LogChannel(this, parentWorkflow);
     this.setVariable(Const.INTERNAL_VARIABLE_ACTION_ID, log.getLogChannelId());

--- a/engine/src/test/java/org/apache/hop/workflow/action/ActionBaseExecutionMetadataTest.java
+++ b/engine/src/test/java/org/apache/hop/workflow/action/ActionBaseExecutionMetadataTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.workflow.action;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.hop.core.logging.LogLevel;
+import org.apache.hop.metadata.api.IHopMetadataProvider;
+import org.apache.hop.workflow.WorkflowMeta;
+import org.apache.hop.workflow.actions.ActionFake;
+import org.apache.hop.workflow.engine.IWorkflowEngine;
+import org.junit.jupiter.api.Test;
+
+/**
+ * An action resolves variables through the variable space it delegates to, not through itself. That
+ * space has to reach the running workflow, or {@link
+ * org.apache.hop.core.variables.IVariables#findExecutionMetadataProvider()} finds nothing and a
+ * <code>#{variable-resolver:...}</code> expression in an action falls back to the process global
+ * metadata instead of the metadata of this execution - the bundled metadata of an export on a Hop
+ * Server (issue #8096).
+ */
+class ActionBaseExecutionMetadataTest {
+
+  @Test
+  void executionMetadataProviderIsFoundFromTheActionVariableSpace() {
+    IHopMetadataProvider provider = mock(IHopMetadataProvider.class);
+
+    @SuppressWarnings("unchecked")
+    IWorkflowEngine<WorkflowMeta> workflow = mock(IWorkflowEngine.class);
+    when(workflow.getLogLevel()).thenReturn(LogLevel.BASIC);
+    when(workflow.getMetadataProvider()).thenReturn(provider);
+
+    ActionFake action = new ActionFake();
+    assertNull(
+        action.getVariables().findExecutionMetadataProvider(),
+        "An action without a parent workflow has no execution metadata to offer");
+
+    action.setParentWorkflow(workflow);
+
+    // getVariables() is what resolve() delegates to, so it is the space
+    // Variables#substituteVariableResolvers walks - asserting on the action itself would pass
+    // even without the parent link, through ActionBase#getParentVariables().
+    assertSame(provider, action.getVariables().findExecutionMetadataProvider());
+    assertSame(provider, action.findExecutionMetadataProvider());
+  }
+}

--- a/integration-tests/hop_server/0013-trigger-pipeline.hpl
+++ b/integration-tests/hop_server/0013-trigger-pipeline.hpl
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<pipeline>
+  <info>
+    <name>0013-trigger-pipeline</name>
+    <name_sync_with_filename>Y</name_sync_with_filename>
+    <description>Resolves a variable through the resolver-0013 Variable Resolver
+      (#{resolver-0013:...}). That resolver runs its referenced pipeline with the
+      'local-export-only' run configuration, which only exists in the metadata bundled in the
+      export ZIP. When the resolver looks the run configuration up in the Hop Server's own
+      (default) metadata instead, resolving fails with "Unable to find the specified pipeline run
+      configuration" and this pipeline errors out (#8096). The value check below additionally
+      guards against a silently unresolved expression.</description>
+    <extended_description/>
+    <pipeline_version/>
+    <pipeline_type>Normal</pipeline_type>
+    <parameters>
+    </parameters>
+    <capture_transform_performance>N</capture_transform_performance>
+    <transform_performance_capturing_delay>1000</transform_performance_capturing_delay>
+    <transform_performance_capturing_size_limit>100</transform_performance_capturing_size_limit>
+    <created_user>-</created_user>
+    <created_date>2024/01/01 00:00:00.000</created_date>
+    <modified_user>-</modified_user>
+    <modified_date>2024/01/01 00:00:00.000</modified_date>
+    <key_for_session_key/>
+    <is_key_private>N</is_key_private>
+  </info>
+  <notepads>
+  </notepads>
+  <order>
+    <hop>
+      <from>Resolve variable</from>
+      <to>Check resolved value</to>
+      <enabled>Y</enabled>
+    </hop>
+    <hop>
+      <from>Check resolved value</from>
+      <to>Resolved</to>
+      <enabled>Y</enabled>
+    </hop>
+    <hop>
+      <from>Check resolved value</from>
+      <to>Not resolved</to>
+      <enabled>Y</enabled>
+    </hop>
+  </order>
+  <transform>
+    <name>Resolve variable</name>
+    <type>GetVariable</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <fields>
+      <field>
+        <length>-1</length>
+        <name>resolved</name>
+        <precision>-1</precision>
+        <trim_type>none</trim_type>
+        <type>String</type>
+        <variable>#{resolver-0013:trigger:resolved}</variable>
+      </field>
+    </fields>
+    <attributes/>
+    <GUI>
+      <xloc>144</xloc>
+      <yloc>96</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>Check resolved value</name>
+    <type>FilterRows</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <compare>
+      <condition>
+        <conditions>
+</conditions>
+        <function>=</function>
+        <leftvalue>resolved</leftvalue>
+        <negated>N</negated>
+        <operator>-</operator>
+        <value>
+          <isnull>N</isnull>
+          <length>-1</length>
+          <name>constant</name>
+          <precision>-1</precision>
+          <text>resolved-value-8096</text>
+          <type>String</type>
+        </value>
+      </condition>
+    </compare>
+    <send_false_to>Not resolved</send_false_to>
+    <send_true_to>Resolved</send_true_to>
+    <attributes/>
+    <GUI>
+      <xloc>352</xloc>
+      <yloc>96</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>Resolved</name>
+    <type>Dummy</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <attributes/>
+    <GUI>
+      <xloc>560</xloc>
+      <yloc>48</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>Not resolved</name>
+    <type>Abort</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <abort_option>ABORT_WITH_ERROR</abort_option>
+    <always_log_rows>Y</always_log_rows>
+    <message>The #{resolver-0013:...} expression did not resolve to 'resolved-value-8096' on the Hop Server</message>
+    <row_threshold>0</row_threshold>
+    <attributes/>
+    <GUI>
+      <xloc>560</xloc>
+      <yloc>160</yloc>
+    </GUI>
+  </transform>
+  <transform_error_handling>
+  </transform_error_handling>
+  <attributes/>
+</pipeline>

--- a/integration-tests/hop_server/0013-verify-resolver-run-configuration.hwf
+++ b/integration-tests/hop_server/0013-verify-resolver-run-configuration.hwf
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<workflow>
+  <name>0013-verify-resolver-run-configuration</name>
+  <name_sync_with_filename>Y</name_sync_with_filename>
+  <description>Runs entirely on the remote Hop Server (shipped there by the "remote" run
+    configuration of the parent workflow). It runs a trigger pipeline that resolves
+    #{resolver-0013:...}. That resolver runs its referenced pipeline with the 'local-export-only'
+    pipeline run configuration, which lives in the client project's metadata-client-only folder and
+    is therefore only present in the metadata bundled in the export ZIP - never in the server's own
+    metadata. The check below confirms the marker written by the resolver pipeline exists, i.e. the
+    resolver used the execution (exported) metadata instead of the server default metadata
+    (#8096). A second check resolves the same expression from a workflow action, so both execution
+    contexts that findExecutionMetadataProvider() has to walk - a transform and an action - are
+    covered.</description>
+  <extended_description/>
+  <workflow_version/>
+  <created_user>-</created_user>
+  <created_date>2024/01/01 00:00:00.000</created_date>
+  <modified_user>-</modified_user>
+  <modified_date>2024/01/01 00:00:00.000</modified_date>
+  <parameters>
+    </parameters>
+  <actions>
+    <action>
+      <name>Start</name>
+      <description/>
+      <type>SPECIAL</type>
+      <attributes/>
+      <DayOfMonth>1</DayOfMonth>
+      <hour>12</hour>
+      <intervalMinutes>60</intervalMinutes>
+      <intervalSeconds>0</intervalSeconds>
+      <minutes>0</minutes>
+      <repeat>N</repeat>
+      <schedulerType>0</schedulerType>
+      <weekDay>1</weekDay>
+      <parallel>N</parallel>
+      <xloc>50</xloc>
+      <yloc>50</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>Cleanup marker</name>
+      <description>Remove any marker left by a previous run so the check can only succeed on a marker
+        written now.</description>
+      <type>DELETE_FILE</type>
+      <attributes/>
+      <filename>${PROJECT_HOME}/output-0013/resolver-marker.txt</filename>
+      <fail_if_file_not_exists>N</fail_if_file_not_exists>
+      <parallel>N</parallel>
+      <xloc>150</xloc>
+      <yloc>50</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>Run trigger pipeline</name>
+      <description/>
+      <type>PIPELINE</type>
+      <attributes/>
+      <filename>${PROJECT_HOME}/0013-trigger-pipeline.hpl</filename>
+      <params_from_previous>N</params_from_previous>
+      <exec_per_row>N</exec_per_row>
+      <set_logfile>N</set_logfile>
+      <logfile/>
+      <logext/>
+      <add_date>N</add_date>
+      <add_time>N</add_time>
+      <loglevel>Basic</loglevel>
+      <run_configuration>local</run_configuration>
+      <wait_until_finished>Y</wait_until_finished>
+      <create_parent_folder>N</create_parent_folder>
+      <parameters>
+        <pass_all_parameters>Y</pass_all_parameters>
+      </parameters>
+      <set_append_logfile>N</set_append_logfile>
+      <parallel>N</parallel>
+      <xloc>300</xloc>
+      <yloc>50</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>Verify resolver pipeline ran</name>
+      <description/>
+      <type>FILE_EXISTS</type>
+      <attributes/>
+      <filename>${PROJECT_HOME}/output-0013/resolver-marker.txt</filename>
+      <parallel>N</parallel>
+      <xloc>470</xloc>
+      <yloc>50</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <valuetype>variable</valuetype>
+      <fieldtype>string</fieldtype>
+      <variablename>#{resolver-0013:trigger:resolved}</variablename>
+      <comparevalue>resolved-value-8096</comparevalue>
+      <successcondition>equal</successcondition>
+      <successwhenvarset>N</successwhenvarset>
+      <successbooleancondition>true</successbooleancondition>
+      <successnumbercondition>equal</successnumbercondition>
+      <name>Resolve from a workflow action</name>
+      <description>Resolves the same expression from a workflow ACTION instead of a pipeline
+        transform. findExecutionMetadataProvider() stops at the action's own provider
+        (ActionBase.getMetadataProvider(), handed down by Workflow), so this covers a different
+        code path than the trigger pipeline above. A Simple evaluation is used on purpose: unlike
+        a file based action it has no exportResources() that would resolve the expression away on
+        the client, so the server is the one that has to find 'local-export-only'.</description>
+      <type>SIMPLE_EVAL</type>
+      <attributes/>
+      <xloc>650</xloc>
+      <yloc>50</yloc>
+      <parallel>N</parallel>
+      <attributes_hac/>
+    </action>
+  </actions>
+  <hops>
+    <hop>
+      <from>Start</from>
+      <to>Cleanup marker</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>Y</unconditional>
+    </hop>
+    <hop>
+      <from>Cleanup marker</from>
+      <to>Run trigger pipeline</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>Y</unconditional>
+    </hop>
+    <hop>
+      <from>Run trigger pipeline</from>
+      <to>Verify resolver pipeline ran</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>N</unconditional>
+    </hop>
+    <hop>
+      <from>Verify resolver pipeline ran</from>
+      <to>Resolve from a workflow action</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>N</unconditional>
+    </hop>
+  </hops>
+  <notepads>
+  </notepads>
+  <attributes/>
+</workflow>

--- a/integration-tests/hop_server/main-0013-test-variable-resolver-run-configuration.hwf
+++ b/integration-tests/hop_server/main-0013-test-variable-resolver-run-configuration.hwf
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<workflow>
+  <name>main-0013-test-variable-resolver-run-configuration</name>
+  <name_sync_with_filename>Y</name_sync_with_filename>
+  <description>Regression test for issue #8096: on a remote Hop Server the Pipeline Variable
+    Resolver must resolve the pipeline run configuration (and the referenced pipeline) it needs
+    against the metadata of the running execution - the metadata bundled in the export ZIP - and
+    not against the server's process-global default metadata.
+
+    Unlike main-0009, the resolver here points at the 'local-export-only' run configuration, which
+    lives in the client project's second metadata folder (${PROJECT_HOME}/metadata-client-only).
+    The Hop Server in these tests registers ${PROJECT_HOME}/metadata as its own metadata folder, so
+    'local-export-only' is genuinely unknown to the server and can only come from the export. That
+    is what makes this test fail before the fix with "Unable to find the specified pipeline run
+    configuration 'local-export-only'", while main-0009 (which uses the run configuration 'local',
+    known to the server as well) passes either way.</description>
+  <extended_description/>
+  <workflow_version/>
+  <created_user>-</created_user>
+  <created_date>2024/01/01 00:00:00.000</created_date>
+  <modified_user>-</modified_user>
+  <modified_date>2024/01/01 00:00:00.000</modified_date>
+  <parameters>
+    </parameters>
+  <actions>
+    <action>
+      <name>Start</name>
+      <description/>
+      <type>SPECIAL</type>
+      <attributes/>
+      <DayOfMonth>1</DayOfMonth>
+      <hour>12</hour>
+      <intervalMinutes>60</intervalMinutes>
+      <intervalSeconds>0</intervalSeconds>
+      <minutes>0</minutes>
+      <repeat>N</repeat>
+      <schedulerType>0</schedulerType>
+      <weekDay>1</weekDay>
+      <parallel>N</parallel>
+      <xloc>50</xloc>
+      <yloc>50</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>Verify resolver run configuration on server</name>
+      <description/>
+      <type>WORKFLOW</type>
+      <attributes/>
+      <run_configuration>remote</run_configuration>
+      <filename>${PROJECT_HOME}/0013-verify-resolver-run-configuration.hwf</filename>
+      <params_from_previous>N</params_from_previous>
+      <exec_per_row>N</exec_per_row>
+      <set_logfile>N</set_logfile>
+      <logfile/>
+      <logext/>
+      <add_date>N</add_date>
+      <add_time>N</add_time>
+      <loglevel>Basic</loglevel>
+      <wait_until_finished>Y</wait_until_finished>
+      <create_parent_folder>N</create_parent_folder>
+      <parameters>
+        <pass_all_parameters>Y</pass_all_parameters>
+      </parameters>
+      <set_append_logfile>N</set_append_logfile>
+      <parallel>N</parallel>
+      <xloc>288</xloc>
+      <yloc>50</yloc>
+      <attributes_hac/>
+    </action>
+  </actions>
+  <hops>
+    <hop>
+      <from>Start</from>
+      <to>Verify resolver run configuration on server</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>Y</unconditional>
+    </hop>
+  </hops>
+  <notepads>
+  </notepads>
+  <attributes/>
+</workflow>

--- a/integration-tests/hop_server/metadata-client-only/pipeline-run-configuration/local-export-only.json
+++ b/integration-tests/hop_server/metadata-client-only/pipeline-run-configuration/local-export-only.json
@@ -1,0 +1,17 @@
+{
+  "engineRunConfiguration": {
+    "Local": {
+      "feedback_size": "50000",
+      "sample_size": "100",
+      "sample_type_in_gui": "Last",
+      "rowset_size": "10000",
+      "safe_mode": false,
+      "show_feedback": false,
+      "topo_sort": false,
+      "gather_metrics": false
+    }
+  },
+  "configurationVariables": [],
+  "name": "local-export-only",
+  "description": "Local pipeline run configuration that only exists in the client project (second metadata folder ${PROJECT_HOME}/metadata-client-only). The Hop Server used by these tests registers ${PROJECT_HOME}/metadata as its metadata folder, so this run configuration is NOT part of the server's own metadata: it can only be found in the metadata bundled in the export ZIP. Used by main-0013 to prove the pipeline variable resolver resolves against the execution metadata instead of the server default metadata (#8096)."
+}

--- a/integration-tests/hop_server/metadata/variable-resolver/resolver-0013.json
+++ b/integration-tests/hop_server/metadata/variable-resolver/resolver-0013.json
@@ -1,0 +1,13 @@
+{
+  "virtualPath": "",
+  "name": "resolver-0013",
+  "description": "Resolves a variable by running a referenced pipeline with the 'local-export-only' pipeline run configuration. That run configuration only exists in the client project (metadata-client-only folder), never in the Hop Server's own metadata, so the resolver can only work when it is resolved against the metadata bundled in the export (#8096).",
+  "variable-resolver": {
+    "Variable-Resolver-Pipeline": {
+      "outputTransformName": "OUTPUT",
+      "filename": "${PROJECT_HOME}/reflection/0013-resolver.hpl",
+      "expressionVariableName": "VARIABLE_TO_RESOLVE",
+      "runConfigurationName": "local-export-only"
+    }
+  }
+}

--- a/integration-tests/hop_server/project-config.json
+++ b/integration-tests/hop_server/project-config.json
@@ -1,5 +1,5 @@
 {
-  "metadataBaseFolder" : "${PROJECT_HOME}/metadata",
+  "metadataBaseFolder" : "${PROJECT_HOME}/metadata,${PROJECT_HOME}/metadata-client-only",
   "unitTestsBasePath" : "${PROJECT_HOME}",
   "dataSetsCsvFolder" : "${PROJECT_HOME}/datasets",
   "enforcingExecutionInHome" : true,

--- a/integration-tests/hop_server/reflection/0013-resolver.hpl
+++ b/integration-tests/hop_server/reflection/0013-resolver.hpl
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<pipeline>
+  <info>
+    <name>0013-resolver</name>
+    <name_sync_with_filename>Y</name_sync_with_filename>
+    <description>Pipeline referenced by the resolver-0013 Variable Resolver. It runs under the
+      'local-export-only' pipeline run configuration, which only exists in the client project's
+      metadata-client-only folder and therefore only reaches the server inside the export ZIP. It
+      writes a marker file so the test can prove the resolver really ran on the remote
+      server (#8096).</description>
+    <extended_description/>
+    <pipeline_version/>
+    <pipeline_type>Normal</pipeline_type>
+    <parameters>
+    </parameters>
+    <capture_transform_performance>N</capture_transform_performance>
+    <transform_performance_capturing_delay>1000</transform_performance_capturing_delay>
+    <transform_performance_capturing_size_limit>100</transform_performance_capturing_size_limit>
+    <created_user>-</created_user>
+    <created_date>2024/01/01 00:00:00.000</created_date>
+    <modified_user>-</modified_user>
+    <modified_date>2024/01/01 00:00:00.000</modified_date>
+    <key_for_session_key/>
+    <is_key_private>N</is_key_private>
+  </info>
+  <notepads>
+  </notepads>
+  <order>
+    <hop>
+      <from>Generate rows</from>
+      <to>Write marker</to>
+      <enabled>Y</enabled>
+    </hop>
+    <hop>
+      <from>Write marker</from>
+      <to>OUTPUT</to>
+      <enabled>Y</enabled>
+    </hop>
+  </order>
+  <transform>
+    <name>Generate rows</name>
+    <type>RowGenerator</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <fields>
+      <field>
+        <name>resolved</name>
+        <type>String</type>
+        <format/>
+        <currency/>
+        <decimal/>
+        <group/>
+        <nullif>resolved-value-8096</nullif>
+        <length>-1</length>
+        <precision>-1</precision>
+        <set_empty_string>N</set_empty_string>
+      </field>
+    </fields>
+    <limit>1</limit>
+    <never_ending>N</never_ending>
+    <interval_in_ms>5000</interval_in_ms>
+    <row_time_field>now</row_time_field>
+    <last_time_field>FiveSecondsAgo</last_time_field>
+    <attributes/>
+    <GUI>
+      <xloc>144</xloc>
+      <yloc>96</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>Write marker</name>
+    <type>TextFileOutput</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <separator>;</separator>
+    <enclosure>"</enclosure>
+    <enclosure_forced>N</enclosure_forced>
+    <enclosure_fix_disabled>N</enclosure_fix_disabled>
+    <header>Y</header>
+    <footer>N</footer>
+    <format>DOS</format>
+    <compression>None</compression>
+    <encoding>UTF-8</encoding>
+    <endedLine/>
+    <fileNameInField>N</fileNameInField>
+    <fileNameField/>
+    <create_parent_folder>Y</create_parent_folder>
+    <file>
+      <name>${PROJECT_HOME}/output-0013/resolver-marker</name>
+      <servlet_output>N</servlet_output>
+      <do_not_open_new_file_init>N</do_not_open_new_file_init>
+      <extention>txt</extention>
+      <append>N</append>
+      <split>N</split>
+      <haspartno>N</haspartno>
+      <add_date>N</add_date>
+      <add_time>N</add_time>
+      <SpecifyFormat>N</SpecifyFormat>
+      <date_time_format/>
+      <add_to_result_filenames>Y</add_to_result_filenames>
+      <pad>N</pad>
+      <fast_dump>N</fast_dump>
+      <splitevery/>
+    </file>
+    <fields>
+      <field>
+        <name>resolved</name>
+        <type>String</type>
+        <format/>
+        <currency/>
+        <decimal/>
+        <group/>
+        <nullif/>
+        <trim_type>none</trim_type>
+        <length>-1</length>
+        <precision>-1</precision>
+      </field>
+    </fields>
+    <attributes/>
+    <GUI>
+      <xloc>384</xloc>
+      <yloc>96</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>OUTPUT</name>
+    <type>Dummy</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <attributes/>
+    <GUI>
+      <xloc>592</xloc>
+      <yloc>96</yloc>
+    </GUI>
+  </transform>
+  <transform_error_handling>
+  </transform_error_handling>
+  <attributes/>
+</pipeline>

--- a/plugins/resolvers/pipeline/src/main/java/org/apache/hop/resolvers/pipeline/VariableResolverPipeline.java
+++ b/plugins/resolvers/pipeline/src/main/java/org/apache/hop/resolvers/pipeline/VariableResolverPipeline.java
@@ -36,7 +36,7 @@ import org.apache.hop.core.variables.resolver.VariableResolver;
 import org.apache.hop.core.variables.resolver.VariableResolverPlugin;
 import org.apache.hop.metadata.api.HopMetadataProperty;
 import org.apache.hop.metadata.api.HopMetadataPropertyType;
-import org.apache.hop.metadata.serializer.multi.MultiMetadataProvider;
+import org.apache.hop.metadata.api.IHopMetadataProvider;
 import org.apache.hop.metadata.util.HopMetadataInstance;
 import org.apache.hop.pipeline.PipelineExecutionConfiguration;
 import org.apache.hop.pipeline.PipelineMeta;
@@ -118,7 +118,13 @@ public class VariableResolverPipeline implements IVariableResolver {
 
   @Override
   public String resolve(String expression, IVariables variables) throws HopException {
-    MultiMetadataProvider metadataProvider = HopMetadataInstance.getMetadataProvider();
+    // Prefer the metadata of the current execution (exported/bundled metadata on a remote server)
+    // so referenced run configurations are resolved from the ZIP, not the server's default
+    // project. See Apache Hop issue #8096.
+    IHopMetadataProvider metadataProvider = variables.findExecutionMetadataProvider();
+    if (metadataProvider == null) {
+      metadataProvider = HopMetadataInstance.getMetadataProvider();
+    }
     String pipelineFilename = variables.resolve(filename);
     if (StringUtils.isEmpty(pipelineFilename)) {
       throw new HopException(


### PR DESCRIPTION
Fix https://github.com/apache/hop/issues/8096

## Summary
- When a pipeline is executed remotely with **Export linked resources to server**, `#{variable-resolver:...}` expressions were resolved against the Hop Server process-global metadata (`config/projects/default/metadata`) instead of the metadata bundled in the export ZIP.
- `Variables` already loaded the Variable Resolver from the current execution metadata, but `VariableResolverPipeline.resolve()` then called `HopMetadataInstance.getMetadataProvider()` to look up the referenced run configuration and pipeline. That lookup failed with `Unable to find the specified pipeline run configuration '...' in metadata provider: ... config/projects/default/metadata`.
- Use `IVariables.findExecutionMetadataProvider()` (walk the parent variable space to the running pipeline/workflow) and fall back to the process-global provider only when none is set. Local runs keep using the open project metadata.