### PR TITLE
Issue #8163 : Harden XmlInputStream StAX factory against XXE

### DIFF
--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -156,7 +156,10 @@ where strict outbound TLS verification is required (see §9).
   ([`XmlParserFactoryProducer.java`](core/src/main/java/org/apache/hop/core/xml/XmlParserFactoryProducer.java)) with external general/parameter entities and
   external DTD loading disabled and `FEATURE_SECURE_PROCESSING` on — XXE
   file-read/SSRF and entity-expansion are mitigated (verified empirically). The
-  same secure parser is used by the Hop Server remote-add endpoints.
+  same secure parser is used by the Hop Server remote-add endpoints. StAX ingest
+  (`XmlInputStream` and other `XMLInputFactory` sites) uses
+  `createSecureXmlInputFactory()`, which disables DTD processing and external
+  entities.
 - **Credential storage — NOT confidential by default.** Connection passwords in
   metadata are by default only **reversibly obfuscated, not encrypted**: the
   built-in `Hop` encoder ([`HopTwoWayPasswordEncoder.java`](core/src/main/java/org/apache/hop/core/encryption/HopTwoWayPasswordEncoder.java)) XORs against a

--- a/core/src/main/java/org/apache/hop/core/xml/XmlFormatter.java
+++ b/core/src/main/java/org/apache/hop/core/xml/XmlFormatter.java
@@ -37,7 +37,8 @@ import org.apache.hop.core.exception.HopRuntimeException;
 public class XmlFormatter {
   private static final String TRANSFORM_PREFIX = "  ";
 
-  private static XMLInputFactory INPUT_FACTORY = XMLInputFactory.newInstance();
+  private static XMLInputFactory INPUT_FACTORY =
+      XmlParserFactoryProducer.createSecureXmlInputFactory();
   private static XMLOutputFactory OUTPUT_FACTORY = XMLOutputFactory.newInstance();
 
   static {

--- a/core/src/main/java/org/apache/hop/core/xml/XmlParserFactoryProducer.java
+++ b/core/src/main/java/org/apache/hop/core/xml/XmlParserFactoryProducer.java
@@ -21,6 +21,7 @@ import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
+import javax.xml.stream.XMLInputFactory;
 import javax.xml.validation.SchemaFactory;
 import org.apache.hop.core.Const;
 import org.apache.hop.core.logging.LogChannel;
@@ -141,6 +142,28 @@ public class XmlParserFactoryProducer {
     factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
     factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, LOCAL_FILE_ACCESS_ONLY);
 
+    return factory;
+  }
+
+  /**
+   * Creates an instance of {@link XMLInputFactory} with DTD processing and external entity
+   * resolution disabled to protect against XML External Entity (XXE) attacks and XML entity
+   * expansion bombs.
+   *
+   * <p>{@link XMLConstants#ACCESS_EXTERNAL_DTD} and {@link XMLConstants#ACCESS_EXTERNAL_SCHEMA} are
+   * set when the StAX provider recognizes them. Woodstox (the factory on Hop's runtime classpath)
+   * does not, so those two calls are best-effort.
+   */
+  public static XMLInputFactory createSecureXmlInputFactory() {
+    XMLInputFactory factory = XMLInputFactory.newInstance();
+    factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+    factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+    try {
+      factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+      factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+    } catch (IllegalArgumentException e) {
+      // Property not supported by this StAX provider
+    }
     return factory;
   }
 }

