### PR TITLE
Issue #8154 : Support binary data in bulk load transforms

### DIFF
--- a/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/cratedb-bulkloader.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/cratedb-bulkloader.adoc
@@ -30,6 +30,8 @@ The CrateDB Bulk Loader transform loads data from Apache Hop to CrateDB using tw
 * the https://cratedb.com/docs/crate/reference/en/5.7/sql/statements/copy-from.html#copy-from[`COPY FROM`^] command.
 * The https://cratedb.com/docs/crate/reference/en/latest/interfaces/http.html#bulk-operations[CrateDB HTTP endpoint] for bulk operations.
 
+TIP: CrateDB has no native binary column type. Binary stream fields are written as lowercase hex strings, which can be loaded into a `STRING` column.
+
 
 |
 == Supported Engines

--- a/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/monetdbbulkloader.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/monetdbbulkloader.adoc
@@ -27,6 +27,8 @@ under the License.
 
 The MonetDB Bulk Loader transform bulk loads data to MonetDB. This significantly speeds up data loading to MonetDB.
 
+TIP: binary stream fields are written as lowercase hex, which is the format MonetDB `COPY INTO` expects for `BLOB`.
+
 |
 == Supported Engines
 [%noheader,cols="2,1a",frame=none, role="table-supported-engines"]

--- a/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/mssqlbulkloader.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/mssqlbulkloader.adoc
@@ -31,7 +31,8 @@ https://learn.microsoft.com/en-us/sql/connect/jdbc/using-bulk-copy-with-the-jdbc
 API, which is typically much faster than inserting the same rows with a Table Output transform.
 
 Rows never leave the JVM as text: they are buffered and handed to the driver as typed values, so a
-NULL stays a NULL and no value can be mistaken for a field separator.
+NULL stays a NULL and no value can be mistaken for a field separator. Binary stream fields are
+passed through as `byte[]` for `BINARY`/`VARBINARY` columns.
 
 Use the xref:workflow/actions/mssqlbulkload.adoc[MSSQL Bulk Load] action instead when the data is
 already sitting in a file the server itself can read.

--- a/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/mysqlbulkloader.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/mysqlbulkloader.adoc
@@ -28,6 +28,8 @@ under the License.
 The MySQL bulk loader transform uses the copy command to load data as opposed to sending individual insert statements.
 
 It will create a local file which will then be loaded using the `LOAD DATA` command. More information https://dev.mysql.com/doc/refman/9.2/en/load-data.html[here]
+
+TIP: binary stream fields are written as lowercase hex and restored with `SET col = UNHEX(@col)` so a `BLOB`/`VARBINARY` column receives the original bytes. Null binary values are written as `\N`.
 |
 == Supported Engines
 [%noheader,cols="2,1a",frame=none, role="table-supported-engines"]

--- a/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/orabulkloader.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/orabulkloader.adoc
@@ -27,6 +27,8 @@ under the License.
 
 This transform allows you to bulk load data to an Oracle database. It will write the data it receives to a proper load format and will then invoke Oracle SQL*Loader to transfer it to the specified table.
 
+TIP: binary stream fields are written as lowercase hex. The SQL*Loader control file converts them with `HEXTORAW`.
+
 |
 == Supported Engines
 [%noheader,cols="2,1a",frame=none, role="table-supported-engines"]

--- a/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/postgresbulkloader.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/postgresbulkloader.adoc
@@ -29,6 +29,8 @@ The PostgreSQL bulk loader transform streams data from Hop to Postgresql using h
 
 TIP: boolean stream fields are serialized as `t` or `f`, which PostgreSQL `COPY` accepts for boolean columns.
 
+TIP: binary stream fields (for example a 16-byte hash key) are serialized as PostgreSQL `bytea` hex, `\xdeadbeef`.
+
 |
 == Supported Engines
 [%noheader,cols="2,1a",frame=none, role="table-supported-engines"]

--- a/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/redshift-bulkloader.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/redshift-bulkloader.adoc
@@ -29,6 +29,8 @@ The Redshift Bulk Loader transform loads data from Apache Hop to AWS Redshift us
 
 TIP: make sure your target Redshift table has a layout that is compatible with Parquet data types, e.g. use `int8` instead of `int4` data types.
 
+TIP: binary stream fields are written as lowercase hex (no `\x` prefix), which is what Redshift `COPY` expects for `VARBYTE`.
+
 |
 == Supported Engines
 [%noheader,cols="2,1a",frame=none, role="table-supported-engines"]

--- a/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/snowflakebulkloader.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/snowflakebulkloader.adoc
@@ -31,6 +31,8 @@ The Snowflake bulk loader transform utilizes the Snowflake Copy command to load 
 * Run a put statement to copy the local files to a Snowflake stage.
 * Run a copy command to bulk load the data from the Snowflake stage to a table.
 
+TIP: binary stream fields are written as lowercase hex. The `COPY` file format sets `BINARY_FORMAT = 'HEX'`.
+
 |
 == Supported Engines
 [%noheader,cols="2,1a",frame=none, role="table-supported-engines"]

--- a/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/terafast.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/terafast.adoc
@@ -30,6 +30,8 @@ under the License.
 
 The Teradata Bulkloader transform supports fastloading data into a Teradata database using the fastload command line tool.
 
+TIP: binary stream fields are written as lowercase hex, which is the format FastLoad expects for `BYTE`/`VARBYTE` in a VARTEXT data file.
+
 |
 == Supported Engines
 [%noheader,cols="2,1a",frame=none, role="table-supported-engines"]

--- a/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/verticabulkloader.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/verticabulkloader.adoc
@@ -30,6 +30,8 @@ The Vertica Bulk Loader uses https://www.vertica.com/docs/12.0.x/HTML/Content/Au
 
 This is typically significantly faster than loading data through e.g. a Table Output transform.
 
+TIP: binary stream fields are sent as raw bytes in Vertica's native binary protocol (`BINARY` is zero-padded to the column width, `VARBINARY` carries a length prefix).
+
 |
 == Supported Engines
 [%noheader,cols="2,1a",frame=none, role="table-supported-engines"]

--- a/integration-tests/database/0043-postgresql-bulkloader-binary-validate.hpl
+++ b/integration-tests/database/0043-postgresql-bulkloader-binary-validate.hpl
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<pipeline>
+  <info>
+    <name>0043-postgresql-bulkloader-binary-validate</name>
+    <name_sync_with_filename>Y</name_sync_with_filename>
+    <description>Compares the stored BYTEA values to the original bytes, including NUL and 0xFF.</description>
+    <extended_description/>
+    <pipeline_version/>
+    <pipeline_type>Normal</pipeline_type>
+    <parameters>
+    </parameters>
+    <capture_transform_performance>N</capture_transform_performance>
+    <transform_performance_capturing_delay>1000</transform_performance_capturing_delay>
+    <transform_performance_capturing_size_limit>100</transform_performance_capturing_size_limit>
+    <created_user>-</created_user>
+    <created_date>2026/08/29 12:00:00.000</created_date>
+    <modified_user>-</modified_user>
+    <modified_date>2026/08/29 12:00:00.000</modified_date>
+    <key_for_session_key>H4sIAAAAAAAAAAMAAAAAAAAAAAA=</key_for_session_key>
+    <is_key_private>N</is_key_private>
+  </info>
+  <notepads>
+  </notepads>
+  <order>
+    <hop>
+      <from>Check what was stored</from>
+      <to>All as expected?</to>
+      <enabled>Y</enabled>
+    </hop>
+    <hop>
+      <from>All as expected?</from>
+      <to>Abort</to>
+      <enabled>Y</enabled>
+    </hop>
+  </order>
+  <transform>
+    <name>Check what was stored</name>
+    <type>TableInput</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <connection>unit-test-db</connection>
+    <execute_each_row>N</execute_each_row>
+    <limit>0</limit>
+    <sql>SELECT CASE
+         WHEN (SELECT count(*) FROM public.pg_bulk_bin_test) = 4
+          AND (SELECT payload FROM public.pg_bulk_bin_test WHERE id = 1) = decode('deadbeef', 'hex')
+          AND (SELECT payload FROM public.pg_bulk_bin_test WHERE id = 2) = decode('00ff', 'hex')
+          AND (SELECT payload FROM public.pg_bulk_bin_test WHERE id = 3) IS NULL
+          AND (SELECT payload FROM public.pg_bulk_bin_test WHERE id = 4) = decode('00112233445566778899aabbccddeeff', 'hex')
+         THEN 'ok'
+         ELSE 'bad'
+       END AS result,
+       CONCAT('rows=', (SELECT count(*) FROM public.pg_bulk_bin_test),
+              ', id1=', (SELECT encode(payload, 'hex') FROM public.pg_bulk_bin_test WHERE id = 1),
+              ', id2=', (SELECT encode(payload, 'hex') FROM public.pg_bulk_bin_test WHERE id = 2),
+              ', id3=', (SELECT CASE WHEN payload IS NULL THEN '&lt;null&gt;' ELSE encode(payload, 'hex') END FROM public.pg_bulk_bin_test WHERE id = 3),
+              ', id4=', (SELECT encode(payload, 'hex') FROM public.pg_bulk_bin_test WHERE id = 4)) AS found;</sql>
+    <variables_active>N</variables_active>
+    <attributes/>
+    <GUI>
+      <xloc>176</xloc>
+      <yloc>144</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>All as expected?</name>
+    <type>FilterRows</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <compare>
+      <condition>
+        <conditions>
+</conditions>
+        <function>=</function>
+        <leftvalue>result</leftvalue>
+        <negated>N</negated>
+        <operator>-</operator>
+        <value>
+          <isnull>N</isnull>
+          <length>-1</length>
+          <mask/>
+          <name>constant</name>
+          <precision>-1</precision>
+          <text>ok</text>
+          <type>String</type>
+        </value>
+      </condition>
+    </compare>
+    <send_false_to>Abort</send_false_to>
+    <attributes/>
+    <GUI>
+      <xloc>384</xloc>
+      <yloc>144</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>Abort</name>
+    <type>Abort</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <abort_option>ABORT_WITH_ERROR</abort_option>
+    <always_log_rows>Y</always_log_rows>
+    <message>A binary value did not survive the PostgreSQL bulk load intact</message>
+    <row_threshold>0</row_threshold>
+    <attributes/>
+    <GUI>
+      <xloc>560</xloc>
+      <yloc>144</yloc>
+    </GUI>
+  </transform>
+  <transform_error_handling>
+  </transform_error_handling>
+  <attributes/>
+</pipeline>

--- a/integration-tests/database/0043-postgresql-bulkloader-binary.hpl
+++ b/integration-tests/database/0043-postgresql-bulkloader-binary.hpl
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<pipeline>
+  <info>
+    <name>0043-postgresql-bulkloader-binary</name>
+    <name_sync_with_filename>Y</name_sync_with_filename>
+    <description>Bulk load known binary payloads into PostgreSQL BYTEA.</description>
+    <extended_description/>
+    <pipeline_version/>
+    <pipeline_type>Normal</pipeline_type>
+    <parameters>
+    </parameters>
+    <capture_transform_performance>N</capture_transform_performance>
+    <transform_performance_capturing_delay>1000</transform_performance_capturing_delay>
+    <transform_performance_capturing_size_limit>100</transform_performance_capturing_size_limit>
+    <created_user>-</created_user>
+    <created_date>2026/08/29 12:00:00.000</created_date>
+    <modified_user>-</modified_user>
+    <modified_date>2026/08/29 12:00:00.000</modified_date>
+    <key_for_session_key>H4sIAAAAAAAAAAMAAAAAAAAAAAA=</key_for_session_key>
+    <is_key_private>N</is_key_private>
+  </info>
+  <notepads>
+  </notepads>
+  <order>
+    <hop>
+      <from>binary data</from>
+      <to>PostgreSQL Bulk Loader</to>
+      <enabled>Y</enabled>
+    </hop>
+  </order>
+  <transform>
+    <name>PostgreSQL Bulk Loader</name>
+    <type>PGBulkLoader</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <connection>unit-test-db</connection>
+    <delimiter>;</delimiter>
+    <enclosure>"</enclosure>
+    <load_action>TRUNCATE</load_action>
+    <mapping>
+      <date_mask/>
+      <field_name>id</field_name>
+      <stream_name>id</stream_name>
+    </mapping>
+    <mapping>
+      <date_mask/>
+      <field_name>payload</field_name>
+      <stream_name>payload</stream_name>
+    </mapping>
+    <schema>public</schema>
+    <stop_on_error>Y</stop_on_error>
+    <table>pg_bulk_bin_test</table>
+    <attributes/>
+    <GUI>
+      <xloc>464</xloc>
+      <yloc>128</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>binary data</name>
+    <type>DataSetInput</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <dataSetName>bulk-binary</dataSetName>
+    <attributes/>
+    <GUI>
+      <xloc>176</xloc>
+      <yloc>128</yloc>
+    </GUI>
+  </transform>
+  <transform_error_handling>
+  </transform_error_handling>
+  <attributes/>
+</pipeline>

--- a/integration-tests/database/0044-mysql-bulkloader-binary-validate.hpl
+++ b/integration-tests/database/0044-mysql-bulkloader-binary-validate.hpl
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<pipeline>
+  <info>
+    <name>0044-mysql-bulkloader-binary-validate</name>
+    <name_sync_with_filename>Y</name_sync_with_filename>
+    <description>Compares the stored VARBINARY values to the original bytes, including NUL and 0xFF.</description>
+    <extended_description/>
+    <pipeline_version/>
+    <pipeline_type>Normal</pipeline_type>
+    <parameters>
+    </parameters>
+    <capture_transform_performance>N</capture_transform_performance>
+    <transform_performance_capturing_delay>1000</transform_performance_capturing_delay>
+    <transform_performance_capturing_size_limit>100</transform_performance_capturing_size_limit>
+    <created_user>-</created_user>
+    <created_date>2026/08/29 12:00:00.000</created_date>
+    <modified_user>-</modified_user>
+    <modified_date>2026/08/29 12:00:00.000</modified_date>
+    <key_for_session_key>H4sIAAAAAAAAAAMAAAAAAAAAAAA=</key_for_session_key>
+    <is_key_private>N</is_key_private>
+  </info>
+  <notepads>
+  </notepads>
+  <order>
+    <hop>
+      <from>Check what was stored</from>
+      <to>All as expected?</to>
+      <enabled>Y</enabled>
+    </hop>
+    <hop>
+      <from>All as expected?</from>
+      <to>Abort</to>
+      <enabled>Y</enabled>
+    </hop>
+  </order>
+  <transform>
+    <name>Check what was stored</name>
+    <type>TableInput</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <connection>mysql</connection>
+    <execute_each_row>N</execute_each_row>
+    <limit>0</limit>
+    <sql>SELECT CASE
+         WHEN (SELECT count(*) FROM test_bulk_bin) = 4
+          AND (SELECT payload FROM test_bulk_bin WHERE id = 1) = UNHEX('deadbeef')
+          AND (SELECT payload FROM test_bulk_bin WHERE id = 2) = UNHEX('00ff')
+          AND (SELECT payload FROM test_bulk_bin WHERE id = 3) IS NULL
+          AND (SELECT payload FROM test_bulk_bin WHERE id = 4) = UNHEX('00112233445566778899aabbccddeeff')
+         THEN 'ok'
+         ELSE 'bad'
+       END AS result,
+       CONCAT('rows=', (SELECT count(*) FROM test_bulk_bin),
+              ', id1=', (SELECT HEX(payload) FROM test_bulk_bin WHERE id = 1),
+              ', id2=', (SELECT HEX(payload) FROM test_bulk_bin WHERE id = 2),
+              ', id3=', (SELECT IF(payload IS NULL, '&lt;null&gt;', HEX(payload)) FROM test_bulk_bin WHERE id = 3),
+              ', id4=', (SELECT HEX(payload) FROM test_bulk_bin WHERE id = 4)) AS found;</sql>
+    <variables_active>N</variables_active>
+    <attributes/>
+    <GUI>
+      <xloc>176</xloc>
+      <yloc>144</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>All as expected?</name>
+    <type>FilterRows</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <compare>
+      <condition>
+        <conditions>
+</conditions>
+        <function>=</function>
+        <leftvalue>result</leftvalue>
+        <negated>N</negated>
+        <operator>-</operator>
+        <value>
+          <isnull>N</isnull>
+          <length>-1</length>
+          <mask/>
+          <name>constant</name>
+          <precision>-1</precision>
+          <text>ok</text>
+          <type>String</type>
+        </value>
+      </condition>
+    </compare>
+    <send_false_to>Abort</send_false_to>
+    <attributes/>
+    <GUI>
+      <xloc>384</xloc>
+      <yloc>144</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>Abort</name>
+    <type>Abort</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <abort_option>ABORT_WITH_ERROR</abort_option>
+    <always_log_rows>Y</always_log_rows>
+    <message>A binary value did not survive the MySQL bulk load intact</message>
+    <row_threshold>0</row_threshold>
+    <attributes/>
+    <GUI>
+      <xloc>560</xloc>
+      <yloc>144</yloc>
+    </GUI>
+  </transform>
+  <transform_error_handling>
+  </transform_error_handling>
+  <attributes/>
+</pipeline>

