### PR TITLE
Issue #8057 : Rasterize palette tree icons at the zoomed small-icon size

### DIFF
--- a/ui/src/main/java/org/apache/hop/ui/core/ConstUi.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/ConstUi.java
@@ -44,6 +44,14 @@ public class ConstUi {
 
   public static final int DOCUMENTATION_ICON_SIZE = 14;
 
+  /**
+   * Bitmap size of a logical icon at a Hop zoom factor. Same truncation as {@code
+   * GuiResource#getZoomedImaged} and explorer tree icons: {@code (int) (zoomFactor * logicalSize)}.
+   */
+  public static int zoomedIconSize(int logicalSize, double zoomFactor) {
+    return (int) (zoomFactor * logicalSize);
+  }
+
   /** Default checkbox width */
   public static final int CHECKBOX_WIDTH = 20;
 

--- a/ui/src/main/java/org/apache/hop/ui/core/gui/GuiResource.java
+++ b/ui/src/main/java/org/apache/hop/ui/core/gui/GuiResource.java
@@ -1224,7 +1224,17 @@ public class GuiResource {
   private Image getZoomedImaged(
       SwtUniversalImage universalImage, Device device, int width, int height) {
     return universalImage.getAsBitmapForSize(
-        device, (int) (zoomFactor * width), (int) (zoomFactor * height));
+        device,
+        ConstUi.zoomedIconSize(width, zoomFactor),
+        ConstUi.zoomedIconSize(height, zoomFactor));
+  }
+
+  /**
+   * Tree/toolbar-sized bitmap of {@code image}, scaled by the current zoom factor. Do not dispose
+   * the returned image; it is cached on the universal image.
+   */
+  public Image getSmallIcon(SwtUniversalImage image) {
+    return getZoomedImaged(image, display, ConstUi.SMALL_ICON_SIZE, ConstUi.SMALL_ICON_SIZE);
   }
 
   /**

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/palette/GraphPaletteTree.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/palette/GraphPaletteTree.java
@@ -19,9 +19,9 @@ package org.apache.hop.ui.hopgui.palette;
 
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hop.core.SwtUniversalImage;
 import org.apache.hop.core.gui.Point;
 import org.apache.hop.i18n.BaseMessages;
-import org.apache.hop.ui.core.ConstUi;
 import org.apache.hop.ui.core.PropsUi;
 import org.apache.hop.ui.core.bus.HopGuiEvents;
 import org.apache.hop.ui.core.gui.GuiResource;
@@ -428,14 +428,12 @@ public class GraphPaletteTree extends Composite {
   }
 
   private Image iconFor(Item item) {
-    int size = ConstUi.SMALL_ICON_SIZE;
     GuiResource images = GuiResource.getInstance();
-    if (host.getPaletteKind() == Kind.TRANSFORM) {
-      return images
-          .getSwtImageTransform(item.pluginId())
-          .getAsBitmapForSize(getDisplay(), size, size);
-    }
-    return images.getSwtImageAction(item.pluginId()).getAsBitmapForSize(getDisplay(), size, size);
+    SwtUniversalImage swtImage =
+        host.getPaletteKind() == Kind.TRANSFORM
+            ? images.getSwtImageTransform(item.pluginId())
+            : images.getSwtImageAction(item.pluginId());
+    return images.getSmallIcon(swtImage);
   }
 
   private void expandAll(boolean expanded) {

--- a/ui/src/test/java/org/apache/hop/ui/core/ConstUiTest.java
+++ b/ui/src/test/java/org/apache/hop/ui/core/ConstUiTest.java
@@ -36,6 +36,15 @@ class ConstUiTest {
   }
 
   @Test
+  void zoomedIconSizeMatchesExplorerAndGuiResourceTruncation() {
+    assertEquals(16, ConstUi.zoomedIconSize(ConstUi.SMALL_ICON_SIZE, 1.0));
+    assertEquals(24, ConstUi.zoomedIconSize(ConstUi.SMALL_ICON_SIZE, 1.5));
+    assertEquals(32, ConstUi.zoomedIconSize(ConstUi.SMALL_ICON_SIZE, 2.0));
+    assertEquals(20, ConstUi.zoomedIconSize(ConstUi.SMALL_ICON_SIZE, 1.25));
+    assertEquals(21, ConstUi.zoomedIconSize(ConstUi.SMALL_ICON_SIZE, 1.333));
+  }
+
+  @Test
   void encodingListContainsTheAvailableCharsets() {
     List<String> encodings = Arrays.asList(ConstUi.getEncodings());
 


### PR DESCRIPTION
## What

Fixes #8057.

Plugin icons in the new transform/action palette tree were rasterized at a raw 16×16, while folder icons in the same SWT `Tree` (and explorer file-type icons) already used Hop's zoomed small-icon size (`zoomFactor * 16`).

On Windows the native tree `ImageList` takes its slot size from the first image and stretches the rest. That made transform and action icons look pixelated or distorted, including at 100% OS scale / 100% Hop UI zoom, because `PropsUi.getZoomFactor()` is font-metric based and is often not 1.0.

This change:

- Adds `ConstUi.zoomedIconSize()` with the same truncation as explorer (`(int) (zoomFactor * logicalSize)`).
- Adds `GuiResource.getSmallIcon()` so tree icons share that path with folder/toolbar images.
- Switches `GraphPaletteTree.iconFor()` to `getSmallIcon()` for transform and action plugins.

## How to test

1. Show the pipeline and workflow palette trees.
2. Compare plugin icons to category folder icons in the same tree, and to explorer file-type icons. Bounds/`ImageList` size should match; icons should look crisp rather than stretched.
3. On Windows, re-check the setups from #8057:
   - OS 100% + Hop UI zoom 100% + `-Dswt.autoScale=exact`
   - OS 100% + Hop UI zoom 100% + `-Dswt.autoScale=quarter`
   - OS 150% + Hop UI zoom 100% + `-Dswt.autoScale=exact`

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [ ] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