--- a/core/src/test/java/org/apache/hop/core/xml/XmlUtilsTest.java
+++ b/core/src/test/java/org/apache/hop/core/xml/XmlUtilsTest.java
@@ -18,15 +18,21 @@
 package org.apache.hop.core.xml;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.SAXParserFactory;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
 import javax.xml.validation.SchemaFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -103,5 +109,47 @@ class XmlUtilsTest {
         XmlParserFactoryProducer.createSecureSchemaFactory(XMLConstants.W3C_XML_SCHEMA_NS_URI);
 
     assertDoesNotThrow(() -> schemaFactory.newSchema(including));
+  }
+
+  @Test
+  void secureXmlInputFactoryDisablesDtdAndExternalEntities() {
+    XMLInputFactory factory = XmlParserFactoryProducer.createSecureXmlInputFactory();
+
+    assertFalse((Boolean) factory.getProperty(XMLInputFactory.SUPPORT_DTD));
+    assertFalse((Boolean) factory.getProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES));
+  }
+
+  @Test
+  void secureXmlInputFactoryDoesNotResolveExternalEntities(@TempDir Path tempDir) throws Exception {
+    Path secret = tempDir.resolve("secret.txt");
+    Files.writeString(secret, "CANARY_SECRET_VALUE");
+    String xml =
+        "<?xml version=\"1.0\"?>"
+            + "<!DOCTYPE foo [ <!ENTITY xxe SYSTEM \""
+            + secret.toUri()
+            + "\"> ]>"
+            + "<root>&xxe;</root>";
+
+    XMLInputFactory factory = XmlParserFactoryProducer.createSecureXmlInputFactory();
+    StringBuilder text = new StringBuilder();
+    XMLStreamReader streamReader = factory.createXMLStreamReader(new StringReader(xml));
+    try {
+      while (streamReader.hasNext()) {
+        int event = streamReader.next();
+        if (event == XMLStreamConstants.CHARACTERS || event == XMLStreamConstants.CDATA) {
+          text.append(streamReader.getText());
+        }
+      }
+    } catch (XMLStreamException e) {
+      // Expected when DTD processing is disabled
+      assertFalse(text.toString().contains("CANARY_SECRET_VALUE"));
+      return;
+    } finally {
+      streamReader.close();
+    }
+
+    assertFalse(
+        text.toString().contains("CANARY_SECRET_VALUE"),
+        "external entity content must not appear in the parse result");
   }
 }

--- a/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelinput/staxpoi/StaxUtil.java
+++ b/plugins/transforms/excel/src/main/java/org/apache/hop/pipeline/transforms/excelinput/staxpoi/StaxUtil.java
@@ -18,6 +18,7 @@
 package org.apache.hop.pipeline.transforms.excelinput.staxpoi;
 
 import javax.xml.stream.XMLInputFactory;
+import org.apache.hop.core.xml.XmlParserFactoryProducer;
 import org.apache.poi.ss.SpreadsheetVersion;
 
 public class StaxUtil {
@@ -67,10 +68,6 @@ public class StaxUtil {
   }
 
   public static final XMLInputFactory safeXMLInputFactory() {
-    XMLInputFactory factory = XMLInputFactory.newInstance();
-    // To prevent from XXE attacks
-    factory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
-    factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
-    return factory;
+    return XmlParserFactoryProducer.createSecureXmlInputFactory();
   }
 }

--- a/plugins/transforms/webservices/src/main/java/org/apache/hop/pipeline/transforms/webservices/WebService.java
+++ b/plugins/transforms/webservices/src/main/java/org/apache/hop/pipeline/transforms/webservices/WebService.java
@@ -36,7 +36,6 @@ import java.util.Date;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.List;
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.stream.XMLInputFactory;
@@ -906,9 +905,7 @@ public class WebService extends BaseTransform<WebServiceMeta, WebServiceData> {
 
     // TODO Very empirical : see if we can do something better here
     try {
-      XMLInputFactory vFactory = XMLInputFactory.newInstance();
-      vFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-      vFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+      XMLInputFactory vFactory = XmlParserFactoryProducer.createSecureXmlInputFactory();
       XMLStreamReader vReader = vFactory.createXMLStreamReader(stringReader);
 
       Object[] outputRowData = RowDataUtil.allocateRowData(data.outputRowMeta.size());

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/advancedxmloutput/AdvancedXmlOutput.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/advancedxmloutput/AdvancedXmlOutput.java
@@ -48,6 +48,7 @@ import org.apache.hop.core.row.IValueMeta;
 import org.apache.hop.core.row.RowDataUtil;
 import org.apache.hop.core.util.Utils;
 import org.apache.hop.core.vfs.HopVfs;
+import org.apache.hop.core.xml.XmlParserFactoryProducer;
 import org.apache.hop.i18n.BaseMessages;
 import org.apache.hop.pipeline.Pipeline;
 import org.apache.hop.pipeline.PipelineMeta;
@@ -64,7 +65,8 @@ public class AdvancedXmlOutput extends BaseTransform<AdvancedXmlOutputMeta, Adva
 
   private static final String EOL = "\n";
   private static final XMLOutputFactory XML_OUT_FACTORY = XMLOutputFactory.newInstance();
-  private static final XMLInputFactory XML_IN_FACTORY = createSecureInputFactory();
+  private static final XMLInputFactory XML_IN_FACTORY =
+      XmlParserFactoryProducer.createSecureXmlInputFactory();
 
   /** Writes every byte to two underlying streams (e.g. file + in-memory capture). */
   private static final class TeeOutputStream extends OutputStream {
@@ -988,13 +990,6 @@ public class AdvancedXmlOutput extends BaseTransform<AdvancedXmlOutputMeta, Adva
       }
     }
     return s;
-  }
-
-  private static XMLInputFactory createSecureInputFactory() {
-    XMLInputFactory f = XMLInputFactory.newInstance();
-    f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
-    f.setProperty(XMLInputFactory.SUPPORT_DTD, false);
-    return f;
   }
 
   /** Test hook: returns the current data object's writer (so unit tests can inject a mock). */