--- a/integration-tests/database/0044-mysql-bulkloader-binary.hpl
+++ b/integration-tests/database/0044-mysql-bulkloader-binary.hpl
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<pipeline>
+  <info>
+    <name>0044-mysql-bulkloader-binary</name>
+    <name_sync_with_filename>Y</name_sync_with_filename>
+    <description>Bulk load known binary payloads into MySQL VARBINARY.</description>
+    <extended_description/>
+    <pipeline_version/>
+    <pipeline_type>Normal</pipeline_type>
+    <parameters>
+    </parameters>
+    <capture_transform_performance>N</capture_transform_performance>
+    <transform_performance_capturing_delay>1000</transform_performance_capturing_delay>
+    <transform_performance_capturing_size_limit>100</transform_performance_capturing_size_limit>
+    <created_user>-</created_user>
+    <created_date>2026/08/29 12:00:00.000</created_date>
+    <modified_user>-</modified_user>
+    <modified_date>2026/08/29 12:00:00.000</modified_date>
+    <key_for_session_key>H4sIAAAAAAAAAAMAAAAAAAAAAAA=</key_for_session_key>
+    <is_key_private>N</is_key_private>
+  </info>
+  <notepads>
+  </notepads>
+  <order>
+    <hop>
+      <from>binary data</from>
+      <to>MySQL bulk loader</to>
+      <enabled>Y</enabled>
+    </hop>
+  </order>
+  <transform>
+    <name>binary data</name>
+    <type>DataSetInput</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <dataSetName>bulk-binary</dataSetName>
+    <attributes/>
+    <GUI>
+      <xloc>176</xloc>
+      <yloc>160</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>MySQL bulk loader</name>
+    <type>MySqlBulkLoader</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <bulk_size/>
+    <connection>mysql</connection>
+    <delimiter>	</delimiter>
+    <enclosure>"</enclosure>
+    <encoding/>
+    <escape_char>\</escape_char>
+    <fields>
+      <field>
+        <field_format_ok>OK</field_format_ok>
+        <field_name>id</field_name>
+        <stream_name>id</stream_name>
+      </field>
+      <field>
+        <field_format_ok>OK</field_format_ok>
+        <field_name>payload</field_name>
+        <stream_name>payload</stream_name>
+      </field>
+    </fields>
+    <fifo_file_name>/tmp/fifo</fifo_file_name>
+    <ignore>N</ignore>
+    <local>Y</local>
+    <replace>N</replace>
+    <schema/>
+    <table>test_bulk_bin</table>
+    <attributes/>
+    <GUI>
+      <xloc>464</xloc>
+      <yloc>160</yloc>
+    </GUI>
+  </transform>
+  <transform_error_handling>
+  </transform_error_handling>
+  <attributes/>
+</pipeline>

--- a/integration-tests/database/datasets/bulk-binary.csv
+++ b/integration-tests/database/datasets/bulk-binary.csv
@@ -1,0 +1,5 @@
+id,payload
+1,deadbeef
+2,00ff
+3,
+4,00112233445566778899aabbccddeeff

--- a/integration-tests/database/main-0043-postgresql-bulkloader-binary.hwf
+++ b/integration-tests/database/main-0043-postgresql-bulkloader-binary.hwf
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<workflow>
+  <name>main-0043-postgresql-bulkloader-binary</name>
+  <name_sync_with_filename>Y</name_sync_with_filename>
+  <description>Bulk load known BYTEA values and compare the stored bytes to the originals.</description>
+  <extended_description/>
+  <workflow_version/>
+  <created_user>-</created_user>
+  <created_date>2026/08/29 12:00:00.000</created_date>
+  <modified_user>-</modified_user>
+  <modified_date>2026/08/29 12:00:00.000</modified_date>
+  <parameters>
+    </parameters>
+  <actions>
+    <action>
+      <name>Start</name>
+      <description/>
+      <type>SPECIAL</type>
+      <attributes/>
+      <DayOfMonth>1</DayOfMonth>
+      <hour>12</hour>
+      <intervalMinutes>60</intervalMinutes>
+      <intervalSeconds>0</intervalSeconds>
+      <minutes>0</minutes>
+      <repeat>N</repeat>
+      <schedulerType>0</schedulerType>
+      <weekDay>1</weekDay>
+      <parallel>N</parallel>
+      <xloc>80</xloc>
+      <yloc>80</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>SQL</name>
+      <description/>
+      <type>SQL</type>
+      <attributes/>
+      <sql/>
+      <useVariableSubstitution>F</useVariableSubstitution>
+      <sqlfromfile>T</sqlfromfile>
+      <sqlfilename>${PROJECT_HOME}/scripts/script_postgresql_bulkloader_binary.sql</sqlfilename>
+      <sendOneStatement>F</sendOneStatement>
+      <connection>unit-test-db</connection>
+      <parallel>N</parallel>
+      <xloc>256</xloc>
+      <yloc>80</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>0043-postgresql-bulkloader-binary.hpl</name>
+      <description/>
+      <type>PIPELINE</type>
+      <attributes/>
+      <filename>${PROJECT_HOME}/0043-postgresql-bulkloader-binary.hpl</filename>
+      <params_from_previous>N</params_from_previous>
+      <exec_per_row>N</exec_per_row>
+      <clear_rows>N</clear_rows>
+      <clear_files>N</clear_files>
+      <set_logfile>N</set_logfile>
+      <logfile/>
+      <logext/>
+      <add_date>N</add_date>
+      <add_time>N</add_time>
+      <loglevel>Basic</loglevel>
+      <set_append_logfile>N</set_append_logfile>
+      <wait_until_finished>Y</wait_until_finished>
+      <create_parent_folder>N</create_parent_folder>
+      <run_configuration>local</run_configuration>
+      <parameters>
+        <pass_all_parameters>Y</pass_all_parameters>
+      </parameters>
+      <parallel>N</parallel>
+      <xloc>464</xloc>
+      <yloc>80</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>Validate</name>
+      <description/>
+      <type>PIPELINE</type>
+      <attributes/>
+      <filename>${PROJECT_HOME}/0043-postgresql-bulkloader-binary-validate.hpl</filename>
+      <params_from_previous>N</params_from_previous>
+      <exec_per_row>N</exec_per_row>
+      <clear_rows>N</clear_rows>
+      <clear_files>N</clear_files>
+      <set_logfile>N</set_logfile>
+      <logfile/>
+      <logext/>
+      <add_date>N</add_date>
+      <add_time>N</add_time>
+      <loglevel>Basic</loglevel>
+      <set_append_logfile>N</set_append_logfile>
+      <wait_until_finished>Y</wait_until_finished>
+      <create_parent_folder>N</create_parent_folder>
+      <run_configuration>local</run_configuration>
+      <parameters>
+        <pass_all_parameters>Y</pass_all_parameters>
+      </parameters>
+      <parallel>N</parallel>
+      <xloc>672</xloc>
+      <yloc>80</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>Abort workflow</name>
+      <description/>
+      <type>ABORT</type>
+      <attributes/>
+      <always_log_rows>N</always_log_rows>
+      <parallel>N</parallel>
+      <xloc>464</xloc>
+      <yloc>208</yloc>
+      <attributes_hac/>
+    </action>
+  </actions>
+  <hops>
+    <hop>
+      <from>Start</from>
+      <to>SQL</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>Y</unconditional>
+    </hop>
+    <hop>
+      <from>SQL</from>
+      <to>0043-postgresql-bulkloader-binary.hpl</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>N</unconditional>
+    </hop>
+    <hop>
+      <from>0043-postgresql-bulkloader-binary.hpl</from>
+      <to>Validate</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>N</unconditional>
+    </hop>
+    <hop>
+      <from>0043-postgresql-bulkloader-binary.hpl</from>
+      <to>Abort workflow</to>
+      <enabled>Y</enabled>
+      <evaluation>N</evaluation>
+      <unconditional>N</unconditional>
+    </hop>
+    <hop>
+      <from>Validate</from>
+      <to>Abort workflow</to>
+      <enabled>Y</enabled>
+      <evaluation>N</evaluation>
+      <unconditional>N</unconditional>
+    </hop>
+  </hops>
+  <notepads>
+  </notepads>
+  <attributes/>
+</workflow>

