### PR TITLE
fix: DatabaseJoin dialog NPE when the configured connection no longer exists

### DIFF
--- a/plugins/transforms/databasejoin/src/main/java/org/apache/hop/pipeline/transforms/databasejoin/DatabaseJoinDialog.java
+++ b/plugins/transforms/databasejoin/src/main/java/org/apache/hop/pipeline/transforms/databasejoin/DatabaseJoinDialog.java
@@ -444,6 +444,9 @@ public class DatabaseJoinDialog extends BaseTransformDialog {
     }
 
     DatabaseMeta databaseMeta = pipelineMeta.findDatabase(input.getConnection(), variables);
+    if (databaseMeta == null) {
+      return List.of();
+    }
     return Arrays.stream(databaseMeta.getReservedWords()).toList();
   }
 


### PR DESCRIPTION
Fixes #8095

`DatabaseJoinDialog.getSqlReservedWords()` dereferences the result of `pipelineMeta.findDatabase()` without a null check. When the configured connection no longer exists, `findDatabase()` returns `null` and `databaseMeta.getReservedWords()` throws `NullPointerException`, making the transform impossible to reopen.

This matches the existing null check in the dialog's `ok()` method. When the database is missing, `getSqlReservedWords()` now returns an empty list so the dialog stays open and the connection can be fixed.