--- a/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xmlinputstream/XmlInputStream.java
+++ b/plugins/transforms/xml/src/main/java/org/apache/hop/pipeline/transforms/xml/xmlinputstream/XmlInputStream.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.Attribute;
@@ -42,6 +41,7 @@ import org.apache.hop.core.row.RowDataUtil;
 import org.apache.hop.core.row.RowMeta;
 import org.apache.hop.core.util.Utils;
 import org.apache.hop.core.vfs.HopVfs;
+import org.apache.hop.core.xml.XmlParserFactoryProducer;
 import org.apache.hop.i18n.BaseMessages;
 import org.apache.hop.lineage.LineageFileIoEmitter;
 import org.apache.hop.lineage.model.FileIoOperation;
@@ -651,7 +651,7 @@ public class XmlInputStream extends BaseTransform<XmlInputStreamMeta, XmlInputSt
   @Override
   public boolean init() {
     if (super.init()) {
-      data.staxInstance = XMLInputFactory.newInstance(); // could select the parser later on
+      data.staxInstance = XmlParserFactoryProducer.createSecureXmlInputFactory();
       data.staxInstance.setProperty("javax.xml.stream.isCoalescing", false);
       data.filenr = 0;
       if (getPipelineMeta().findPreviousTransforms(getTransformMeta()).isEmpty()

--- a/plugins/transforms/xml/src/test/java/org/apache/hop/pipeline/transforms/xml/xmlinputstream/XmlInputStreamTest.java
+++ b/plugins/transforms/xml/src/test/java/org/apache/hop/pipeline/transforms/xml/xmlinputstream/XmlInputStreamTest.java
@@ -17,6 +17,7 @@
 package org.apache.hop.pipeline.transforms.xml.xmlinputstream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -348,6 +349,33 @@ class XmlInputStreamTest {
     assertEquals("some data", rl.getWritten().get(2)[3]);
     assertEquals("CHARACTERS", rl.getWritten().get(3)[0]);
     assertEquals("other data", rl.getWritten().get(3)[3]);
+  }
+
+  @Test
+  void doesNotResolveExternalEntities() throws Exception {
+    File secret = File.createTempFile("xxe-secret", ".txt");
+    secret.deleteOnExit();
+    try (Writer writer = new PrintWriter(secret, "UTF8")) {
+      writer.write("CANARY_SECRET_VALUE");
+    }
+
+    String xml =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<!DOCTYPE root [ <!ENTITY xxe SYSTEM \""
+            + secret.toURI()
+            + "\"> ]>"
+            + "<root>&xxe;</root>";
+    xmlInputStreamMeta.setFilename(createTestFile(xml));
+
+    assertThrows(HopException.class, this::doTest);
+
+    for (Object[] row : rl.getWritten()) {
+      for (Object cell : row) {
+        if (cell instanceof String value) {
+          assertFalse(value.contains("CANARY_SECRET_VALUE"));
+        }
+      }
+    }
   }
 
   private void doTest() throws HopException {


### PR DESCRIPTION
fixes #8163

`XmlInputStream` created a raw StAX `XMLInputFactory` and never disabled DTD processing or external entity resolution. Other Hop XML parsers already go through `XmlParserFactoryProducer` (DOM/SAX/Schema) or set the two StAX flags locally.

This adds `XmlParserFactoryProducer.createSecureXmlInputFactory()` (`SUPPORT_DTD=false`, `IS_SUPPORTING_EXTERNAL_ENTITIES=false`, best-effort `ACCESS_EXTERNAL_DTD/SCHEMA`) and uses it from:

- `XmlInputStream` (the reported sink)
- `WebService` (SOAP/HTTP responses)
- `XmlFormatter`
- `AdvancedXmlOutput` and Excel `StaxUtil` (already local flags; they now share the helper)

**Behavior change:** XML documents that contain a DOCTYPE will fail to parse. That is the intended trade-off.

## Tests

- Factory property assertions and a canary-file external-entity test in `XmlUtilsTest`
- `XmlInputStreamTest` regression that the canary is not emitted as row data

Targeted unit tests: `./mvnw -pl core,plugins/transforms/xml,plugins/transforms/excel,plugins/transforms/webservices -am test -Pskip-uitest`

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).