--- a/integration-tests/database/main-0044-mysql-bulkloader-binary.hwf
+++ b/integration-tests/database/main-0044-mysql-bulkloader-binary.hwf
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<workflow>
+  <name>main-0044-mysql-bulkloader-binary</name>
+  <name_sync_with_filename>Y</name_sync_with_filename>
+  <description>Bulk load known VARBINARY values and compare the stored bytes to the originals.</description>
+  <extended_description/>
+  <workflow_version/>
+  <created_user>-</created_user>
+  <created_date>2026/08/29 12:00:00.000</created_date>
+  <modified_user>-</modified_user>
+  <modified_date>2026/08/29 12:00:00.000</modified_date>
+  <parameters>
+    </parameters>
+  <actions>
+    <action>
+      <name>Start</name>
+      <description/>
+      <type>SPECIAL</type>
+      <attributes/>
+      <DayOfMonth>1</DayOfMonth>
+      <hour>12</hour>
+      <intervalMinutes>60</intervalMinutes>
+      <intervalSeconds>0</intervalSeconds>
+      <minutes>0</minutes>
+      <repeat>N</repeat>
+      <schedulerType>0</schedulerType>
+      <weekDay>1</weekDay>
+      <parallel>N</parallel>
+      <xloc>80</xloc>
+      <yloc>80</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>Create table</name>
+      <description/>
+      <type>SQL</type>
+      <attributes/>
+      <connection>mysql</connection>
+      <sendOneStatement>N</sendOneStatement>
+      <sql>DROP TABLE IF EXISTS `test_bulk_bin`;
+
+CREATE TABLE `test_bulk_bin` (
+  `id` int DEFAULT NULL,
+  `payload` varbinary(64) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;</sql>
+      <sqlfromfile>N</sqlfromfile>
+      <useVariableSubstitution>N</useVariableSubstitution>
+      <parallel>N</parallel>
+      <xloc>256</xloc>
+      <yloc>80</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>0044-mysql-bulkloader-binary.hpl</name>
+      <description/>
+      <type>PIPELINE</type>
+      <attributes/>
+      <add_date>N</add_date>
+      <add_time>N</add_time>
+      <clear_files>N</clear_files>
+      <clear_rows>N</clear_rows>
+      <create_parent_folder>N</create_parent_folder>
+      <exec_per_row>N</exec_per_row>
+      <filename>${PROJECT_HOME}/0044-mysql-bulkloader-binary.hpl</filename>
+      <loglevel>Basic</loglevel>
+      <parameters>
+        <pass_all_parameters>Y</pass_all_parameters>
+      </parameters>
+      <params_from_previous>N</params_from_previous>
+      <run_configuration>local</run_configuration>
+      <set_append_logfile>N</set_append_logfile>
+      <set_logfile>N</set_logfile>
+      <wait_until_finished>Y</wait_until_finished>
+      <parallel>N</parallel>
+      <xloc>464</xloc>
+      <yloc>80</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>Validate</name>
+      <description/>
+      <type>PIPELINE</type>
+      <attributes/>
+      <add_date>N</add_date>
+      <add_time>N</add_time>
+      <clear_files>N</clear_files>
+      <clear_rows>N</clear_rows>
+      <create_parent_folder>N</create_parent_folder>
+      <exec_per_row>N</exec_per_row>
+      <filename>${PROJECT_HOME}/0044-mysql-bulkloader-binary-validate.hpl</filename>
+      <loglevel>Basic</loglevel>
+      <parameters>
+        <pass_all_parameters>Y</pass_all_parameters>
+      </parameters>
+      <params_from_previous>N</params_from_previous>
+      <run_configuration>local</run_configuration>
+      <set_append_logfile>N</set_append_logfile>
+      <set_logfile>N</set_logfile>
+      <wait_until_finished>Y</wait_until_finished>
+      <parallel>N</parallel>
+      <xloc>672</xloc>
+      <yloc>80</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>Abort workflow</name>
+      <description/>
+      <type>ABORT</type>
+      <attributes/>
+      <always_log_rows>N</always_log_rows>
+      <parallel>N</parallel>
+      <xloc>464</xloc>
+      <yloc>208</yloc>
+      <attributes_hac/>
+    </action>
+  </actions>
+  <hops>
+    <hop>
+      <from>Start</from>
+      <to>Create table</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>Y</unconditional>
+    </hop>
+    <hop>
+      <from>Create table</from>
+      <to>0044-mysql-bulkloader-binary.hpl</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>Y</unconditional>
+    </hop>
+    <hop>
+      <from>0044-mysql-bulkloader-binary.hpl</from>
+      <to>Validate</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>N</unconditional>
+    </hop>
+    <hop>
+      <from>0044-mysql-bulkloader-binary.hpl</from>
+      <to>Abort workflow</to>
+      <enabled>Y</enabled>
+      <evaluation>N</evaluation>
+      <unconditional>N</unconditional>
+    </hop>
+    <hop>
+      <from>Validate</from>
+      <to>Abort workflow</to>
+      <enabled>Y</enabled>
+      <evaluation>N</evaluation>
+      <unconditional>N</unconditional>
+    </hop>
+  </hops>
+  <notepads>
+  </notepads>
+  <attributes/>
+</workflow>

--- a/integration-tests/database/metadata/dataset/bulk-binary.json
+++ b/integration-tests/database/metadata/dataset/bulk-binary.json
@@ -1,0 +1,24 @@
+{
+  "base_filename": "bulk-binary.csv",
+  "name": "bulk-binary",
+  "description": "Known binary payloads for bulk-loader integration tests",
+  "dataset_fields": [
+    {
+      "field_comment": "",
+      "field_length": -1,
+      "field_type": 5,
+      "field_precision": 0,
+      "field_name": "id",
+      "field_format": "0"
+    },
+    {
+      "field_comment": "",
+      "field_length": -1,
+      "field_type": 8,
+      "field_precision": -1,
+      "field_name": "payload",
+      "field_format": ""
+    }
+  ],
+  "folder_name": "${HOP_DATASETS_FOLDER}"
+}

--- a/integration-tests/database/scripts/script_postgresql_bulkloader_binary.sql
+++ b/integration-tests/database/scripts/script_postgresql_bulkloader_binary.sql
@@ -1,0 +1,24 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file to
+you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+DROP TABLE IF EXISTS public.pg_bulk_bin_test;
+
+CREATE TABLE public.pg_bulk_bin_test
+(
+    id      integer NULL,
+    payload bytea NULL
+);

--- a/integration-tests/monetdb/0003-monetdb-bulk-loader-binary-validate.hpl
+++ b/integration-tests/monetdb/0003-monetdb-bulk-loader-binary-validate.hpl
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<pipeline>
+  <info>
+    <name>0003-monetdb-bulk-loader-binary-validate</name>
+    <name_sync_with_filename>Y</name_sync_with_filename>
+    <description>Compares the stored BLOB values to the original bytes, including NUL and 0xFF.</description>
+    <extended_description/>
+    <pipeline_version/>
+    <pipeline_type>Normal</pipeline_type>
+    <parameters>
+    </parameters>
+    <capture_transform_performance>N</capture_transform_performance>
+    <transform_performance_capturing_delay>1000</transform_performance_capturing_delay>
+    <transform_performance_capturing_size_limit>100</transform_performance_capturing_size_limit>
+    <created_user>-</created_user>
+    <created_date>2026/08/29 12:00:00.000</created_date>
+    <modified_user>-</modified_user>
+    <modified_date>2026/08/29 12:00:00.000</modified_date>
+    <key_for_session_key>H4sIAAAAAAAAAAMAAAAAAAAAAAA=</key_for_session_key>
+    <is_key_private>N</is_key_private>
+  </info>
+  <notepads>
+  </notepads>
+  <order>
+    <hop>
+      <from>Check what was stored</from>
+      <to>All as expected?</to>
+      <enabled>Y</enabled>
+    </hop>
+    <hop>
+      <from>All as expected?</from>
+      <to>Abort</to>
+      <enabled>Y</enabled>
+    </hop>
+  </order>
+  <transform>
+    <name>Check what was stored</name>
+    <type>TableInput</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <connection>monetdb</connection>
+    <execute_each_row>N</execute_each_row>
+    <limit>0</limit>
+    <sql>SELECT CASE
+         WHEN (SELECT count(*) FROM sys.bulk_bin) = 4
+          AND (SELECT payload FROM sys.bulk_bin WHERE id = 1) = blob 'deadbeef'
+          AND (SELECT payload FROM sys.bulk_bin WHERE id = 2) = blob '00ff'
+          AND (SELECT payload FROM sys.bulk_bin WHERE id = 3) IS NULL
+          AND (SELECT payload FROM sys.bulk_bin WHERE id = 4) = blob '00112233445566778899aabbccddeeff'
+         THEN 'ok'
+         ELSE 'bad'
+       END AS result,
+       'rows=' || CAST((SELECT count(*) FROM sys.bulk_bin) AS VARCHAR(16)) ||
+       ', id3null=' || (SELECT CASE WHEN payload IS NULL THEN 'Y' ELSE 'N' END FROM sys.bulk_bin WHERE id = 3) AS found;</sql>
+    <variables_active>N</variables_active>
+    <attributes/>
+    <GUI>
+      <xloc>176</xloc>
+      <yloc>144</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>All as expected?</name>
+    <type>FilterRows</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <compare>
+      <condition>
+        <conditions>
+</conditions>
+        <function>=</function>
+        <leftvalue>result</leftvalue>
+        <negated>N</negated>
+        <operator>-</operator>
+        <value>
+          <isnull>N</isnull>
+          <length>-1</length>
+          <mask/>
+          <name>constant</name>
+          <precision>-1</precision>
+          <text>ok</text>
+          <type>String</type>
+        </value>
+      </condition>
+    </compare>
+    <send_false_to>Abort</send_false_to>
+    <attributes/>
+    <GUI>
+      <xloc>384</xloc>
+      <yloc>144</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>Abort</name>
+    <type>Abort</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <abort_option>ABORT_WITH_ERROR</abort_option>
+    <always_log_rows>Y</always_log_rows>
+    <message>A binary value did not survive the MonetDB bulk load intact</message>
+    <row_threshold>0</row_threshold>
+    <attributes/>
+    <GUI>
+      <xloc>560</xloc>
+      <yloc>144</yloc>
+    </GUI>
+  </transform>
+  <transform_error_handling>
+  </transform_error_handling>
+  <attributes/>
+</pipeline>

--- a/integration-tests/monetdb/0003-monetdb-bulk-loader-binary.hpl
+++ b/integration-tests/monetdb/0003-monetdb-bulk-loader-binary.hpl
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<pipeline>
+  <info>
+    <name>0003-monetdb-bulk-loader-binary</name>
+    <name_sync_with_filename>Y</name_sync_with_filename>
+    <description>Bulk load known binary payloads into MonetDB BLOB.</description>
+    <extended_description/>
+    <pipeline_version/>
+    <pipeline_type>Normal</pipeline_type>
+    <parameters>
+    </parameters>
+    <capture_transform_performance>N</capture_transform_performance>
+    <transform_performance_capturing_delay>1000</transform_performance_capturing_delay>
+    <transform_performance_capturing_size_limit>100</transform_performance_capturing_size_limit>
+    <created_user>-</created_user>
+    <created_date>2026/08/29 12:00:00.000</created_date>
+    <modified_user>-</modified_user>
+    <modified_date>2026/08/29 12:00:00.000</modified_date>
+    <key_for_session_key>H4sIAAAAAAAAAAMAAAAAAAAAAAA=</key_for_session_key>
+    <is_key_private>N</is_key_private>
+  </info>
+  <notepads>
+  </notepads>
+  <order>
+    <hop>
+      <from>binary data</from>
+      <to>MonetDB bulk loader</to>
+      <enabled>Y</enabled>
+    </hop>
+  </order>
+  <transform>
+    <name>binary data</name>
+    <type>DataSetInput</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <dataSetName>bulk-binary</dataSetName>
+    <attributes/>
+    <GUI>
+      <xloc>128</xloc>
+      <yloc>80</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>MonetDB bulk loader</name>
+    <type>MonetDBBulkLoader</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <connection>monetdb</connection>
+    <buffer_size>100000</buffer_size>
+    <schema>sys</schema>
+    <table>bulk_bin</table>
+    <log_file/>
+    <truncate>N</truncate>
+    <fully_quote_sql>Y</fully_quote_sql>
+    <field_separator>|</field_separator>
+    <field_enclosure>"</field_enclosure>
+    <null_representation>null</null_representation>
+    <encoding>UTF-8</encoding>
+    <mapping>
+      <stream_name>id</stream_name>
+      <field_name>id</field_name>
+      <field_format_ok>N</field_format_ok>
+    </mapping>
+    <mapping>
+      <stream_name>payload</stream_name>
+      <field_name>payload</field_name>
+      <field_format_ok>N</field_format_ok>
+    </mapping>
+    <attributes/>
+    <GUI>
+      <xloc>352</xloc>
+      <yloc>80</yloc>
+    </GUI>
+  </transform>
+  <transform_error_handling>
+  </transform_error_handling>
+  <attributes/>
+</pipeline>

--- a/integration-tests/monetdb/datasets/bulk-binary.csv
+++ b/integration-tests/monetdb/datasets/bulk-binary.csv
@@ -1,0 +1,5 @@
+id,payload
+1,deadbeef
+2,00ff
+3,
+4,00112233445566778899aabbccddeeff

--- a/integration-tests/monetdb/main-0003-monetdb-bulk-loader-binary.hwf
+++ b/integration-tests/monetdb/main-0003-monetdb-bulk-loader-binary.hwf
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<workflow>
+  <name>main-0003-monetdb-bulk-loader-binary</name>
+  <name_sync_with_filename>Y</name_sync_with_filename>
+  <description>Bulk load known BLOB values and compare the stored bytes to the originals.</description>
+  <extended_description/>
+  <workflow_version/>
+  <created_user>-</created_user>
+  <created_date>2026/08/29 12:00:00.000</created_date>
+  <modified_user>-</modified_user>
+  <modified_date>2026/08/29 12:00:00.000</modified_date>
+  <parameters>
+    </parameters>
+  <actions>
+    <action>
+      <name>Start</name>
+      <description/>
+      <type>SPECIAL</type>
+      <attributes/>
+      <repeat>N</repeat>
+      <schedulerType>0</schedulerType>
+      <intervalSeconds>0</intervalSeconds>
+      <intervalMinutes>60</intervalMinutes>
+      <hour>12</hour>
+      <minutes>0</minutes>
+      <weekDay>1</weekDay>
+      <DayOfMonth>1</DayOfMonth>
+      <parallel>N</parallel>
+      <xloc>50</xloc>
+      <yloc>50</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>SQL</name>
+      <description/>
+      <type>SQL</type>
+      <attributes/>
+      <sql>DROP TABLE IF EXISTS sys.bulk_bin;
+CREATE TABLE sys.bulk_bin (
+    id integer,
+    payload blob
+)</sql>
+      <useVariableSubstitution>F</useVariableSubstitution>
+      <sqlfromfile>F</sqlfromfile>
+      <sqlfilename/>
+      <sendOneStatement>F</sendOneStatement>
+      <connection>monetdb</connection>
+      <parallel>N</parallel>
+      <xloc>208</xloc>
+      <yloc>50</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>0003-monetdb-bulk-loader-binary.hpl</name>
+      <description/>
+      <type>PIPELINE</type>
+      <attributes/>
+      <filename>${PROJECT_HOME}/0003-monetdb-bulk-loader-binary.hpl</filename>
+      <params_from_previous>N</params_from_previous>
+      <exec_per_row>N</exec_per_row>
+      <clear_rows>N</clear_rows>
+      <clear_files>N</clear_files>
+      <set_logfile>N</set_logfile>
+      <logfile/>
+      <logext/>
+      <add_date>N</add_date>
+      <add_time>N</add_time>
+      <loglevel>Basic</loglevel>
+      <set_append_logfile>N</set_append_logfile>
+      <wait_until_finished>Y</wait_until_finished>
+      <create_parent_folder>N</create_parent_folder>
+      <run_configuration>local</run_configuration>
+      <parameters>
+        <pass_all_parameters>Y</pass_all_parameters>
+      </parameters>
+      <parallel>N</parallel>
+      <xloc>400</xloc>
+      <yloc>50</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>Validate</name>
+      <description/>
+      <type>PIPELINE</type>
+      <attributes/>
+      <filename>${PROJECT_HOME}/0003-monetdb-bulk-loader-binary-validate.hpl</filename>
+      <params_from_previous>N</params_from_previous>
+      <exec_per_row>N</exec_per_row>
+      <clear_rows>N</clear_rows>
+      <clear_files>N</clear_files>
+      <set_logfile>N</set_logfile>
+      <logfile/>
+      <logext/>
+      <add_date>N</add_date>
+      <add_time>N</add_time>
+      <loglevel>Basic</loglevel>
+      <set_append_logfile>N</set_append_logfile>
+      <wait_until_finished>Y</wait_until_finished>
+      <create_parent_folder>N</create_parent_folder>
+      <run_configuration>local</run_configuration>
+      <parameters>
+        <pass_all_parameters>Y</pass_all_parameters>
+      </parameters>
+      <parallel>N</parallel>
+      <xloc>608</xloc>
+      <yloc>50</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>Abort workflow</name>
+      <description/>
+      <type>ABORT</type>
+      <attributes/>
+      <always_log_rows>N</always_log_rows>
+      <parallel>N</parallel>
+      <xloc>400</xloc>
+      <yloc>176</yloc>
+      <attributes_hac/>
+    </action>
+  </actions>
+  <hops>
+    <hop>
+      <from>Start</from>
+      <to>SQL</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>Y</unconditional>
+    </hop>
+    <hop>
+      <from>SQL</from>
+      <to>0003-monetdb-bulk-loader-binary.hpl</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>N</unconditional>
+    </hop>
+    <hop>
+      <from>0003-monetdb-bulk-loader-binary.hpl</from>
+      <to>Validate</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>N</unconditional>
+    </hop>
+    <hop>
+      <from>0003-monetdb-bulk-loader-binary.hpl</from>
+      <to>Abort workflow</to>
+      <enabled>Y</enabled>
+      <evaluation>N</evaluation>
+      <unconditional>N</unconditional>
+    </hop>
+    <hop>
+      <from>Validate</from>
+      <to>Abort workflow</to>
+      <enabled>Y</enabled>
+      <evaluation>N</evaluation>
+      <unconditional>N</unconditional>
+    </hop>
+  </hops>
+  <notepads>
+  </notepads>
+  <attributes/>
+</workflow>

--- a/integration-tests/monetdb/metadata/dataset/bulk-binary.json
+++ b/integration-tests/monetdb/metadata/dataset/bulk-binary.json
@@ -1,0 +1,24 @@
+{
+  "base_filename": "bulk-binary.csv",
+  "name": "bulk-binary",
+  "description": "Known binary payloads for bulk-loader integration tests",
+  "dataset_fields": [
+    {
+      "field_comment": "",
+      "field_length": -1,
+      "field_type": 5,
+      "field_precision": 0,
+      "field_name": "id",
+      "field_format": "0"
+    },
+    {
+      "field_comment": "",
+      "field_length": -1,
+      "field_type": 8,
+      "field_precision": -1,
+      "field_name": "payload",
+      "field_format": ""
+    }
+  ],
+  "folder_name": "${HOP_DATASETS_FOLDER}"
+}

--- a/integration-tests/mssql/0007-bulk-loader-binary-validate.hpl
+++ b/integration-tests/mssql/0007-bulk-loader-binary-validate.hpl
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<pipeline>
+  <info>
+    <name>0007-bulk-loader-binary-validate</name>
+    <name_sync_with_filename>Y</name_sync_with_filename>
+    <description>Compares the stored VARBINARY values to the original bytes, including NUL and 0xFF.</description>
+    <extended_description/>
+    <pipeline_version/>
+    <pipeline_type>Normal</pipeline_type>
+    <parameters>
+    </parameters>
+    <capture_transform_performance>N</capture_transform_performance>
+    <transform_performance_capturing_delay>1000</transform_performance_capturing_delay>
+    <transform_performance_capturing_size_limit>100</transform_performance_capturing_size_limit>
+    <created_user>-</created_user>
+    <created_date>2026/08/29 12:00:00.000</created_date>
+    <modified_user>-</modified_user>
+    <modified_date>2026/08/29 12:00:00.000</modified_date>
+  </info>
+  <notepads>
+  </notepads>
+  <order>
+    <hop>
+      <from>Check what was stored</from>
+      <to>All as expected?</to>
+      <enabled>Y</enabled>
+    </hop>
+    <hop>
+      <from>All as expected?</from>
+      <to>Abort</to>
+      <enabled>Y</enabled>
+    </hop>
+  </order>
+  <transform>
+    <name>Check what was stored</name>
+    <type>TableInput</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <connection>${MSSQL_CONNECTION}</connection>
+    <execute_each_row>N</execute_each_row>
+    <limit>0</limit>
+    <sql>SELECT CASE
+         WHEN (SELECT count(*) FROM master.dbo.bulkloader_binary) = 4
+          AND (SELECT payload FROM master.dbo.bulkloader_binary WHERE id = 1) = 0xDEADBEEF
+          AND (SELECT payload FROM master.dbo.bulkloader_binary WHERE id = 2) = 0x00FF
+          AND (SELECT payload FROM master.dbo.bulkloader_binary WHERE id = 3) IS NULL
+          AND (SELECT payload FROM master.dbo.bulkloader_binary WHERE id = 4) = 0x00112233445566778899AABBCCDDEEFF
+         THEN 'ok'
+         ELSE 'bad'
+       END AS result,
+       CONCAT('rows=', (SELECT count(*) FROM master.dbo.bulkloader_binary),
+              ', id1=', (SELECT CONVERT(varchar(max), payload, 2) FROM master.dbo.bulkloader_binary WHERE id = 1),
+              ', id2=', (SELECT CONVERT(varchar(max), payload, 2) FROM master.dbo.bulkloader_binary WHERE id = 2),
+              ', id3=', (SELECT IIF(payload IS NULL, '&lt;null&gt;', CONVERT(varchar(max), payload, 2)) FROM master.dbo.bulkloader_binary WHERE id = 3),
+              ', id4=', (SELECT CONVERT(varchar(max), payload, 2) FROM master.dbo.bulkloader_binary WHERE id = 4)) AS found;</sql>
+    <variables_active>N</variables_active>
+    <attributes/>
+    <GUI>
+      <xloc>176</xloc>
+      <yloc>144</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>All as expected?</name>
+    <type>FilterRows</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <compare>
+      <condition>
+        <conditions>
+</conditions>
+        <function>=</function>
+        <leftvalue>result</leftvalue>
+        <negated>N</negated>
+        <operator>-</operator>
+        <value>
+          <isnull>N</isnull>
+          <length>-1</length>
+          <mask/>
+          <name>constant</name>
+          <precision>-1</precision>
+          <text>ok</text>
+          <type>String</type>
+        </value>
+      </condition>
+    </compare>
+    <send_false_to>Abort</send_false_to>
+    <attributes/>
+    <GUI>
+      <xloc>384</xloc>
+      <yloc>144</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>Abort</name>
+    <type>Abort</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <abort_option>ABORT_WITH_ERROR</abort_option>
+    <always_log_rows>Y</always_log_rows>
+    <message>A binary value did not survive the SQL Server bulk copy intact</message>
+    <row_threshold>0</row_threshold>
+    <attributes/>
+    <GUI>
+      <xloc>560</xloc>
+      <yloc>144</yloc>
+    </GUI>
+  </transform>
+  <transform_error_handling>
+  </transform_error_handling>
+  <attributes/>
+</pipeline>

--- a/integration-tests/mssql/0007-bulk-loader-binary.hpl
+++ b/integration-tests/mssql/0007-bulk-loader-binary.hpl
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<pipeline>
+  <info>
+    <name>0007-bulk-loader-binary</name>
+    <name_sync_with_filename>Y</name_sync_with_filename>
+    <description>Bulk load known binary payloads into SQL Server VARBINARY.</description>
+    <extended_description/>
+    <pipeline_version/>
+    <pipeline_type>Normal</pipeline_type>
+    <parameters>
+    </parameters>
+    <capture_transform_performance>N</capture_transform_performance>
+    <transform_performance_capturing_delay>1000</transform_performance_capturing_delay>
+    <transform_performance_capturing_size_limit>100</transform_performance_capturing_size_limit>
+    <created_user>-</created_user>
+    <created_date>2026/08/29 12:00:00.000</created_date>
+    <modified_user>-</modified_user>
+    <modified_date>2026/08/29 12:00:00.000</modified_date>
+  </info>
+  <notepads>
+  </notepads>
+  <order>
+    <hop>
+      <from>binary data</from>
+      <to>Bulk load binary</to>
+      <enabled>Y</enabled>
+    </hop>
+  </order>
+  <transform>
+    <name>binary data</name>
+    <type>DataSetInput</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <dataSetName>bulk-binary</dataSetName>
+    <attributes/>
+    <GUI>
+      <xloc>176</xloc>
+      <yloc>144</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>Bulk load binary</name>
+    <type>MsSqlServerBulkLoader</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <allow_encrypted_value_modifications>N</allow_encrypted_value_modifications>
+    <batch_size>3</batch_size>
+    <bulk_copy_timeout>0</bulk_copy_timeout>
+    <check_constraints>N</check_constraints>
+    <connection>${MSSQL_CONNECTION}</connection>
+    <fields>
+      <field>
+        <order_hint>NONE</order_hint>
+        <stream_field>id</stream_field>
+        <table_field>id</table_field>
+      </field>
+      <field>
+        <order_hint>NONE</order_hint>
+        <stream_field>payload</stream_field>
+        <table_field>payload</table_field>
+      </field>
+    </fields>
+    <fire_triggers>N</fire_triggers>
+    <keep_identity>N</keep_identity>
+    <keep_nulls>Y</keep_nulls>
+    <only_when_have_rows>N</only_when_have_rows>
+    <schema>dbo</schema>
+    <specify_fields>Y</specify_fields>
+    <table>bulkloader_binary</table>
+    <table_lock>Y</table_lock>
+    <truncate>Y</truncate>
+    <attributes/>
+    <GUI>
+      <xloc>400</xloc>
+      <yloc>144</yloc>
+    </GUI>
+  </transform>
+  <transform_error_handling>
+  </transform_error_handling>
+  <attributes/>
+</pipeline>

--- a/integration-tests/mssql/0007-bulk-loader-binary.hwf
+++ b/integration-tests/mssql/0007-bulk-loader-binary.hwf
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<workflow>
+  <name>0007-bulk-loader-binary</name>
+  <name_sync_with_filename>Y</name_sync_with_filename>
+  <description>Create a VARBINARY table, bulk load known bytes, and compare what landed.</description>
+  <extended_description/>
+  <workflow_version/>
+  <created_user>-</created_user>
+  <created_date>2026/08/29 12:00:00.000</created_date>
+  <modified_user>-</modified_user>
+  <modified_date>2026/08/29 12:00:00.000</modified_date>
+  <parameters>
+    </parameters>
+  <actions>
+    <action>
+      <name>Start</name>
+      <description/>
+      <type>SPECIAL</type>
+      <attributes/>
+      <DayOfMonth>1</DayOfMonth>
+      <doNotWaitOnFirstExecution>N</doNotWaitOnFirstExecution>
+      <hour>12</hour>
+      <intervalMinutes>60</intervalMinutes>
+      <intervalSeconds>0</intervalSeconds>
+      <minutes>0</minutes>
+      <repeat>N</repeat>
+      <schedulerType>0</schedulerType>
+      <weekDay>1</weekDay>
+      <parallel>N</parallel>
+      <xloc>80</xloc>
+      <yloc>80</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>Create table</name>
+      <description/>
+      <type>SQL</type>
+      <attributes/>
+      <connection>${MSSQL_CONNECTION}</connection>
+      <sendOneStatement>N</sendOneStatement>
+      <sql>DROP TABLE IF EXISTS master.dbo.bulkloader_binary;
+CREATE TABLE master.dbo.bulkloader_binary (
+	id int NOT NULL,
+	payload varbinary(64) NULL
+);</sql>
+      <sqlfromfile>N</sqlfromfile>
+      <useVariableSubstitution>Y</useVariableSubstitution>
+      <parallel>N</parallel>
+      <xloc>256</xloc>
+      <yloc>80</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>Load</name>
+      <description/>
+      <type>PIPELINE</type>
+      <attributes/>
+      <add_date>N</add_date>
+      <add_time>N</add_time>
+      <clear_files>N</clear_files>
+      <clear_rows>N</clear_rows>
+      <create_parent_folder>N</create_parent_folder>
+      <exec_per_row>N</exec_per_row>
+      <filename>${PROJECT_HOME}/0007-bulk-loader-binary.hpl</filename>
+      <loglevel>Basic</loglevel>
+      <parameters>
+        <pass_all_parameters>Y</pass_all_parameters>
+      </parameters>
+      <params_from_previous>N</params_from_previous>
+      <run_configuration>local</run_configuration>
+      <set_append_logfile>N</set_append_logfile>
+      <set_logfile>N</set_logfile>
+      <wait_until_finished>Y</wait_until_finished>
+      <parallel>N</parallel>
+      <xloc>432</xloc>
+      <yloc>80</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>Validate</name>
+      <description/>
+      <type>PIPELINE</type>
+      <attributes/>
+      <add_date>N</add_date>
+      <add_time>N</add_time>
+      <clear_files>N</clear_files>
+      <clear_rows>N</clear_rows>
+      <create_parent_folder>N</create_parent_folder>
+      <exec_per_row>N</exec_per_row>
+      <filename>${PROJECT_HOME}/0007-bulk-loader-binary-validate.hpl</filename>
+      <loglevel>Basic</loglevel>
+      <parameters>
+        <pass_all_parameters>Y</pass_all_parameters>
+      </parameters>
+      <params_from_previous>N</params_from_previous>
+      <run_configuration>local</run_configuration>
+      <set_append_logfile>N</set_append_logfile>
+      <set_logfile>N</set_logfile>
+      <wait_until_finished>Y</wait_until_finished>
+      <parallel>N</parallel>
+      <xloc>608</xloc>
+      <yloc>80</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>Drop table</name>
+      <description/>
+      <type>SQL</type>
+      <attributes/>
+      <connection>${MSSQL_CONNECTION}</connection>
+      <sendOneStatement>N</sendOneStatement>
+      <sql>DROP TABLE master.dbo.bulkloader_binary;</sql>
+      <sqlfromfile>N</sqlfromfile>
+      <useVariableSubstitution>Y</useVariableSubstitution>
+      <parallel>N</parallel>
+      <xloc>784</xloc>
+      <yloc>80</yloc>
+      <attributes_hac/>
+    </action>
+  </actions>
+  <hops>
+    <hop>
+      <from>Start</from>
+      <to>Create table</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>Y</unconditional>
+    </hop>
+    <hop>
+      <from>Create table</from>
+      <to>Load</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>N</unconditional>
+    </hop>
+    <hop>
+      <from>Load</from>
+      <to>Validate</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>N</unconditional>
+    </hop>
+    <hop>
+      <from>Validate</from>
+      <to>Drop table</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>N</unconditional>
+    </hop>
+  </hops>
+  <notepads>
+  </notepads>
+  <attributes/>
+</workflow>

--- a/integration-tests/mssql/datasets/bulk-binary.csv
+++ b/integration-tests/mssql/datasets/bulk-binary.csv
@@ -1,0 +1,5 @@
+id,payload
+1,deadbeef
+2,00ff
+3,
+4,00112233445566778899aabbccddeeff

--- a/integration-tests/mssql/main-0007-bulk-loader-binary-2025.hwf
+++ b/integration-tests/mssql/main-0007-bulk-loader-binary-2025.hwf
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<workflow>
+  <name>main-0007-bulk-loader-binary-2025</name>
+  <name_sync_with_filename>Y</name_sync_with_filename>
+  <description>Binary bulk load against SQL Server 2025.</description>
+  <extended_description/>
+  <workflow_version/>
+  <created_user>-</created_user>
+  <created_date>2026/08/29 12:00:00.000</created_date>
+  <modified_user>-</modified_user>
+  <modified_date>2026/08/29 12:00:00.000</modified_date>
+  <parameters>
+    <parameter>
+      <name>MSSQL_CONNECTION</name>
+      <default_value>mssql-2025</default_value>
+      <description>Which of the two servers this run is against</description>
+    </parameter>
+  </parameters>
+  <actions>
+    <action>
+      <name>Start</name>
+      <description/>
+      <type>SPECIAL</type>
+      <attributes/>
+      <DayOfMonth>1</DayOfMonth>
+      <doNotWaitOnFirstExecution>N</doNotWaitOnFirstExecution>
+      <hour>12</hour>
+      <intervalMinutes>60</intervalMinutes>
+      <intervalSeconds>0</intervalSeconds>
+      <minutes>0</minutes>
+      <repeat>N</repeat>
+      <schedulerType>0</schedulerType>
+      <weekDay>1</weekDay>
+      <parallel>N</parallel>
+      <xloc>80</xloc>
+      <yloc>80</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>0007-bulk-loader-binary.hwf</name>
+      <description/>
+      <type>WORKFLOW</type>
+      <attributes/>
+      <add_date>N</add_date>
+      <add_time>N</add_time>
+      <clear_files>N</clear_files>
+      <clear_rows>N</clear_rows>
+      <create_parent_folder>N</create_parent_folder>
+      <exec_per_row>N</exec_per_row>
+      <filename>${PROJECT_HOME}/0007-bulk-loader-binary.hwf</filename>
+      <loglevel>Basic</loglevel>
+      <parameters>
+        <pass_all_parameters>Y</pass_all_parameters>
+      </parameters>
+      <params_from_previous>N</params_from_previous>
+      <run_configuration>local</run_configuration>
+      <set_append_logfile>N</set_append_logfile>
+      <set_logfile>N</set_logfile>
+      <wait_until_finished>Y</wait_until_finished>
+      <parallel>N</parallel>
+      <xloc>288</xloc>
+      <yloc>80</yloc>
+      <attributes_hac/>
+    </action>
+  </actions>
+  <hops>
+    <hop>
+      <from>Start</from>
+      <to>0007-bulk-loader-binary.hwf</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>Y</unconditional>
+    </hop>
+  </hops>
+  <notepads>
+  </notepads>
+  <attributes/>
+</workflow>

--- a/integration-tests/mssql/main-0008-bulk-loader-binary-2022.hwf
+++ b/integration-tests/mssql/main-0008-bulk-loader-binary-2022.hwf
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<workflow>
+  <name>main-0008-bulk-loader-binary-2022</name>
+  <name_sync_with_filename>Y</name_sync_with_filename>
+  <description>Binary bulk load against SQL Server 2022.</description>
+  <extended_description/>
+  <workflow_version/>
+  <created_user>-</created_user>
+  <created_date>2026/08/29 12:00:00.000</created_date>
+  <modified_user>-</modified_user>
+  <modified_date>2026/08/29 12:00:00.000</modified_date>
+  <parameters>
+    <parameter>
+      <name>MSSQL_CONNECTION</name>
+      <default_value>mssql-2022</default_value>
+      <description>Which of the two servers this run is against</description>
+    </parameter>
+  </parameters>
+  <actions>
+    <action>
+      <name>Start</name>
+      <description/>
+      <type>SPECIAL</type>
+      <attributes/>
+      <DayOfMonth>1</DayOfMonth>
+      <doNotWaitOnFirstExecution>N</doNotWaitOnFirstExecution>
+      <hour>12</hour>
+      <intervalMinutes>60</intervalMinutes>
+      <intervalSeconds>0</intervalSeconds>
+      <minutes>0</minutes>
+      <repeat>N</repeat>
+      <schedulerType>0</schedulerType>
+      <weekDay>1</weekDay>
+      <parallel>N</parallel>
+      <xloc>80</xloc>
+      <yloc>80</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>0007-bulk-loader-binary.hwf</name>
+      <description/>
+      <type>WORKFLOW</type>
+      <attributes/>
+      <add_date>N</add_date>
+      <add_time>N</add_time>
+      <clear_files>N</clear_files>
+      <clear_rows>N</clear_rows>
+      <create_parent_folder>N</create_parent_folder>
+      <exec_per_row>N</exec_per_row>
+      <filename>${PROJECT_HOME}/0007-bulk-loader-binary.hwf</filename>
+      <loglevel>Basic</loglevel>
+      <parameters>
+        <pass_all_parameters>Y</pass_all_parameters>
+      </parameters>
+      <params_from_previous>N</params_from_previous>
+      <run_configuration>local</run_configuration>
+      <set_append_logfile>N</set_append_logfile>
+      <set_logfile>N</set_logfile>
+      <wait_until_finished>Y</wait_until_finished>
+      <parallel>N</parallel>
+      <xloc>288</xloc>
+      <yloc>80</yloc>
+      <attributes_hac/>
+    </action>
+  </actions>
+  <hops>
+    <hop>
+      <from>Start</from>
+      <to>0007-bulk-loader-binary.hwf</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>Y</unconditional>
+    </hop>
+  </hops>
+  <notepads>
+  </notepads>
+  <attributes/>
+</workflow>

--- a/integration-tests/mssql/metadata/dataset/bulk-binary.json
+++ b/integration-tests/mssql/metadata/dataset/bulk-binary.json
@@ -1,0 +1,24 @@
+{
+  "base_filename": "bulk-binary.csv",
+  "name": "bulk-binary",
+  "description": "Known binary payloads for bulk-loader integration tests",
+  "dataset_fields": [
+    {
+      "field_comment": "",
+      "field_length": -1,
+      "field_type": 5,
+      "field_precision": 0,
+      "field_name": "id",
+      "field_format": "0"
+    },
+    {
+      "field_comment": "",
+      "field_length": -1,
+      "field_type": 8,
+      "field_precision": -1,
+      "field_name": "payload",
+      "field_format": ""
+    }
+  ],
+  "folder_name": "${HOP_DATASETS_FOLDER}"
+}

--- a/integration-tests/vertica/0006-vertica-bulk-load-binary-validate.hpl
+++ b/integration-tests/vertica/0006-vertica-bulk-load-binary-validate.hpl
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<pipeline>
+  <info>
+    <name>0006-vertica-bulk-load-binary-validate</name>
+    <name_sync_with_filename>Y</name_sync_with_filename>
+    <description>Compares the stored VARBINARY values to the original bytes, including NUL and 0xFF.</description>
+    <extended_description/>
+    <pipeline_version/>
+    <pipeline_type>Normal</pipeline_type>
+    <parameters>
+    </parameters>
+    <capture_transform_performance>N</capture_transform_performance>
+    <transform_performance_capturing_delay>1000</transform_performance_capturing_delay>
+    <transform_performance_capturing_size_limit>100</transform_performance_capturing_size_limit>
+    <created_user>-</created_user>
+    <created_date>2026/08/29 12:00:00.000</created_date>
+    <modified_user>-</modified_user>
+    <modified_date>2026/08/29 12:00:00.000</modified_date>
+    <key_for_session_key>H4sIAAAAAAAAAAMAAAAAAAAAAAA=</key_for_session_key>
+    <is_key_private>N</is_key_private>
+  </info>
+  <notepads>
+  </notepads>
+  <order>
+    <hop>
+      <from>Check what was stored</from>
+      <to>All as expected?</to>
+      <enabled>Y</enabled>
+    </hop>
+    <hop>
+      <from>All as expected?</from>
+      <to>Abort</to>
+      <enabled>Y</enabled>
+    </hop>
+  </order>
+  <transform>
+    <name>Check what was stored</name>
+    <type>TableInput</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <connection>vertica</connection>
+    <execute_each_row>N</execute_each_row>
+    <limit>0</limit>
+    <sql>SELECT CASE
+         WHEN (SELECT count(*) FROM bulk_bin) = 4
+          AND (SELECT payload FROM bulk_bin WHERE id = 1) = HEX_TO_BINARY('DEADBEEF')
+          AND (SELECT payload FROM bulk_bin WHERE id = 2) = HEX_TO_BINARY('00FF')
+          AND (SELECT payload FROM bulk_bin WHERE id = 3) IS NULL
+          AND (SELECT payload FROM bulk_bin WHERE id = 4) = HEX_TO_BINARY('00112233445566778899AABBCCDDEEFF')
+         THEN 'ok'
+         ELSE 'bad'
+       END AS result,
+       'rows=' || (SELECT count(*) FROM bulk_bin) ||
+       ', id1=' || (SELECT TO_HEX(payload) FROM bulk_bin WHERE id = 1) ||
+       ', id2=' || (SELECT TO_HEX(payload) FROM bulk_bin WHERE id = 2) ||
+       ', id3=' || (SELECT CASE WHEN payload IS NULL THEN '&lt;null&gt;' ELSE TO_HEX(payload) END FROM bulk_bin WHERE id = 3) ||
+       ', id4=' || (SELECT TO_HEX(payload) FROM bulk_bin WHERE id = 4) AS found;</sql>
+    <variables_active>N</variables_active>
+    <attributes/>
+    <GUI>
+      <xloc>176</xloc>
+      <yloc>144</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>All as expected?</name>
+    <type>FilterRows</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <compare>
+      <condition>
+        <conditions>
+</conditions>
+        <function>=</function>
+        <leftvalue>result</leftvalue>
+        <negated>N</negated>
+        <operator>-</operator>
+        <value>
+          <isnull>N</isnull>
+          <length>-1</length>
+          <mask/>
+          <name>constant</name>
+          <precision>-1</precision>
+          <text>ok</text>
+          <type>String</type>
+        </value>
+      </condition>
+    </compare>
+    <send_false_to>Abort</send_false_to>
+    <attributes/>
+    <GUI>
+      <xloc>384</xloc>
+      <yloc>144</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>Abort</name>
+    <type>Abort</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <abort_option>ABORT_WITH_ERROR</abort_option>
+    <always_log_rows>Y</always_log_rows>
+    <message>A binary value did not survive the Vertica bulk load intact</message>
+    <row_threshold>0</row_threshold>
+    <attributes/>
+    <GUI>
+      <xloc>560</xloc>
+      <yloc>144</yloc>
+    </GUI>
+  </transform>
+  <transform_error_handling>
+  </transform_error_handling>
+  <attributes/>
+</pipeline>

--- a/integration-tests/vertica/0006-vertica-bulk-load-binary.hpl
+++ b/integration-tests/vertica/0006-vertica-bulk-load-binary.hpl
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<pipeline>
+  <info>
+    <name>0006-vertica-bulk-load-binary</name>
+    <name_sync_with_filename>Y</name_sync_with_filename>
+    <description>Bulk load known binary payloads into Vertica VARBINARY.</description>
+    <extended_description/>
+    <pipeline_version/>
+    <pipeline_type>Normal</pipeline_type>
+    <parameters>
+    </parameters>
+    <capture_transform_performance>N</capture_transform_performance>
+    <transform_performance_capturing_delay>1000</transform_performance_capturing_delay>
+    <transform_performance_capturing_size_limit>100</transform_performance_capturing_size_limit>
+    <created_user>-</created_user>
+    <created_date>2026/08/29 12:00:00.000</created_date>
+    <modified_user>-</modified_user>
+    <modified_date>2026/08/29 12:00:00.000</modified_date>
+    <key_for_session_key>H4sIAAAAAAAAAAMAAAAAAAAAAAA=</key_for_session_key>
+    <is_key_private>N</is_key_private>
+  </info>
+  <notepads>
+  </notepads>
+  <order>
+    <hop>
+      <from>binary data</from>
+      <to>Vertica bulk loader</to>
+      <enabled>Y</enabled>
+    </hop>
+  </order>
+  <transform>
+    <name>Vertica bulk loader</name>
+    <type>VerticaBulkLoader</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <abort_on_error>Y</abort_on_error>
+    <connection>vertica</connection>
+    <direct>Y</direct>
+    <fields>
+      <field>
+        <column_name>id</column_name>
+        <stream_name>id</stream_name>
+      </field>
+      <field>
+        <column_name>payload</column_name>
+        <stream_name>payload</stream_name>
+      </field>
+    </fields>
+    <specify_fields>Y</specify_fields>
+    <table>bulk_bin</table>
+    <attributes/>
+    <GUI>
+      <xloc>464</xloc>
+      <yloc>160</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>binary data</name>
+    <type>DataSetInput</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <dataSetName>bulk-binary</dataSetName>
+    <attributes/>
+    <GUI>
+      <xloc>176</xloc>
+      <yloc>160</yloc>
+    </GUI>
+  </transform>
+  <transform_error_handling>
+  </transform_error_handling>
+  <attributes/>
+</pipeline>

--- a/integration-tests/vertica/datasets/bulk-binary.csv
+++ b/integration-tests/vertica/datasets/bulk-binary.csv
@@ -1,0 +1,5 @@
+id,payload
+1,deadbeef
+2,00ff
+3,
+4,00112233445566778899aabbccddeeff

--- a/integration-tests/vertica/main-0006-vertica-bulk-load-binary.hwf
+++ b/integration-tests/vertica/main-0006-vertica-bulk-load-binary.hwf
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<workflow>
+  <name>main-0006-vertica-bulk-load-binary</name>
+  <name_sync_with_filename>Y</name_sync_with_filename>
+  <description>Bulk load known VARBINARY values and compare the stored bytes to the originals.</description>
+  <extended_description/>
+  <workflow_version/>
+  <created_user>-</created_user>
+  <created_date>2026/08/29 12:00:00.000</created_date>
+  <modified_user>-</modified_user>
+  <modified_date>2026/08/29 12:00:00.000</modified_date>
+  <parameters>
+    </parameters>
+  <actions>
+    <action>
+      <name>Start</name>
+      <description/>
+      <type>SPECIAL</type>
+      <attributes/>
+      <DayOfMonth>1</DayOfMonth>
+      <hour>12</hour>
+      <intervalMinutes>60</intervalMinutes>
+      <intervalSeconds>0</intervalSeconds>
+      <minutes>0</minutes>
+      <repeat>N</repeat>
+      <schedulerType>0</schedulerType>
+      <weekDay>1</weekDay>
+      <parallel>N</parallel>
+      <xloc>50</xloc>
+      <yloc>50</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>DDL</name>
+      <description/>
+      <type>SQL</type>
+      <attributes/>
+      <sql>DROP TABLE IF EXISTS bulk_bin;
+CREATE TABLE bulk_bin (
+  id INT,
+  payload VARBINARY(64)
+);
+</sql>
+      <useVariableSubstitution>F</useVariableSubstitution>
+      <sqlfromfile>F</sqlfromfile>
+      <sqlfilename/>
+      <sendOneStatement>F</sendOneStatement>
+      <connection>vertica</connection>
+      <parallel>N</parallel>
+      <xloc>176</xloc>
+      <yloc>48</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>0006-vertica-bulk-load-binary.hpl</name>
+      <description/>
+      <type>PIPELINE</type>
+      <attributes/>
+      <filename>${PROJECT_HOME}/0006-vertica-bulk-load-binary.hpl</filename>
+      <params_from_previous>N</params_from_previous>
+      <exec_per_row>N</exec_per_row>
+      <clear_rows>N</clear_rows>
+      <clear_files>N</clear_files>
+      <set_logfile>N</set_logfile>
+      <logfile/>
+      <logext/>
+      <add_date>N</add_date>
+      <add_time>N</add_time>
+      <loglevel>Basic</loglevel>
+      <set_append_logfile>N</set_append_logfile>
+      <wait_until_finished>Y</wait_until_finished>
+      <create_parent_folder>N</create_parent_folder>
+      <run_configuration>local</run_configuration>
+      <parameters>
+        <pass_all_parameters>Y</pass_all_parameters>
+      </parameters>
+      <parallel>N</parallel>
+      <xloc>352</xloc>
+      <yloc>48</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>Validate</name>
+      <description/>
+      <type>PIPELINE</type>
+      <attributes/>
+      <filename>${PROJECT_HOME}/0006-vertica-bulk-load-binary-validate.hpl</filename>
+      <params_from_previous>N</params_from_previous>
+      <exec_per_row>N</exec_per_row>
+      <clear_rows>N</clear_rows>
+      <clear_files>N</clear_files>
+      <set_logfile>N</set_logfile>
+      <logfile/>
+      <logext/>
+      <add_date>N</add_date>
+      <add_time>N</add_time>
+      <loglevel>Basic</loglevel>
+      <set_append_logfile>N</set_append_logfile>
+      <wait_until_finished>Y</wait_until_finished>
+      <create_parent_folder>N</create_parent_folder>
+      <run_configuration>local</run_configuration>
+      <parameters>
+        <pass_all_parameters>Y</pass_all_parameters>
+      </parameters>
+      <parallel>N</parallel>
+      <xloc>560</xloc>
+      <yloc>48</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>Abort workflow</name>
+      <description/>
+      <type>ABORT</type>
+      <attributes/>
+      <always_log_rows>N</always_log_rows>
+      <parallel>N</parallel>
+      <xloc>352</xloc>
+      <yloc>176</yloc>
+      <attributes_hac/>
+    </action>
+  </actions>
+  <hops>
+    <hop>
+      <from>Start</from>
+      <to>DDL</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>Y</unconditional>
+    </hop>
+    <hop>
+      <from>DDL</from>
+      <to>0006-vertica-bulk-load-binary.hpl</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>N</unconditional>
+    </hop>
+    <hop>
+      <from>0006-vertica-bulk-load-binary.hpl</from>
+      <to>Validate</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>N</unconditional>
+    </hop>
+    <hop>
+      <from>0006-vertica-bulk-load-binary.hpl</from>
+      <to>Abort workflow</to>
+      <enabled>Y</enabled>
+      <evaluation>N</evaluation>
+      <unconditional>N</unconditional>
+    </hop>
+    <hop>
+      <from>Validate</from>
+      <to>Abort workflow</to>
+      <enabled>Y</enabled>
+      <evaluation>N</evaluation>
+      <unconditional>N</unconditional>
+    </hop>
+  </hops>
+  <notepads>
+  </notepads>
+  <attributes/>
+</workflow>

--- a/integration-tests/vertica/metadata/dataset/bulk-binary.json
+++ b/integration-tests/vertica/metadata/dataset/bulk-binary.json
@@ -1,0 +1,24 @@
+{
+  "base_filename": "bulk-binary.csv",
+  "name": "bulk-binary",
+  "description": "Known binary payloads for bulk-loader integration tests",
+  "dataset_fields": [
+    {
+      "field_comment": "",
+      "field_length": -1,
+      "field_type": 5,
+      "field_precision": 0,
+      "field_name": "id",
+      "field_format": "0"
+    },
+    {
+      "field_comment": "",
+      "field_length": -1,
+      "field_type": 8,
+      "field_precision": -1,
+      "field_name": "payload",
+      "field_format": ""
+    }
+  ],
+  "folder_name": "${HOP_DATASETS_FOLDER}"
+}

--- a/plugins/databases/cratedb/src/main/java/org/apache/hop/pipeline/transforms/cratedbbulkloader/CrateDBBulkLoader.java
+++ b/plugins/databases/cratedb/src/main/java/org/apache/hop/pipeline/transforms/cratedbbulkloader/CrateDBBulkLoader.java
@@ -28,6 +28,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.vfs2.FileObject;
@@ -438,6 +439,11 @@ public class CrateDBBulkLoader extends BaseTransform<CrateDBBulkLoaderMeta, Crat
           v.setConversionMask(DATE_CONVERSION_MASK);
           vc.setConversionMask(DATE_CONVERSION_MASK);
           convertedValue = (String) vc.convertData(v, rowItem);
+          break;
+        case IValueMeta.TYPE_BINARY:
+          // CrateDB has no BYTEA type. Hex is JSON/CSV-safe and can be stored in a STRING column.
+          byte[] bytes = v.getBinary(rowItem);
+          convertedValue = bytes == null ? null : Hex.encodeHexString(bytes);
           break;
         default:
           convertedValue = v.getString(rowItem);

--- a/plugins/databases/cratedb/src/test/java/org/apache/hop/pipeline/transforms/cratedbbulkloader/CrateDBBulkLoaderTest.java
+++ b/plugins/databases/cratedb/src/test/java/org/apache/hop/pipeline/transforms/cratedbbulkloader/CrateDBBulkLoaderTest.java
@@ -43,6 +43,7 @@ import org.apache.hop.core.database.DatabaseMeta;
 import org.apache.hop.core.exception.HopException;
 import org.apache.hop.core.row.IRowMeta;
 import org.apache.hop.core.row.RowMeta;
+import org.apache.hop.core.row.value.ValueMetaBinary;
 import org.apache.hop.core.row.value.ValueMetaDate;
 import org.apache.hop.core.row.value.ValueMetaInteger;
 import org.apache.hop.core.row.value.ValueMetaJson;
@@ -246,6 +247,18 @@ class CrateDBBulkLoaderTest {
     rowMeta.addValueMeta(new ValueMetaInteger("amount"));
 
     assertEquals("\"Acme\",42\n", writeRow(rowMeta, new Object[] {"Acme", 42L}));
+  }
+
+  @Test
+  void writesBinaryValuesAsHex() throws Exception {
+    IRowMeta rowMeta = new RowMeta();
+    rowMeta.addValueMeta(new ValueMetaBinary("hash"));
+
+    assertEquals(
+        "\"deadbeef\"\n",
+        writeRow(
+            rowMeta,
+            new Object[] {new byte[] {(byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef}}));
   }
 
   /** A value carrying the separator has to be enclosed or it becomes two columns. */

--- a/plugins/databases/monetdb/src/main/java/org/apache/hop/pipeline/transforms/monetdbbulkloader/MonetDbBulkLoader.java
+++ b/plugins/databases/monetdb/src/main/java/org/apache/hop/pipeline/transforms/monetdbbulkloader/MonetDbBulkLoader.java
@@ -16,9 +16,11 @@
  */
 package org.apache.hop.pipeline.transforms.monetdbbulkloader;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.math.BigDecimal;
 import java.util.Date;
 import java.util.List;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.hop.core.Const;
 import org.apache.hop.core.SqlStatement;
 import org.apache.hop.core.database.Database;
@@ -194,6 +196,16 @@ public class MonetDbBulkLoader extends BaseTransform<MonetDbBulkLoaderMeta, Mone
     addRowToBuffer(rowMeta, r);
   }
 
+  /** MonetDB COPY INTO reads BLOB values as hexadecimal strings with no prefix. */
+  @VisibleForTesting
+  static String hexFieldForMonetDbCopy(IValueMeta valueMeta, Object valueData) throws HopException {
+    byte[] bytes = valueMeta.getBinary(valueData);
+    if (bytes == null) {
+      return null;
+    }
+    return Hex.encodeHexString(bytes);
+  }
+
   protected void addRowToBuffer(IRowMeta rowMeta, Object[] r) throws HopException {
 
     StringBuilder line = new StringBuilder();
@@ -346,6 +358,14 @@ public class MonetDbBulkLoader extends BaseTransform<MonetDbBulkLoaderMeta, Mone
                           precision,
                           java.math.BigDecimal.ROUND_HALF_UP));
                 }
+              }
+              break;
+            case IValueMeta.TYPE_BINARY:
+              String hex = hexFieldForMonetDbCopy(valueMeta, valueData);
+              if (hex == null) {
+                line.append(data.nullrepresentation);
+              } else {
+                line.append(hex);
               }
               break;
             default:

--- a/plugins/databases/monetdb/src/test/java/org/apache/hop/pipeline/transforms/monetdbbulkloader/MonetDbBulkLoaderTest.java
+++ b/plugins/databases/monetdb/src/test/java/org/apache/hop/pipeline/transforms/monetdbbulkloader/MonetDbBulkLoaderTest.java
@@ -19,9 +19,11 @@ package org.apache.hop.pipeline.transforms.monetdbbulkloader;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.apache.hop.core.HopEnvironment;
 import org.apache.hop.core.plugins.PluginRegistry;
+import org.apache.hop.core.row.value.ValueMetaBinary;
 import org.apache.hop.pipeline.Pipeline;
 import org.apache.hop.pipeline.PipelineMeta;
 import org.apache.hop.pipeline.engines.local.LocalPipelineEngine;
@@ -69,6 +71,17 @@ class MonetDbBulkLoaderTest {
 
     String result = transform.escapeOsPath("/path with spaces/file", false);
     assertEquals("/path\\ with\\ spaces/file", result);
+  }
+
+  @Test
+  void hexFieldForMonetDbCopy_usesPlainHex() throws Exception {
+    ValueMetaBinary meta = new ValueMetaBinary("hash");
+    assertEquals(
+        "deadbeef",
+        MonetDbBulkLoader.hexFieldForMonetDbCopy(
+            meta, new byte[] {(byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef}));
+    assertEquals("", MonetDbBulkLoader.hexFieldForMonetDbCopy(meta, new byte[0]));
+    assertNull(MonetDbBulkLoader.hexFieldForMonetDbCopy(meta, null));
   }
 
   @Test

--- a/plugins/databases/mysql/src/main/java/org/apache/hop/pipeline/transforms/mysqlbulkloader/MySqlBulkLoader.java
+++ b/plugins/databases/mysql/src/main/java/org/apache/hop/pipeline/transforms/mysqlbulkloader/MySqlBulkLoader.java
@@ -20,6 +20,7 @@ package org.apache.hop.pipeline.transforms.mysqlbulkloader;
 import static org.apache.hop.pipeline.transforms.mysqlbulkloader.MySqlBulkLoaderMeta.Field;
 import static org.apache.hop.pipeline.transforms.mysqlbulkloader.MySqlBulkLoaderMeta.FieldFormatType;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -27,12 +28,17 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.hop.core.Const;
 import org.apache.hop.core.database.Database;
 import org.apache.hop.core.database.DatabaseMeta;
 import org.apache.hop.core.exception.HopException;
+import org.apache.hop.core.exception.HopValueException;
 import org.apache.hop.core.row.IRowMeta;
 import org.apache.hop.core.row.IValueMeta;
 import org.apache.hop.core.row.value.ValueMetaDate;
@@ -52,6 +58,12 @@ public class MySqlBulkLoader extends BaseTransform<MySqlBulkLoaderMeta, MySqlBul
 
   private static final long THREAD_WAIT_TIME = 300000;
   private static final String THREAD_WAIT_TIME_TEXT = "5min";
+
+  /**
+   * MySQL LOAD DATA reads this unquoted token as SQL NULL, including when the column is bound as a
+   * user variable for {@code UNHEX}.
+   */
+  private static final byte[] MYSQL_NULL_TOKEN = "\\N".getBytes(StandardCharsets.US_ASCII);
 
   public MySqlBulkLoader(
       TransformMeta transformMeta,
@@ -181,17 +193,16 @@ public class MySqlBulkLoader extends BaseTransform<MySqlBulkLoaderMeta, MySqlBul
             + ("\\".equals(meta.getEscapeChar()) ? meta.getEscapeChar() : "")
             + "' ");
 
-    // Build list of column names to set
-    loadCommand.append("(");
+    DatabaseMeta databaseMeta = getPipelineMeta().findDatabase(meta.getConnection(), variables);
+    String[] quotedNames = new String[meta.getFields().size()];
     for (int cnt = 0; cnt < meta.getFields().size(); cnt++) {
-      DatabaseMeta databaseMeta = getPipelineMeta().findDatabase(meta.getConnection(), variables);
-      loadCommand.append(databaseMeta.quoteField(meta.getFields().get(cnt).getFieldTable()));
-      if (cnt < meta.getFields().size() - 1) {
-        loadCommand.append(",");
-      }
+      quotedNames[cnt] = databaseMeta.quoteField(meta.getFields().get(cnt).getFieldTable());
     }
-
-    loadCommand.append(");" + Const.CR);
+    boolean[] binaryFields = data.binaryFields;
+    if (binaryFields == null || binaryFields.length != quotedNames.length) {
+      binaryFields = new boolean[quotedNames.length];
+    }
+    appendLoadColumns(loadCommand, quotedNames, binaryFields);
 
     if (isBasic()) {
       logBasic(
@@ -261,8 +272,12 @@ public class MySqlBulkLoader extends BaseTransform<MySqlBulkLoaderMeta, MySqlBul
         // Cache field indexes.
         //
         data.keynrs = new int[meta.getFields().size()];
+        data.binaryFields = new boolean[data.keynrs.length];
         for (int i = 0; i < data.keynrs.length; i++) {
           data.keynrs[i] = getInputRowMeta().indexOfValue(meta.getFields().get(i).getFieldStream());
+          if (data.keynrs[i] >= 0) {
+            data.binaryFields[i] = getInputRowMeta().getValueMeta(data.keynrs[i]).isBinary();
+          }
         }
 
         data.bulkFormatMeta = new IValueMeta[data.keynrs.length];
@@ -370,7 +385,9 @@ public class MySqlBulkLoader extends BaseTransform<MySqlBulkLoaderMeta, MySqlBul
         Field field = meta.getFields().get(i);
 
         if (valueData == null) {
-          data.fifoStream.write("NULL".getBytes());
+          // Binary columns are bound as user variables and converted with UNHEX. The word NULL
+          // assigned to a user variable is the string "NULL", so use MySQL's \N token instead.
+          data.fifoStream.write(valueMeta.isBinary() ? MYSQL_NULL_TOKEN : "NULL".getBytes());
         } else {
           switch (valueMeta.getType()) {
             case IValueMeta.TYPE_STRING:
@@ -481,6 +498,12 @@ public class MySqlBulkLoader extends BaseTransform<MySqlBulkLoaderMeta, MySqlBul
                 }
               }
               break;
+            case IValueMeta.TYPE_BINARY:
+              byte[] binaryBytes = binaryFieldBytesForMysqlLoadData(valueMeta, valueData);
+              if (binaryBytes != null) {
+                data.fifoStream.write(binaryBytes);
+              }
+              break;
             default:
               break;
           }
@@ -516,6 +539,49 @@ public class MySqlBulkLoader extends BaseTransform<MySqlBulkLoaderMeta, MySqlBul
       // Null pointer exceptions etc.
       throw new HopException(BaseMessages.getString(PKG, MESSAGE_ERRORSERIALIZING), e2);
     }
+  }
+
+  /**
+   * Encodes binary data as lowercase hex so {@code LOAD DATA ... SET col = UNHEX(@col)} can restore
+   * the original bytes.
+   */
+  @VisibleForTesting
+  static byte[] binaryFieldBytesForMysqlLoadData(IValueMeta valueMeta, Object valueData)
+      throws HopValueException {
+    byte[] bytes = valueMeta.getBinary(valueData);
+    if (bytes == null) {
+      return null;
+    }
+    return Hex.encodeHexString(bytes).getBytes(StandardCharsets.US_ASCII);
+  }
+
+  /**
+   * Binary columns cannot be loaded as text. They are bound as {@code @colN} user variables and
+   * converted with {@code UNHEX} so the BLOB receives the original bytes, not the hex characters.
+   */
+  @VisibleForTesting
+  static void appendLoadColumns(
+      StringBuilder loadCommand, String[] quotedNames, boolean[] binaryFields) {
+    loadCommand.append("(");
+    List<String> setClauses = new ArrayList<>();
+    for (int i = 0; i < quotedNames.length; i++) {
+      if (i > 0) {
+        loadCommand.append(",");
+      }
+      if (binaryFields[i]) {
+        String variable = "@col" + i;
+        loadCommand.append(variable);
+        setClauses.add(quotedNames[i] + " = UNHEX(" + variable + ")");
+      } else {
+        loadCommand.append(quotedNames[i]);
+      }
+    }
+    loadCommand.append(")");
+    if (!setClauses.isEmpty()) {
+      loadCommand.append(" SET ");
+      loadCommand.append(String.join(", ", setClauses));
+    }
+    loadCommand.append(";" + Const.CR);
   }
 
   protected void verifyDatabaseConnection() throws HopException {

--- a/plugins/databases/mysql/src/main/java/org/apache/hop/pipeline/transforms/mysqlbulkloader/MySqlBulkLoaderData.java
+++ b/plugins/databases/mysql/src/main/java/org/apache/hop/pipeline/transforms/mysqlbulkloader/MySqlBulkLoaderData.java
@@ -56,6 +56,9 @@ public class MySqlBulkLoaderData extends BaseTransformData implements ITransform
 
   public IValueMeta[] bulkFormatMeta;
 
+  /** True for mapped fields whose stream type is Binary, aligned with {@link #keynrs}. */
+  public boolean[] binaryFields;
+
   public long bulkSize;
 
   /** Default constructor. */

--- a/plugins/databases/mysql/src/test/java/org/apache/hop/pipeline/transforms/mysqlbulkloader/MySqlBulkLoaderTest.java
+++ b/plugins/databases/mysql/src/test/java/org/apache/hop/pipeline/transforms/mysqlbulkloader/MySqlBulkLoaderTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.pipeline.transforms.mysqlbulkloader;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.hop.core.exception.HopValueException;
+import org.apache.hop.core.row.value.ValueMetaBinary;
+import org.junit.jupiter.api.Test;
+
+class MySqlBulkLoaderTest {
+
+  @Test
+  void binaryFieldBytesForMysqlLoadData_usesLowercaseHex() throws HopValueException {
+    ValueMetaBinary meta = new ValueMetaBinary("hash");
+    byte[] bytes = {(byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef};
+    assertArrayEquals(
+        "deadbeef".getBytes(java.nio.charset.StandardCharsets.US_ASCII),
+        MySqlBulkLoader.binaryFieldBytesForMysqlLoadData(meta, bytes));
+    assertArrayEquals(
+        new byte[0], MySqlBulkLoader.binaryFieldBytesForMysqlLoadData(meta, new byte[0]));
+    assertNull(MySqlBulkLoader.binaryFieldBytesForMysqlLoadData(meta, null));
+  }
+
+  @Test
+  void appendLoadColumns_bindsBinaryFieldsAsUnhexUserVariables() {
+    StringBuilder sql = new StringBuilder();
+    MySqlBulkLoader.appendLoadColumns(
+        sql, new String[] {"id", "`hash`", "name"}, new boolean[] {false, true, false});
+
+    String written = sql.toString();
+    assertTrue(written.startsWith("(id,@col1,name) SET `hash` = UNHEX(@col1);"), written);
+    assertFalse(written.contains("id = UNHEX"), written);
+  }
+
+  @Test
+  void appendLoadColumns_leavesTheStatementAloneWhenNoFieldIsBinary() {
+    StringBuilder sql = new StringBuilder();
+    MySqlBulkLoader.appendLoadColumns(
+        sql, new String[] {"id", "name"}, new boolean[] {false, false});
+
+    assertEquals("(id,name);\n", sql.toString().replace("\r\n", "\n"));
+  }
+}

--- a/plugins/databases/oracle/src/main/java/org/apache/hop/pipeline/transforms/orabulkloader/OraBulkDataOutput.java
+++ b/plugins/databases/oracle/src/main/java/org/apache/hop/pipeline/transforms/orabulkloader/OraBulkDataOutput.java
@@ -28,6 +28,7 @@ import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.hop.core.Const;
 import org.apache.hop.core.exception.HopException;
@@ -96,6 +97,15 @@ public class OraBulkDataOutput {
 
   Writer getOutput() {
     return output;
+  }
+
+  @VisibleForTesting
+  void initForTest(Writer writer, String enclosure, int[] fieldNumbers) {
+    this.output = writer;
+    this.enclosure = enclosure;
+    this.fieldNumbers = fieldNumbers;
+    this.outbuf = new StringBuilder();
+    this.first = false;
   }
 
   private String createEscapedString(String orig, String enclosure) {
@@ -207,10 +217,11 @@ public class OraBulkDataOutput {
             break;
           case IValueMeta.TYPE_BINARY:
             byte[] byt = rowMeta.getBinary(row, number);
-            outbuf.append("<startlob>");
-            // TODO REVIEW - implicit .toString
-            outbuf.append(byt);
-            outbuf.append("<endlob>");
+            outbuf.append(enclosure);
+            if (byt != null) {
+              outbuf.append(Hex.encodeHexString(byt));
+            }
+            outbuf.append(enclosure);
             break;
           case IValueMeta.TYPE_TIMESTAMP:
             Timestamp timestamp = (Timestamp) rowMeta.getDate(row, number);

--- a/plugins/databases/oracle/src/main/java/org/apache/hop/pipeline/transforms/orabulkloader/OraBulkLoader.java
+++ b/plugins/databases/oracle/src/main/java/org/apache/hop/pipeline/transforms/orabulkloader/OraBulkLoader.java
@@ -290,7 +290,7 @@ public class OraBulkLoader extends BaseTransform<OraBulkLoaderMeta, OraBulkLoade
           }
           break;
         case IValueMeta.TYPE_BINARY:
-          contents.append(" ENCLOSED BY '<startlob>' AND '<endlob>'");
+          contents.append(binarySqlLoaderField(mapping.getFieldTable(), v.getLength()));
           break;
         case IValueMeta.TYPE_TIMESTAMP:
           contents.append(" TIMESTAMP 'yyyy-mm-dd hh24:mi:ss.ff'");
@@ -302,6 +302,17 @@ public class OraBulkLoader extends BaseTransform<OraBulkLoaderMeta, OraBulkLoade
     contents.append(")");
 
     return contents.toString();
+  }
+
+  /**
+   * SQL*Loader reads hex digits and {@code HEXTORAW} restores the original bytes. CHAR width is the
+   * hex length (two characters per byte); a generous default is used when Hop length is unset so
+   * hash keys and modest BLOBs still fit.
+   */
+  @VisibleForTesting
+  static String binarySqlLoaderField(String fieldTable, int length) {
+    int hexChars = length > 0 ? Math.max(255, length * 2) : 2_000_000;
+    return " CHAR(" + hexChars + ") \"HEXTORAW(:" + fieldTable + ")\"";
   }
 
   /**

--- a/plugins/databases/oracle/src/test/java/org/apache/hop/pipeline/transforms/orabulkloader/OraBulkLoaderTest.java
+++ b/plugins/databases/oracle/src/test/java/org/apache/hop/pipeline/transforms/orabulkloader/OraBulkLoaderTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.pipeline.transforms.orabulkloader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.StringWriter;
+import java.util.List;
+import org.apache.hop.core.row.IRowMeta;
+import org.apache.hop.core.row.RowMeta;
+import org.apache.hop.core.row.value.ValueMetaBinary;
+import org.junit.jupiter.api.Test;
+
+class OraBulkLoaderTest {
+
+  @Test
+  void binarySqlLoaderField_usesHextorawAndAWideChar() {
+    assertEquals(
+        " CHAR(2000000) \"HEXTORAW(:HASH)\"", OraBulkLoader.binarySqlLoaderField("HASH", -1));
+    assertEquals(" CHAR(255) \"HEXTORAW(:HASH)\"", OraBulkLoader.binarySqlLoaderField("HASH", 16));
+    assertEquals(
+        " CHAR(4000) \"HEXTORAW(:HASH)\"", OraBulkLoader.binarySqlLoaderField("HASH", 2000));
+  }
+
+  @Test
+  void writesBinaryValuesAsQuotedHex() throws Exception {
+    OraBulkLoaderMeta meta = new OraBulkLoaderMeta();
+    meta.setMappings(List.of(new OraBulkLoaderMappingMeta("HASH", "hash", null)));
+
+    OraBulkDataOutput output = new OraBulkDataOutput(meta, "\n");
+    StringWriter writer = new StringWriter();
+    output.initForTest(writer, "\"", new int[] {0});
+
+    IRowMeta rowMeta = new RowMeta();
+    rowMeta.addValueMeta(new ValueMetaBinary("hash"));
+    output.writeLine(rowMeta, new Object[] {new byte[] {(byte) 0xde, (byte) 0xad}});
+
+    assertEquals("\"dead\"\n", writer.toString());
+    assertFalse(writer.toString().contains("startlob"));
+    assertTrue(writer.toString().startsWith("\""));
+  }
+}

--- a/plugins/databases/postgresql/src/main/java/org/apache/hop/pipeline/transforms/pgbulkloader/PGBulkLoader.java
+++ b/plugins/databases/postgresql/src/main/java/org/apache/hop/pipeline/transforms/pgbulkloader/PGBulkLoader.java
@@ -33,6 +33,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.hop.core.Const;
 import org.apache.hop.core.database.Database;
 import org.apache.hop.core.database.DatabaseMeta;
@@ -282,6 +283,20 @@ public class PGBulkLoader extends BaseTransform<PGBulkLoaderMeta, PGBulkLoaderDa
     return (bool ? "t" : "f").getBytes(charset);
   }
 
+  /**
+   * Encodes binary data for PostgreSQL COPY text/CSV format. {@code bytea} accepts the hex form
+   * {@code \x} followed by two hex digits per byte.
+   */
+  @VisibleForTesting
+  static byte[] binaryFieldBytesForPgCopyText(
+      IValueMeta valueMeta, Object valueData, Charset charset) throws HopValueException {
+    byte[] bytes = valueMeta.getBinary(valueData);
+    if (bytes == null) {
+      return null;
+    }
+    return ("\\x" + Hex.encodeHexString(bytes)).getBytes(charset);
+  }
+
   private void writeRowToPostgres(IRowMeta rowMeta, Object[] r) throws HopException {
 
     try {
@@ -429,6 +444,13 @@ public class PGBulkLoader extends BaseTransform<PGBulkLoaderMeta, PGBulkLoaderDa
                 if (big != null) {
                   pgCopyOut.write(big.toString().getBytes(clientEncoding));
                 }
+              }
+              break;
+            case IValueMeta.TYPE_BINARY:
+              byte[] binaryBytes =
+                  binaryFieldBytesForPgCopyText(valueMeta, valueData, clientEncoding);
+              if (binaryBytes != null) {
+                pgCopyOut.write(binaryBytes);
               }
               break;
             default:

--- a/plugins/databases/postgresql/src/test/java/org/apache/hop/pipeline/transforms/pgbulkloader/PGBulkLoaderTest.java
+++ b/plugins/databases/postgresql/src/test/java/org/apache/hop/pipeline/transforms/pgbulkloader/PGBulkLoaderTest.java
@@ -44,6 +44,7 @@ import org.apache.hop.core.exception.HopValueException;
 import org.apache.hop.core.exception.HopXmlException;
 import org.apache.hop.core.logging.ILoggingObject;
 import org.apache.hop.core.plugins.PluginRegistry;
+import org.apache.hop.core.row.value.ValueMetaBinary;
 import org.apache.hop.core.row.value.ValueMetaBoolean;
 import org.apache.hop.databases.postgresql.PostgreSqlDatabaseMeta;
 import org.apache.hop.junit.rules.RestoreHopEngineEnvironmentExtension;
@@ -116,6 +117,19 @@ class PGBulkLoaderTest {
         "f".getBytes(StandardCharsets.UTF_8),
         PGBulkLoader.booleanFieldBytesForPgCopyText(meta, Boolean.FALSE, StandardCharsets.UTF_8));
     assertNull(PGBulkLoader.booleanFieldBytesForPgCopyText(meta, null, StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void binaryFieldBytesForPgCopyText_usesPostgresByteaHex() throws HopValueException {
+    ValueMetaBinary meta = new ValueMetaBinary("hash");
+    byte[] bytes = {(byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef};
+    assertArrayEquals(
+        "\\xdeadbeef".getBytes(StandardCharsets.UTF_8),
+        PGBulkLoader.binaryFieldBytesForPgCopyText(meta, bytes, StandardCharsets.UTF_8));
+    assertArrayEquals(
+        "\\x".getBytes(StandardCharsets.UTF_8),
+        PGBulkLoader.binaryFieldBytesForPgCopyText(meta, new byte[0], StandardCharsets.UTF_8));
+    assertNull(PGBulkLoader.binaryFieldBytesForPgCopyText(meta, null, StandardCharsets.UTF_8));
   }
 
   @Test

--- a/plugins/databases/snowflake/src/main/java/org/apache/hop/pipeline/transforms/snowflake/bulkloader/SnowflakeBulkLoader.java
+++ b/plugins/databases/snowflake/src/main/java/org/apache/hop/pipeline/transforms/snowflake/bulkloader/SnowflakeBulkLoader.java
@@ -25,6 +25,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.hop.core.Const;
@@ -365,6 +366,11 @@ public class SnowflakeBulkLoader
     data.db.execStatement("commit");
   }
 
+  private static boolean isSnowflakeBinaryColumn(String type) {
+    String upper = type.toUpperCase();
+    return upper.startsWith("BINARY") || upper.startsWith("VARBINARY");
+  }
+
   /**
    * Determines the value metadata to use when writing the fields of the stream to a temp file. Date
    * and timestamp values are written with the conversion mask matching the file format of the COPY
@@ -481,7 +487,15 @@ public class SnowflakeBulkLoader
             }
             Object valueData = null;
             if (fieldIndex >= 0) {
-              valueData = v.convertData(rowMeta.getValueMeta(fieldIndex), row[fieldIndex]);
+              IValueMeta streamMeta = rowMeta.getValueMeta(fieldIndex);
+              // Binary must not be converted through String (that is `new String(bytes)`). Keep
+              // the stream metadata so formatField can emit hex for COPY BINARY_FORMAT='HEX'.
+              if (streamMeta.isBinary() || isSnowflakeBinaryColumn(field[1])) {
+                v = streamMeta;
+                valueData = row[fieldIndex];
+              } else {
+                valueData = v.convertData(streamMeta, row[fieldIndex]);
+              }
             } else if (meta.isErrorColumnMismatch()) {
               throw new HopException(
                   "Error column mismatch: Database field "
@@ -514,6 +528,13 @@ public class SnowflakeBulkLoader
    * @throws HopValueException
    */
   private byte[] formatField(IValueMeta v, Object valueData) throws HopValueException {
+    if (v.isBinary()) {
+      byte[] bytes = v.getBinary(valueData);
+      if (bytes == null) {
+        return null;
+      }
+      return Hex.encodeHexString(bytes).getBytes(StandardCharsets.UTF_8);
+    }
     if (v.isString()) {
       if (v.isStorageBinaryString()
           && v.getTrimType() == IValueMeta.TRIM_TYPE_NONE

--- a/plugins/databases/snowflake/src/main/java/org/apache/hop/pipeline/transforms/snowflake/bulkloader/SnowflakeBulkLoaderMeta.java
+++ b/plugins/databases/snowflake/src/main/java/org/apache/hop/pipeline/transforms/snowflake/bulkloader/SnowflakeBulkLoaderMeta.java
@@ -1091,6 +1091,7 @@ public class SnowflakeBulkLoaderMeta
           .append(errorColumnMismatch)
           .append(" ");
       returnValue.append("COMPRESSION = 'GZIP' ");
+      returnValue.append("BINARY_FORMAT = 'HEX' ");
 
     } else if (dataType.equals(DATA_TYPE_CODES[DATA_TYPE_JSON])) {
       returnValue.append("'JSON' COMPRESSION = 'GZIP' STRIP_OUTER_ARRAY = FALSE ");

--- a/plugins/databases/snowflake/src/test/java/org/apache/hop/pipeline/transforms/snowflake/bulkloader/SnowflakeBulkLoaderMetaTest.java
+++ b/plugins/databases/snowflake/src/test/java/org/apache/hop/pipeline/transforms/snowflake/bulkloader/SnowflakeBulkLoaderMetaTest.java
@@ -20,9 +20,18 @@ package org.apache.hop.pipeline.transforms.snowflake.bulkloader;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+import org.apache.hop.core.HopClientEnvironment;
+import org.apache.hop.core.variables.Variables;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 class SnowflakeBulkLoaderMetaTest {
+
+  @BeforeAll
+  static void initHop() throws Exception {
+    HopClientEnvironment.init();
+  }
 
   @Test
   void testDefaultTruncateFlagsAreOff() {
@@ -53,5 +62,16 @@ class SnowflakeBulkLoaderMetaTest {
 
     meta.setOnlyWhenHaveRows(false);
     assertFalse(meta.isOnlyWhenHaveRows());
+  }
+
+  @Test
+  void copyStatementDeclaresHexBinaryFormat() throws Exception {
+    SnowflakeBulkLoaderMeta meta = new SnowflakeBulkLoaderMeta();
+    meta.setDefault();
+    meta.setTargetTable("orders");
+
+    String sql = meta.getCopyStatement(new Variables(), List.of("/tmp/orders.csv"));
+
+    assertTrue(sql.contains("BINARY_FORMAT = 'HEX'"), sql);
   }
 }

--- a/plugins/databases/snowflake/src/test/java/org/apache/hop/pipeline/transforms/snowflake/bulkloader/SnowflakeBulkLoaderTest.java
+++ b/plugins/databases/snowflake/src/test/java/org/apache/hop/pipeline/transforms/snowflake/bulkloader/SnowflakeBulkLoaderTest.java
@@ -42,6 +42,7 @@ import org.apache.hop.core.database.DatabaseMeta;
 import org.apache.hop.core.row.IRowMeta;
 import org.apache.hop.core.row.IValueMeta;
 import org.apache.hop.core.row.RowMeta;
+import org.apache.hop.core.row.value.ValueMetaBinary;
 import org.apache.hop.core.row.value.ValueMetaDate;
 import org.apache.hop.core.row.value.ValueMetaString;
 import org.apache.hop.core.row.value.ValueMetaTimestamp;
@@ -291,6 +292,30 @@ class SnowflakeBulkLoaderTest {
 
     assertEquals(
         "2023-02-09,2023-02-09 10:11:12.000" + SnowflakeBulkLoaderMeta.CSV_RECORD_DELIMITER,
+        output.toString(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void writesBinaryValuesAsHex() throws Exception {
+    IRowMeta rowMeta = new RowMeta();
+    rowMeta.addValueMeta(new ValueMetaBinary("hash"));
+
+    data.outputRowMeta = rowMeta;
+    data.writeValueMetas = bulkLoaderSpy.getWriteValueMetas(rowMeta);
+    data.binarySeparator = SnowflakeBulkLoaderMeta.CSV_DELIMITER.getBytes(StandardCharsets.UTF_8);
+    data.binaryEnclosure = SnowflakeBulkLoaderMeta.ENCLOSURE.getBytes(StandardCharsets.UTF_8);
+    data.escapeCharacters =
+        SnowflakeBulkLoaderMeta.CSV_ESCAPE_CHAR.getBytes(StandardCharsets.UTF_8);
+    data.binaryNewline =
+        SnowflakeBulkLoaderMeta.CSV_RECORD_DELIMITER.getBytes(StandardCharsets.UTF_8);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    data.writer = output;
+
+    bulkLoaderSpy.writeRowToFile(
+        rowMeta, new Object[] {new byte[] {(byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef}});
+
+    assertEquals(
+        "deadbeef" + SnowflakeBulkLoaderMeta.CSV_RECORD_DELIMITER,
         output.toString(StandardCharsets.UTF_8));
   }
 }

--- a/plugins/databases/teradata/src/main/java/org/apache/hop/pipeline/transforms/terafast/TeraFast.java
+++ b/plugins/databases/teradata/src/main/java/org/apache/hop/pipeline/transforms/terafast/TeraFast.java
@@ -17,6 +17,7 @@
 
 package org.apache.hop.pipeline.transforms.terafast;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,6 +28,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -241,8 +243,9 @@ public class TeraFast extends BaseTransform<TeraFastMeta, TeraFastData> {
             break;
           case IValueMeta.TYPE_BINARY:
             byte[] byt = iRowMeta.getBinary(row, i);
-            // REVIEW - this does an implicit byt.toString, which can't be what was intended.
-            dataFilePrintStream.print(byt);
+            if (byt != null) {
+              dataFilePrintStream.print(hexFieldForFastLoad(byt));
+            }
             break;
           default:
             throw new HopException(
@@ -253,6 +256,17 @@ public class TeraFast extends BaseTransform<TeraFastMeta, TeraFastData> {
       dataFilePrintStream.print(FastloadControlBuilder.DATAFILE_COLUMN_SEPERATOR);
     }
     dataFilePrintStream.print(Const.CR);
+  }
+
+  /** FastLoad VARTEXT reads BYTE/VARBYTE values as hexadecimal strings with no prefix. */
+  @VisibleForTesting
+  static String hexFieldForFastLoad(byte[] bytes) {
+    return bytes == null ? null : Hex.encodeHexString(bytes);
+  }
+
+  @VisibleForTesting
+  void setDataFilePrintStream(PrintStream printStream) {
+    this.dataFilePrintStream = printStream;
   }
 
   private String pad(IValueMeta iValueMeta, String data) {

--- a/plugins/databases/teradata/src/test/java/org/apache/hop/pipeline/transforms/terafast/TeraFastTest.java
+++ b/plugins/databases/teradata/src/test/java/org/apache/hop/pipeline/transforms/terafast/TeraFastTest.java
@@ -17,14 +17,23 @@
 
 package org.apache.hop.pipeline.transforms.terafast;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import org.apache.hop.core.Const;
 import org.apache.hop.core.HopEnvironment;
 import org.apache.hop.core.exception.HopException;
 import org.apache.hop.core.plugins.PluginRegistry;
+import org.apache.hop.core.row.IRowMeta;
+import org.apache.hop.core.row.RowMeta;
+import org.apache.hop.core.row.value.ValueMetaBinary;
 import org.apache.hop.pipeline.Pipeline;
 import org.apache.hop.pipeline.PipelineMeta;
 import org.apache.hop.pipeline.engines.local.LocalPipelineEngine;
@@ -103,5 +112,43 @@ class TeraFastTest {
     assertTrue(cmd.contains("-e"));
     assertTrue(
         cmd.contains(logPath) || cmd.replace('\\', '/').contains(logPath.replace('\\', '/')));
+  }
+
+  @Test
+  void hexFieldForFastLoad_usesPlainHex() {
+    assertEquals(
+        "deadbeef",
+        TeraFast.hexFieldForFastLoad(
+            new byte[] {(byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef}));
+    assertEquals("", TeraFast.hexFieldForFastLoad(new byte[0]));
+    assertNull(TeraFast.hexFieldForFastLoad(null));
+  }
+
+  @Test
+  void writesBinaryValuesAsHex() throws Exception {
+    PipelineMeta pipelineMeta = new PipelineMeta();
+    TransformMeta transformMeta = new TransformMeta("test", new TeraFastMeta());
+    pipelineMeta.addTransform(transformMeta);
+
+    TeraFast transform =
+        new TeraFast(
+            transformMeta,
+            new TeraFastMeta(),
+            new TeraFastData(),
+            0,
+            pipelineMeta,
+            new LocalPipelineEngine(pipelineMeta));
+
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    transform.setDataFilePrintStream(new PrintStream(buffer, true, StandardCharsets.UTF_8));
+
+    IRowMeta rowMeta = new RowMeta();
+    rowMeta.addValueMeta(new ValueMetaBinary("hash"));
+    transform.writeToDataFile(
+        rowMeta, new Object[] {new byte[] {(byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef}});
+
+    assertEquals(
+        "deadbeef" + FastloadControlBuilder.DATAFILE_COLUMN_SEPERATOR + Const.CR,
+        buffer.toString(StandardCharsets.UTF_8));
   }
 }

--- a/plugins/databases/vertica/src/main/java/org/apache/hop/pipeline/transforms/vertica/bulkloader/nativebinary/ColumnSpec.java
+++ b/plugins/databases/vertica/src/main/java/org/apache/hop/pipeline/transforms/vertica/bulkloader/nativebinary/ColumnSpec.java
@@ -166,7 +166,7 @@ public class ColumnSpec {
 
     switch (this.type) {
       case BINARY:
-        inputBinary = valueMeta.getBinaryString(value);
+        inputBinary = valueMeta.getBinary(value);
         length = inputBinary.length;
         this.mainBuffer.put(inputBinary);
         for (int i = 0; i < (this.bytes - length); i++) {
@@ -290,7 +290,7 @@ public class ColumnSpec {
         sizePosition = this.mainBuffer.position();
         this.mainBuffer.putInt(0);
         prevPosition = this.mainBuffer.position();
-        this.mainBuffer.put(valueMeta.getBinaryString(value));
+        this.mainBuffer.put(valueMeta.getBinary(value));
         this.mainBuffer.putInt(sizePosition, this.mainBuffer.position() - prevPosition);
         this.bytes = this.mainBuffer.position() - sizePosition;
         break;

--- a/plugins/misc/testing/src/main/java/org/apache/hop/testing/DataSetCsvUtil.java
+++ b/plugins/misc/testing/src/main/java/org/apache/hop/testing/DataSetCsvUtil.java
@@ -22,6 +22,8 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
@@ -96,7 +98,7 @@ public class DataSetCsvUtil {
               constantValueMeta.setConversionMetadata(valueMeta);
               if (i < csvRecord.size()) {
                 String value = csvRecord.get(i);
-                row[i] = valueMeta.convertData(constantValueMeta, value);
+                row[i] = csvValueToField(valueMeta, constantValueMeta, value);
               }
             }
             rows.add(row);
@@ -169,7 +171,7 @@ public class DataSetCsvUtil {
                 IValueMeta valueMeta = setRowMeta.getValueMeta(index);
                 constantValueMeta.setConversionMetadata(valueMeta);
                 String value = csvRecord.get(index);
-                row[i] = valueMeta.convertData(constantValueMeta, value);
+                row[i] = csvValueToField(valueMeta, constantValueMeta, value);
               } else {
                 row[i] = null;
               }
@@ -222,6 +224,30 @@ public class DataSetCsvUtil {
       for (Object[] row : rows) {
         writer.writeRow(row);
       }
+    }
+  }
+
+  /**
+   * Binary data-set fields are stored as lowercase hex (no {@code \\x} prefix). Everything else
+   * uses the field's normal string conversion.
+   */
+  static Object csvValueToField(IValueMeta valueMeta, IValueMeta stringMeta, String value)
+      throws HopException {
+    if (valueMeta.isBinary()) {
+      return decodeHex(value, valueMeta.getName());
+    }
+    return valueMeta.convertData(stringMeta, value);
+  }
+
+  static byte[] decodeHex(String value, String fieldName) throws HopException {
+    if (value == null || value.isEmpty()) {
+      return null;
+    }
+    try {
+      return Hex.decodeHex(value);
+    } catch (DecoderException e) {
+      throw new HopException(
+          "Unable to decode hex binary value for field '" + fieldName + "': " + value, e);
     }
   }
 

--- a/plugins/misc/testing/src/main/java/org/apache/hop/testing/DataSetCsvWriter.java
+++ b/plugins/misc/testing/src/main/java/org/apache/hop/testing/DataSetCsvWriter.java
@@ -23,6 +23,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.hop.core.exception.HopException;
@@ -73,7 +74,12 @@ public class DataSetCsvWriter implements AutoCloseable {
       List<String> strings = new ArrayList<>(setRowMeta.size());
       for (int i = 0; i < setRowMeta.size(); i++) {
         IValueMeta valueMeta = setRowMeta.getValueMeta(i);
-        strings.add(valueMeta.getString(row[i]));
+        if (valueMeta.isBinary()) {
+          byte[] bytes = valueMeta.getBinary(row[i]);
+          strings.add(bytes == null ? null : Hex.encodeHexString(bytes));
+        } else {
+          strings.add(valueMeta.getString(row[i]));
+        }
       }
       csvPrinter.printRecord(strings);
     } catch (Exception e) {

--- a/plugins/misc/testing/src/test/java/org/apache/hop/testing/DataSetCsvWriterTest.java
+++ b/plugins/misc/testing/src/test/java/org/apache/hop/testing/DataSetCsvWriterTest.java
@@ -17,7 +17,9 @@
 
 package org.apache.hop.testing;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
@@ -130,5 +132,39 @@ class DataSetCsvWriterTest {
     }
 
     assertTrue(Files.exists(nested.resolve("nested.csv")));
+  }
+
+  @Test
+  void binaryValuesRoundTripAsLowercaseHex() throws Exception {
+    Variables variables = new Variables();
+    variables.setVariable(DataSet.VARIABLE_HOP_DATASETS_FOLDER, tempDir.toString());
+
+    DataSet dataSet = new DataSet();
+    dataSet.setName("binary");
+    dataSet.setBaseFilename("binary.csv");
+    dataSet.setFields(
+        List.of(
+            new DataSetField("id", IValueMeta.TYPE_INTEGER, -1, 0, "", "0"),
+            new DataSetField("payload", IValueMeta.TYPE_BINARY, -1, -1, "", "")));
+
+    IRowMeta rowMeta = dataSet.getSetRowMeta();
+    byte[] hash = {(byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef};
+    byte[] nulHigh = {0x00, (byte) 0xff};
+    try (DataSetCsvWriter writer = new DataSetCsvWriter(variables, dataSet, rowMeta)) {
+      writer.writeRow(new Object[] {1L, hash});
+      writer.writeRow(new Object[] {2L, nulHigh});
+      writer.writeRow(new Object[] {3L, null});
+    }
+
+    String csv = Files.readString(tempDir.resolve("binary.csv"));
+    assertTrue(csv.contains("deadbeef"), csv);
+    assertTrue(csv.contains("00ff"), csv);
+
+    List<Object[]> rows = DataSetCsvUtil.getAllRows(variables, dataSet);
+    assertEquals(3, rows.size());
+    assertEquals(1L, rows.get(0)[0]);
+    assertArrayEquals(hash, (byte[]) rows.get(0)[1]);
+    assertArrayEquals(nulHigh, (byte[]) rows.get(1)[1]);
+    assertNull(rows.get(2)[1]);
   }
 }

--- a/plugins/tech/aws/src/main/java/org/apache/hop/pipeline/transforms/redshift/bulkloader/RedshiftBulkLoader.java
+++ b/plugins/tech/aws/src/main/java/org/apache/hop/pipeline/transforms/redshift/bulkloader/RedshiftBulkLoader.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.hop.core.Const;
@@ -706,6 +707,13 @@ public class RedshiftBulkLoader
    * @throws HopValueException
    */
   private byte[] formatField(IValueMeta v, Object valueData) throws HopValueException {
+    if (v.isBinary()) {
+      byte[] bytes = v.getBinary(valueData);
+      if (bytes == null) {
+        return null;
+      }
+      return Hex.encodeHexString(bytes).getBytes(StandardCharsets.UTF_8);
+    }
     if (v.isString()) {
       if (v.isStorageBinaryString()
           && v.getTrimType() == IValueMeta.TRIM_TYPE_NONE

--- a/plugins/tech/aws/src/test/java/org/apache/hop/pipeline/transforms/redshift/bulkloader/RedshiftBulkLoaderTest.java
+++ b/plugins/tech/aws/src/test/java/org/apache/hop/pipeline/transforms/redshift/bulkloader/RedshiftBulkLoaderTest.java
@@ -44,6 +44,7 @@ import org.apache.hop.core.database.DatabaseMeta;
 import org.apache.hop.core.exception.HopException;
 import org.apache.hop.core.row.IRowMeta;
 import org.apache.hop.core.row.RowMeta;
+import org.apache.hop.core.row.value.ValueMetaBinary;
 import org.apache.hop.core.row.value.ValueMetaDate;
 import org.apache.hop.core.row.value.ValueMetaInteger;
 import org.apache.hop.core.row.value.ValueMetaJson;
@@ -264,6 +265,19 @@ class RedshiftBulkLoaderTest {
     rowMeta.addValueMeta(new ValueMetaInteger("amount"));
 
     assertEquals("\"Acme, Inc\",42\n", writeRow(rowMeta, new Object[] {"Acme, Inc", 42L}, false));
+  }
+
+  @Test
+  void writesBinaryValuesAsHexWithoutAPostgresPrefix() throws Exception {
+    IRowMeta rowMeta = new RowMeta();
+    rowMeta.addValueMeta(new ValueMetaBinary("hash"));
+
+    assertEquals(
+        "deadbeef\n",
+        writeRow(
+            rowMeta,
+            new Object[] {new byte[] {(byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef}},
+            false));
   }
 
   /** Quotes inside a value are doubled, the way the COPY statement expects them. */


### PR DESCRIPTION
fixes #8154

Hop Binary stream fields (hash keys, raw bytes, BLOBs) can now be bulk loaded on every transform whose engine accepts binary in its bulk protocol. There is no new dialog option: the stream type drives the encoding, the same way PostgreSQL already serializes booleans as `t`/`f`.

The previous failure (`PGBulkLoader doesn't handle the type Binary`) is gone. Text-based loaders call `getBinary()` and write hex in the format that engine actually reads:

| Loader | Encoding |
|---|---|
| PostgreSQL / Greenplum | `\xdeadbeef` (`bytea` hex) |
| MySQL | lowercase hex + `SET col = UNHEX(@col)` |
| Oracle | hex in the data file + `HEXTORAW` in the SQL*Loader control file (replaces the broken `startlob` / `byte[].toString()` path) |
| Snowflake | hex + `BINARY_FORMAT = 'HEX'` on `COPY` |
| Redshift | hex **without** `\x` (`VARBYTE`) |
| MonetDB | hex for `BLOB` |
| TeraFast | hex for FastLoad `BYTE`/`VARBYTE` |
| CrateDB | hex string (no native binary type; lands in `STRING`) |
| SQL Server | unchanged — already sent as `byte[]` |
| Vertica | unchanged native bytes; `BINARY`/`VARBINARY` now use `getBinary()` |

Out of scope: Doris (it stream-loads a payload field you already built) and the MySQL/SQL Server **actions** (they load an existing file, not Hop rows).

## Tests

Unit tests cover the hex helpers and write paths for PostgreSQL, MySQL, Oracle, Snowflake, Redshift, MonetDB, TeraFast, CrateDB, and Vertica.

Existing integration tests were run successfully for projects **database**, **mssql**, **vertica**, and **monetdb**. Project **cratedb** is disabled. None of those suites currently load Binary/`BYTEA`/`VARBINARY` columns.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).