### PR TITLE
Fix pipeline and workflow marked dirty after opening a dialog with no real edits

### DIFF
--- a/core/src/main/java/org/apache/hop/metadata/serializer/xml/XmlMetadataUtil.java
+++ b/core/src/main/java/org/apache/hop/metadata/serializer/xml/XmlMetadataUtil.java
@@ -403,6 +403,11 @@ public class XmlMetadataUtil {
     // Get the value of the field...
     //
     Object value = ReflectionUtil.getFieldValue(parentObject, field.getName(), isBoolean);
+    // Empty strings are omitted like null. Dialogs write "" for blank widgets; serializing that as
+    // <tag/> while null omits the tag made OK-without-edits look like a configuration change.
+    if (value instanceof String string && StringUtils.isEmpty(string)) {
+      return value;
+    }
     if (value != null) {
       // We only serialize non-null values to save space and performance.
       //

--- a/core/src/test/java/org/apache/hop/metadata/serializer/xml/XmlMetadataUtilTest.java
+++ b/core/src/test/java/org/apache/hop/metadata/serializer/xml/XmlMetadataUtilTest.java
@@ -31,6 +31,7 @@ import org.apache.hop.metadata.serializer.memory.MemoryMetadataProvider;
 import org.apache.hop.metadata.serializer.xml.classes.Field;
 import org.apache.hop.metadata.serializer.xml.classes.Info;
 import org.apache.hop.metadata.serializer.xml.classes.MetaData;
+import org.apache.hop.metadata.serializer.xml.classes.MixedValueMeta;
 import org.apache.hop.metadata.serializer.xml.classes.TestEnum;
 import org.apache.hop.metadata.serializer.xml.classes.WithListReference;
 import org.apache.hop.metadata.serializer.xml.classes.WithMap;
@@ -241,5 +242,100 @@ class XmlMetadataUtilTest {
     assertEquals(1, withCopy.getHops().size());
     assertEquals("S1", withCopy.getHops().get(0).getFrom().getName());
     assertNull(withCopy.getHops().get(0).getTo());
+  }
+
+  @Test
+  void emptyStringFieldIsOmittedLikeNull() throws Exception {
+    MetaData withNull = new MetaData();
+    MetaData withEmpty = new MetaData();
+    withEmpty.setFilename("");
+
+    String nullXml = XmlMetadataUtil.serializeObjectToXml(withNull);
+    String emptyXml = XmlMetadataUtil.serializeObjectToXml(withEmpty);
+
+    assertEquals(nullXml, emptyXml);
+    assertFalse(nullXml.contains("<filename"));
+    assertFalse(emptyXml.contains("<filename"));
+  }
+
+  @Test
+  void emptyNestedStringIsOmittedLikeNull() throws Exception {
+    Field withNullFormat = new Field("a", "String", 1, 0, null, null);
+    Field withEmptyFormat = new Field("a", "String", 1, 0, "", null);
+
+    assertEquals(
+        XmlMetadataUtil.serializeObjectToXml(withNullFormat),
+        XmlMetadataUtil.serializeObjectToXml(withEmptyFormat));
+  }
+
+  @Test
+  void nonEmptyStringFieldIsWritten() throws Exception {
+    MetaData meta = new MetaData();
+    meta.setFilename("filename.csv");
+
+    String xml = XmlMetadataUtil.serializeObjectToXml(meta);
+
+    assertTrue(xml.contains("<filename>filename.csv</filename>"));
+  }
+
+  @Test
+  void whitespaceStringFieldIsWritten() throws Exception {
+    MetaData meta = new MetaData();
+    meta.setFilename(" ");
+
+    String xml = XmlMetadataUtil.serializeObjectToXml(meta);
+
+    assertTrue(xml.contains("<filename> </filename>"));
+  }
+
+  @Test
+  void emptyListIsStillSerialized() throws Exception {
+    MixedValueMeta meta = new MixedValueMeta();
+    meta.setName("keep");
+
+    String xml = XmlMetadataUtil.serializeObjectToXml(meta);
+
+    assertTrue(xml.contains("<items>"));
+    assertTrue(xml.contains("</items>"));
+    assertFalse(xml.contains("<item>"));
+    assertFalse(xml.contains("<item/>"));
+  }
+
+  @Test
+  void emptyStringInListIsStillSerialized() throws Exception {
+    MetaData meta = new MetaData();
+    meta.setValues(List.of(""));
+
+    String xml = XmlMetadataUtil.serializeObjectToXml(meta);
+
+    assertTrue(xml.contains("<values>"));
+    assertTrue(xml.contains("<value/>") || xml.contains("<value></value>"));
+  }
+
+  @Test
+  void booleanFalseAndZeroAreStillSerialized() throws Exception {
+    MixedValueMeta meta = new MixedValueMeta();
+    meta.setEnabled(false);
+    meta.setCount(0);
+
+    String xml = XmlMetadataUtil.serializeObjectToXml(meta);
+
+    assertTrue(xml.contains("<enabled>N</enabled>"));
+    assertTrue(xml.contains("<count>0</count>"));
+  }
+
+  @Test
+  void omittedEmptyStringRoundTripsAsNull() throws Exception {
+    MetaData withEmpty = new MetaData();
+    withEmpty.setFilename("");
+    withEmpty.setSeparator(",");
+
+    String xml = XmlMetadataUtil.serializeObjectToXml(withEmpty);
+    Node node = XmlHandler.loadXmlString(XmlHandler.aroundTag("meta", xml), "meta");
+    MetaData loaded =
+        XmlMetadataUtil.deSerializeFromXml(node, MetaData.class, new MemoryMetadataProvider());
+
+    assertNull(loaded.getFilename());
+    assertEquals(",", loaded.getSeparator());
   }
 }

--- a/core/src/test/java/org/apache/hop/metadata/serializer/xml/classes/MixedValueMeta.java
+++ b/core/src/test/java/org/apache/hop/metadata/serializer/xml/classes/MixedValueMeta.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.metadata.serializer.xml.classes;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.hop.metadata.api.HopMetadataProperty;
+
+/** Fixture for testing which field types are omitted vs written by {@code XmlMetadataUtil}. */
+@Getter
+@Setter
+public class MixedValueMeta {
+
+  @HopMetadataProperty private String name;
+
+  @HopMetadataProperty private boolean enabled;
+
+  @HopMetadataProperty private int count;
+
+  @HopMetadataProperty(groupKey = "items", key = "item")
+  private List<String> items = new ArrayList<>();
+}

--- a/engine/src/main/java/org/apache/hop/pipeline/transform/TransformMeta.java
+++ b/engine/src/main/java/org/apache/hop/pipeline/transform/TransformMeta.java
@@ -746,6 +746,12 @@ public class TransformMeta
   }
 
   public void setRowDistribution(IRowDistribution rowDistribution) {
+    if (this.rowDistribution == rowDistribution) {
+      if (rowDistribution != null) {
+        setDistributes(true);
+      }
+      return;
+    }
     this.rowDistribution = rowDistribution;
     if (rowDistribution != null) {
       setDistributes(true);

--- a/engine/src/main/java/org/apache/hop/pipeline/transform/copy/DefaultTransformMetaCopyFactory.java
+++ b/engine/src/main/java/org/apache/hop/pipeline/transform/copy/DefaultTransformMetaCopyFactory.java
@@ -112,34 +112,14 @@ public class DefaultTransformMetaCopyFactory implements ITransformMetaCopyFactor
       copy.setParentPipelineMeta(source.getParentPipelineMeta());
     }
 
-    // Handle changed state preservation/clearing based on context
-    if (context.isPreserveChangedState()) {
-      // Check if the source or its inner transform has changes
-      boolean hasChanges =
-          source.hasChanged()
-              || (source.getTransform() != null && source.getTransform().hasChanged());
-
-      if (hasChanges) {
-        if (log.isDebug()) {
-          log.logDebug("Preserving changed state for TransformMeta: " + source.getName());
-        }
-        copy.setChanged();
-        if (copy.getTransform() != null) {
-          copy.getTransform().setChanged();
-        }
-      }
-    } else {
-      // Explicitly clear changed state if not preserving it
-      if (log.isDebug()) {
-        log.logDebug("Clearing changed state for TransformMeta: " + source.getName());
-      }
-      copy.setChanged(false);
-      if (copy.getTransform() != null
-          && copy.getTransform() instanceof org.apache.hop.pipeline.transform.BaseTransformMeta) {
-        ((org.apache.hop.pipeline.transform.BaseTransformMeta) copy.getTransform())
-            .setChanged(false);
-      }
-    }
+    // Apply the intended dirty flag last. Setters such as setRowDistribution() and
+    // setLocation() mark wrapperChanged while copying; a clone of a clean transform
+    // must remain clean.
+    boolean hasChanges =
+        context.isPreserveChangedState()
+            && (source.hasChanged()
+                || (source.getTransform() != null && source.getTransform().hasChanged()));
+    copy.setChanged(hasChanges);
 
     return copy;
   }
@@ -164,21 +144,8 @@ public class DefaultTransformMetaCopyFactory implements ITransformMetaCopyFactor
     }
 
     try {
-      // Capture the changed state before cloning
-      boolean hadChanges = context.isPreserveChangedState() && source.hasChanged();
-
-      // Perform the clone
       ITransformMeta copy = (ITransformMeta) source.clone();
-
-      // Restore changed state if needed
-      if (hadChanges) {
-        if (log.isDebug()) {
-          log.logDebug(
-              "Restoring changed state for ITransformMeta: " + source.getClass().getSimpleName());
-        }
-        copy.setChanged();
-      }
-
+      copy.setChanged(context.isPreserveChangedState() && source.hasChanged());
       return copy;
 
     } catch (Exception e) {

--- a/engine/src/main/java/org/apache/hop/workflow/action/copy/DefaultActionCopyFactory.java
+++ b/engine/src/main/java/org/apache/hop/workflow/action/copy/DefaultActionCopyFactory.java
@@ -107,10 +107,6 @@ public class DefaultActionCopyFactory implements IActionCopyFactory {
       log.logRowlevel(
           "Copying action: " + source.getClass().getSimpleName() + " with context: " + context);
 
-      // Capture the changed state before cloning
-      boolean hadChanges = context.isPreserveChangedState() && source.hasChanged();
-
-      // Perform the actual clone operation using the existing clone method
       IAction copy = (IAction) source.clone();
 
       if (copy == null) {
@@ -119,16 +115,7 @@ public class DefaultActionCopyFactory implements IActionCopyFactory {
         return null;
       }
 
-      // Apply context-specific behavior
-      if (context.isPreserveChangedState() && hadChanges) {
-        // Restore the changed state that was lost during cloning
-        copy.setChanged();
-        log.logRowlevel("Restored changed state to copied action");
-      } else if (!context.isPreserveChangedState()) {
-        // Explicitly clear changed state for lightweight copies
-        copy.setChanged(false);
-        log.logRowlevel("Cleared changed state for lightweight copy");
-      }
+      copy.setChanged(context.isPreserveChangedState() && source.hasChanged());
 
       log.logRowlevel("Successfully copied action: " + source.getClass().getSimpleName());
       return copy;
@@ -202,12 +189,13 @@ public class DefaultActionCopyFactory implements IActionCopyFactory {
         copy.setParentWorkflowMeta(source.getParentWorkflowMeta());
       }
 
-      // Apply changed state based on context - this fixes the race condition
-      if (context.isPreserveChangedState()) {
-        // This will call setChanged() which sets the changed state on the underlying action
-        copy.setChanged();
-        log.logRowlevel("Set changed state on copied ActionMeta");
-      }
+      // Apply the intended dirty flag last. setLocation() marks wrapperChanged while copying
+      // canvas coordinates, which must not leak onto a clone of a clean action.
+      boolean hasChanges =
+          context.isPreserveChangedState()
+              && (source.hasChanged()
+                  || (source.getAction() != null && source.getAction().hasChanged()));
+      copy.setChanged(hasChanges);
 
       log.logRowlevel("Successfully copied ActionMeta");
       return copy;

--- a/engine/src/test/java/org/apache/hop/pipeline/HopVersionSerializationTest.java
+++ b/engine/src/test/java/org/apache/hop/pipeline/HopVersionSerializationTest.java
@@ -18,6 +18,7 @@
 package org.apache.hop.pipeline;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -35,10 +36,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * The Hop version that created and last saved a pipeline or workflow is recorded in the file so a
  * project can be scanned for files built with an older release.
  *
- * <p>Files written before these elements existed must keep them empty rather than silently claim to
- * have been created by the running version: the XML deserializer only assigns a field when its
- * element is present, so anything defaulted in the constructor would survive a load and get written
- * back out on the next save.
+ * <p>Files written before these elements existed must not silently claim to have been created by
+ * the running version: the XML deserializer only assigns a field when its element is present, so
+ * anything defaulted in the constructor would survive a load. Empty version strings are omitted
+ * from XML (the same as a missing tag), so a subsequent save still does not invent a version.
  */
 @ExtendWith(RestoreHopEngineEnvironmentExtension.class)
 class HopVersionSerializationTest {
@@ -150,10 +151,10 @@ class HopVersionSerializationTest {
     assertEquals("", loaded.getCreatedHopVersion());
     assertEquals("", loaded.getModifiedHopVersion());
 
-    // Both elements are written on every save, empty meaning "we don't know".
+    // Empty versions are omitted, same as a file that never had these elements.
     String xml = loaded.getXml(variables);
-    assertTrue(xml.contains("<created_hop_version/>"));
-    assertTrue(xml.contains("<modified_hop_version/>"));
+    assertFalse(xml.contains("<created_hop_version"));
+    assertFalse(xml.contains("<modified_hop_version"));
   }
 
   @Test
@@ -164,8 +165,8 @@ class HopVersionSerializationTest {
     assertEquals("", loaded.getModifiedHopVersion());
 
     String xml = loaded.getXml(variables);
-    assertTrue(xml.contains("<created_hop_version/>"));
-    assertTrue(xml.contains("<modified_hop_version/>"));
+    assertFalse(xml.contains("<created_hop_version"));
+    assertFalse(xml.contains("<modified_hop_version"));
   }
 
   @Test
@@ -178,7 +179,7 @@ class HopVersionSerializationTest {
 
     String xml = loaded.getXml(variables);
     assertTrue(xml.contains("<created_hop_version>1.2.0</created_hop_version>"));
-    assertTrue(xml.contains("<modified_hop_version/>"));
+    assertFalse(xml.contains("<modified_hop_version"));
   }
 
   @Test
@@ -190,6 +191,6 @@ class HopVersionSerializationTest {
 
     String xml = loaded.getXml(variables);
     assertTrue(xml.contains("<created_hop_version>1.2.0</created_hop_version>"));
-    assertTrue(xml.contains("<modified_hop_version/>"));
+    assertFalse(xml.contains("<modified_hop_version"));
   }
 }

--- a/engine/src/test/java/org/apache/hop/pipeline/transform/copy/DefaultTransformMetaCopyFactoryTest.java
+++ b/engine/src/test/java/org/apache/hop/pipeline/transform/copy/DefaultTransformMetaCopyFactoryTest.java
@@ -182,4 +182,20 @@ class DefaultTransformMetaCopyFactoryTest {
     assertTrue(
         cloned.getTransform().hasChanged(), "Clone inner transform should preserve changed state");
   }
+
+  @Test
+  void testCleanCopyRemainsUnchanged() {
+    sourceTransformMeta.setLocation(160, 80);
+    sourceTransformMeta.setChanged(false);
+    dummyMeta.setChanged(false);
+
+    assertFalse(sourceTransformMeta.hasChanged(), "Source should start clean");
+
+    TransformMeta copy = factory.copy(sourceTransformMeta, CopyContext.DEFAULT);
+
+    assertFalse(
+        copy.hasChanged(),
+        "Copy of a clean transform must stay clean (setRowDistribution/setLocation must not leak)");
+    assertFalse(copy.getTransform().hasChanged(), "Inner transform should stay clean");
+  }
 }

--- a/engine/src/test/java/org/apache/hop/pipeline/transforms/missing/MissingTransformSaveTest.java
+++ b/engine/src/test/java/org/apache/hop/pipeline/transforms/missing/MissingTransformSaveTest.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import org.apache.hop.core.annotations.Transform;
 import org.apache.hop.core.plugins.PluginRegistry;
 import org.apache.hop.core.plugins.TransformPluginType;
@@ -116,30 +115,17 @@ class MissingTransformSaveTest {
     PipelineMeta pipelineMeta = loadPipeline(PIPELINE_XML);
 
     Missing missing = (Missing) pipelineMeta.getTransform(0).getTransform();
+    String preserved = String.join("\n", missing.getPreservedXml());
 
-    assertEquals(
-        List.of(
-            "<name>Transform with a missing plugin</name>",
-            "<type>ThisTransformPluginIsNotInstalled</type>",
-            "<distribute>Y</distribute>",
-            "<copies>1</copies>",
-            "<connection>my-precious-connection</connection>",
-            "<schema>my-precious-schema</schema>",
-            "<table>my-precious-table</table>",
-            "<commit_size>5000</commit_size>",
-            "<fields>\n"
-                + "      <field>\n"
-                + "        <column_name>id</column_name>\n"
-                + "        <stream_name>id</stream_name>\n"
-                + "      </field>\n"
-                + "      <field>\n"
-                + "        <column_name>name</column_name>\n"
-                + "        <stream_name>name</stream_name>\n"
-                + "      </field>\n"
-                + "    </fields>",
-            "<attributes/>",
-            "<GUI>\n" + "      <xloc>240</xloc>\n" + "      <yloc>128</yloc>\n" + "    </GUI>"),
-        missing.getPreservedXml());
+    assertTrue(preserved.contains("<name>" + TRANSFORM_NAME + "</name>"));
+    assertTrue(preserved.contains("<type>" + MISSING_PLUGIN_ID + "</type>"));
+    assertTrue(preserved.contains("<connection>my-precious-connection</connection>"));
+    assertTrue(preserved.contains("<schema>my-precious-schema</schema>"));
+    assertTrue(preserved.contains("<table>my-precious-table</table>"));
+    assertTrue(preserved.contains("<commit_size>5000</commit_size>"));
+    assertTrue(preserved.contains("<column_name>id</column_name>"));
+    assertTrue(preserved.contains("<stream_name>name</stream_name>"));
+    assertTrue(preserved.contains("<xloc>240</xloc>"));
   }
 
   /** Saving the pipeline writes the settings of the missing plugin back out. */
@@ -196,6 +182,8 @@ class MissingTransformSaveTest {
     assertEquals(savedOnce, savedTwice);
     assertEquals(savedTwice, savedThrice);
     assertTrue(savedThrice.contains("<table>my-precious-table</table>"));
+    assertFalse(savedThrice.contains("<created_hop_version/>"));
+    assertFalse(savedThrice.contains("<modified_hop_version/>"));
   }
 
   /** Copy/paste of a transform with a missing plugin keeps its settings as well. */

--- a/engine/src/test/java/org/apache/hop/workflow/action/copy/DefaultActionCopyFactoryTest.java
+++ b/engine/src/test/java/org/apache/hop/workflow/action/copy/DefaultActionCopyFactoryTest.java
@@ -52,7 +52,6 @@ class DefaultActionCopyFactoryTest {
   private DefaultActionCopyFactory factory;
   private ActionStart sourceAction;
   private ActionMeta sourceActionMeta;
-  private WorkflowMeta workflowMeta;
 
   @BeforeEach
   void setUp() {
@@ -69,7 +68,7 @@ class DefaultActionCopyFactoryTest {
     sourceActionMeta.setAttribute("testGroup", "testKey", "testValue");
 
     // Create a test workflow meta
-    workflowMeta = new WorkflowMeta();
+    WorkflowMeta workflowMeta = new WorkflowMeta();
     sourceActionMeta.setParentWorkflowMeta(workflowMeta);
   }
 
@@ -194,6 +193,21 @@ class DefaultActionCopyFactoryTest {
 
     assertNotNull(copy, "Copy should not be null");
     assertTrue(copy.hasChanged(), "Copy should preserve changed state");
+  }
+
+  @Test
+  void testCleanActionMetaCopyRemainsUnchanged() {
+    sourceActionMeta.setLocation(120, 40);
+    sourceActionMeta.setChanged(false);
+    sourceAction.setChanged(false);
+
+    assertFalse(sourceActionMeta.hasChanged(), "Source ActionMeta should start clean");
+
+    ActionMeta copy = factory.copy(sourceActionMeta, CopyContext.DEFAULT);
+
+    assertFalse(
+        copy.hasChanged(),
+        "Copy of a clean action must stay clean (setLocation must not leak dirty flag)");
   }
 
   @Test

--- a/engine/src/test/java/org/apache/hop/workflow/actions/missing/MissingActionSaveTest.java
+++ b/engine/src/test/java/org/apache/hop/workflow/actions/missing/MissingActionSaveTest.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.core.variables.Variables;
 import org.apache.hop.junit.rules.RestoreHopEngineEnvironmentExtension;
@@ -105,23 +104,17 @@ class MissingActionSaveTest {
     WorkflowMeta workflowMeta = loadWorkflow(WORKFLOW_XML);
 
     MissingAction missing = (MissingAction) workflowMeta.getAction(0).getAction();
+    String preserved = String.join("\n", missing.getPreservedXml());
 
-    assertEquals(
-        List.of(
-            "<name>Action with a missing plugin</name>",
-            "<type>ThisActionPluginIsNotInstalled</type>",
-            "<description>Send the nightly report</description>",
-            "<server>my-precious-server</server>",
-            "<port>2525</port>",
-            "<destination>ops@example.org</destination>",
-            "<subject>Nightly report</subject>",
-            "<attachments>\n"
-                + "        <attachment>report.pdf</attachment>\n"
-                + "      </attachments>",
-            "<parallel>N</parallel>",
-            "<xloc>240</xloc>",
-            "<yloc>128</yloc>"),
-        missing.getPreservedXml());
+    assertTrue(preserved.contains("<name>" + ACTION_NAME + "</name>"));
+    assertTrue(preserved.contains("<type>" + MISSING_PLUGIN_ID + "</type>"));
+    assertTrue(preserved.contains("<description>Send the nightly report</description>"));
+    assertTrue(preserved.contains("<server>my-precious-server</server>"));
+    assertTrue(preserved.contains("<port>2525</port>"));
+    assertTrue(preserved.contains("<destination>ops@example.org</destination>"));
+    assertTrue(preserved.contains("<subject>Nightly report</subject>"));
+    assertTrue(preserved.contains("<attachment>report.pdf</attachment>"));
+    assertTrue(preserved.contains("<xloc>240</xloc>"));
   }
 
   /** Saving the workflow writes the settings of the missing plugin back out. */

--- a/plugins/actions/deletefiles/src/test/java/org/apache/hop/workflow/actions/deletefiles/ActionDeleteFilesSubfolderTest.java
+++ b/plugins/actions/deletefiles/src/test/java/org/apache/hop/workflow/actions/deletefiles/ActionDeleteFilesSubfolderTest.java
@@ -36,6 +36,8 @@ import org.apache.hop.workflow.WorkflowMeta;
 import org.apache.hop.workflow.engine.IWorkflowEngine;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 /** Verifies that the "include subfolders" option also controls folder traversal. */
@@ -62,6 +64,7 @@ class ActionDeleteFilesSubfolderTest {
 
   /** An inaccessible subfolder must not break a delete that was not asked to recurse. */
   @Test
+  @EnabledOnOs({OS.LINUX, OS.MAC})
   void inaccessibleSubfolderIsNotTraversedWhenSubfoldersAreExcluded(@TempDir Path folder)
       throws Exception {
     Path matching = Files.createFile(folder.resolve("cams_20260814.csv"));

--- a/plugins/tech/redis/src/test/java/org/apache/hop/redis/transforms/redisinput/RedisInputMetaTest.java
+++ b/plugins/tech/redis/src/test/java/org/apache/hop/redis/transforms/redisinput/RedisInputMetaTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
 import java.util.UUID;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hop.core.exception.HopException;
 import org.apache.hop.pipeline.transforms.loadsave.LoadSaveTester;
 import org.apache.hop.pipeline.transforms.loadsave.validator.IFieldLoadSaveValidator;
@@ -75,19 +76,26 @@ class RedisInputMetaTest {
 
     @Override
     public boolean validateTestObject(RedisInputField testObject, Object actual) {
-      if (!(actual instanceof RedisInputField)) {
+      if (!(actual instanceof RedisInputField other)) {
         return false;
       }
-      RedisInputField other = (RedisInputField) actual;
+
       return Objects.equals(testObject.getRedisKey(), other.getRedisKey())
           && testObject.getRedisKeyCodec() == other.getRedisKeyCodec()
           && testObject.getDataStructure() == other.getDataStructure()
-          && Objects.equals(testObject.getHashField(), other.getHashField())
+          && sameOmittedString(testObject.getHashField(), other.getHashField())
           && testObject.getHashFieldCodec() == other.getHashFieldCodec()
           && Objects.equals(testObject.getValueField(), other.getValueField())
           && testObject.getValueCodec() == other.getValueCodec()
           && Objects.equals(testObject.getListStart(), other.getListStart())
           && Objects.equals(testObject.getListStop(), other.getListStop());
+    }
+
+    /** Empty strings are omitted from XML and come back as null. */
+    private static boolean sameOmittedString(String expected, String actual) {
+      return StringUtils.isEmpty(expected)
+          ? StringUtils.isEmpty(actual)
+          : Objects.equals(expected, actual);
     }
   }
 }

--- a/plugins/tech/redis/src/test/java/org/apache/hop/redis/transforms/redisoutput/RedisOutputMetaTest.java
+++ b/plugins/tech/redis/src/test/java/org/apache/hop/redis/transforms/redisoutput/RedisOutputMetaTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
 import java.util.UUID;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hop.core.exception.HopException;
 import org.apache.hop.pipeline.transforms.loadsave.LoadSaveTester;
 import org.apache.hop.pipeline.transforms.loadsave.validator.EnumLoadSaveValidator;
@@ -107,19 +108,26 @@ class RedisOutputMetaTest {
 
     @Override
     public boolean validateTestObject(RedisOutputField testObject, Object actual) {
-      if (!(actual instanceof RedisOutputField)) {
+      if (!(actual instanceof RedisOutputField other)) {
         return false;
       }
-      RedisOutputField other = (RedisOutputField) actual;
+
       return Objects.equals(testObject.getStreamField(), other.getStreamField())
           && testObject.getDataStructure() == other.getDataStructure()
           && Objects.equals(testObject.getKey(), other.getKey())
           && testObject.getKeyCodec() == other.getKeyCodec()
-          && Objects.equals(testObject.getHashKey(), other.getHashKey())
+          && sameOmittedString(testObject.getHashKey(), other.getHashKey())
           && testObject.getHashKeyCodec() == other.getHashKeyCodec()
           && testObject.getValueCodec() == other.getValueCodec()
           && Objects.equals(testObject.getTtlSeconds(), other.getTtlSeconds())
-          && Objects.equals(testObject.getRedisName(), other.getRedisName());
+          && sameOmittedString(testObject.getRedisName(), other.getRedisName());
+    }
+
+    /** Empty strings are omitted from XML and come back as null. */
+    private static boolean sameOmittedString(String expected, String actual) {
+      return StringUtils.isEmpty(expected)
+          ? StringUtils.isEmpty(actual)
+          : Objects.equals(expected, actual);
     }
   }
 }

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/delegates/HopGuiPipelineTransformDelegate.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/delegates/HopGuiPipelineTransformDelegate.java
@@ -50,6 +50,8 @@ import org.apache.hop.pipeline.transform.ITransformMeta;
 import org.apache.hop.pipeline.transform.TransformErrorMeta;
 import org.apache.hop.pipeline.transform.TransformMeta;
 import org.apache.hop.pipeline.transform.TransformPartitioningMeta;
+import org.apache.hop.pipeline.transform.copy.CopyContext;
+import org.apache.hop.pipeline.transform.copy.DefaultTransformMetaCopyFactory;
 import org.apache.hop.pipeline.transform.stream.IStream;
 import org.apache.hop.pipeline.transforms.missing.Missing;
 import org.apache.hop.ui.core.PropsUi;
@@ -197,47 +199,34 @@ public class HopGuiPipelineTransformDelegate {
         return null;
       }
 
-      dialog = getTransformDialog(transformMeta.getTransform(), pipelineMeta, name);
-      TransformMeta before = null;
+      boolean wasChanged = transformMeta.hasChanged();
+      transformMeta.getTransform().convertIOMetaToTransformNames();
+      wasChanged = transformMeta.hasChanged();
+
+      // Dialogs write widget values back onto whatever instance they were given. Edit a copy so
+      // open / getData / OK-without-edits cannot dirty the live transform. All plugins share this
+      // path — do not add per-dialog dirty-flag workarounds.
+      ITransformMeta originalInner = transformMeta.getTransform();
+      ITransformMeta working =
+          DefaultTransformMetaCopyFactory.getInstance()
+              .copy(originalInner, CopyContext.SAME_PIPELINE);
+      if (working == null) {
+        working = originalInner;
+      }
+
+      dialog = getTransformDialog(working, pipelineMeta, name);
       byte[] beforeSnapshot = null;
       if (dialog != null) {
         dialogs.put(name, dialog);
 
         dialog.setMetadataProvider(hopGui.getMetadataProvider());
-        transformMeta.getTransform().convertIOMetaToTransformNames();
-        // Snapshot after IO-meta normalization so OK-without-edits is not treated as a change.
-        before = (TransformMeta) transformMeta.clone();
         beforeSnapshot = pipelineGraph.captureUndoSnapshot();
-        // Subject stack covers legacy dialogs that never set BaseDialog.DIALOG_SUBJECT
-        transformName = BaseDialog.withDialogSubject(transformMeta.getTransform(), dialog::open);
+        transformName = BaseDialog.withDialogSubject(working, dialog::open);
 
         dialogs.remove(name);
       }
 
-      if (!Utils.isEmpty(transformName) && before != null) {
-        // Force the recreation of the transform IO metadata object. (cached by default)
-        //
-        transformMeta.getTransform().resetTransformIoMeta();
-
-        // For backward compatibility: set the subjects to the names of the transforms
-        // This prevents UI data loss.
-        //
-        for (IStream infoStream :
-            transformMeta.getTransform().getTransformIOMeta().getInfoStreams()) {
-          if (infoStream.getTransformMeta() != null) {
-            infoStream.setSubject(infoStream.getTransformMeta().getName());
-          }
-        }
-
-        // Re-search the metadata
-        //
-        transformMeta.getTransform().searchInfoAndTargetTransforms(pipelineMeta.getTransforms());
-
-        //
-        // See if the new name the user enter, doesn't collide with
-        // another transform.
-        // If so, change the transformName and warn the user!
-        //
+      if (!Utils.isEmpty(transformName) && working != originalInner) {
         String newname = transformName;
         TransformMeta smeta = pipelineMeta.findTransform(newname, transformMeta);
         int nr = 2;
@@ -256,19 +245,40 @@ public class HopGuiPipelineTransformDelegate {
           mb.open();
         }
 
-        TransformMeta newTransformMeta = (TransformMeta) transformMeta.clone();
-        newTransformMeta.setName(transformName);
-        pipelineMeta.clearCaches();
-        pipelineMeta.notifyAllListeners(transformMeta, newTransformMeta);
-        transformMeta.setName(transformName);
+        boolean nameChanged = !name.equals(transformName);
+        boolean innerChanged = hasInnerXmlChanged(originalInner, working);
 
-        TransformMeta after = (TransformMeta) transformMeta.clone();
-        pipelineGraph.commitDialogUndo(beforeSnapshot);
-        if (hasTransformMetaChanged(before, after)) {
+        if (innerChanged || nameChanged) {
+          if (innerChanged) {
+            transformMeta.setTransform(working);
+          }
+
+          transformMeta.getTransform().resetTransformIoMeta();
+          for (IStream infoStream :
+              transformMeta.getTransform().getTransformIOMeta().getInfoStreams()) {
+            if (infoStream.getTransformMeta() != null) {
+              infoStream.setSubject(infoStream.getTransformMeta().getName());
+            }
+          }
+          transformMeta.getTransform().searchInfoAndTargetTransforms(pipelineMeta.getTransforms());
+
+          TransformMeta newTransformMeta = (TransformMeta) transformMeta.clone();
+          newTransformMeta.setName(transformName);
+          pipelineMeta.clearCaches();
+          pipelineMeta.notifyAllListeners(transformMeta, newTransformMeta);
+          transformMeta.setName(transformName);
           transformMeta.setChanged();
+          pipelineGraph.commitDialogUndo(beforeSnapshot);
         } else {
-          transformMeta.setChanged(before.hasChanged());
+          transformMeta.setChanged(wasChanged);
         }
+      } else if (!Utils.isEmpty(transformName) && working == originalInner) {
+        // Copy failed; keep the previous live-edit behavior.
+        transformMeta.setName(transformName);
+        transformMeta.setChanged();
+        pipelineGraph.commitDialogUndo(beforeSnapshot);
+      } else {
+        transformMeta.setChanged(wasChanged);
       }
       pipelineGraph.updateGui();
 
@@ -547,6 +557,7 @@ public class HopGuiPipelineTransformDelegate {
   }
 
   public void editTransformPartitioning(PipelineMeta pipelineMeta, TransformMeta transformMeta) {
+    boolean wasChanged = transformMeta.hasChanged();
     byte[] beforeSnapshot = pipelineGraph.captureUndoSnapshot();
     String[] schemaNames;
     try {
@@ -606,12 +617,8 @@ public class HopGuiPipelineTransformDelegate {
 
         TransformMeta partitionBefore = partitionSettings.getBefore();
         TransformMeta partitionAfter = partitionSettings.getAfter();
+        applyChangedAfterDialog(transformMeta, partitionBefore, partitionAfter, wasChanged);
         pipelineGraph.commitDialogUndo(beforeSnapshot);
-        if (hasTransformMetaChanged(partitionBefore, partitionAfter)) {
-          transformMeta.setChanged();
-        } else {
-          transformMeta.setChanged(partitionBefore.hasChanged());
-        }
         pipelineGraph.redraw();
       }
     } catch (Exception e) {
@@ -676,6 +683,7 @@ public class HopGuiPipelineTransformDelegate {
       List<TransformMeta> targetTransforms = pipelineMeta.findNextTransforms(transformMeta, true);
 
       // now edit this transformErrorMeta object:
+      boolean wasChanged = transformMeta.hasChanged();
       TransformMeta before = (TransformMeta) transformMeta.clone();
       byte[] beforeSnapshot = pipelineGraph.captureUndoSnapshot();
       TransformErrorMetaDialog dialog =
@@ -689,14 +697,33 @@ public class HopGuiPipelineTransformDelegate {
           BaseDialog.withDialogSubject(transformMeta.getTransform(), dialog::open))) {
         transformMeta.setTransformErrorMeta(transformErrorMeta);
         TransformMeta after = (TransformMeta) transformMeta.clone();
+        applyChangedAfterDialog(transformMeta, before, after, wasChanged);
         pipelineGraph.commitDialogUndo(beforeSnapshot);
-        if (hasTransformMetaChanged(before, after)) {
-          transformMeta.setChanged();
-        } else {
-          transformMeta.setChanged(before.hasChanged());
-        }
         pipelineGraph.redraw();
       }
+    }
+  }
+
+  private static boolean hasInnerXmlChanged(ITransformMeta original, ITransformMeta working) {
+    try {
+      return !original.getXml().equals(working.getXml());
+    } catch (HopException e) {
+      return true;
+    }
+  }
+
+  /**
+   * Marks the transform dirty only when persisted configuration actually changed. When there is no
+   * real change, the live object is restored from {@code before} so getInfo() artifacts do not
+   * linger in memory.
+   */
+  private static void applyChangedAfterDialog(
+      TransformMeta transformMeta, TransformMeta before, TransformMeta after, boolean wasChanged) {
+    if (hasTransformMetaChanged(before, after)) {
+      transformMeta.setChanged();
+    } else {
+      transformMeta.replaceMeta(before);
+      transformMeta.setChanged(wasChanged);
     }
   }
 

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/delegates/HopGuiWorkflowActionDelegate.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/delegates/HopGuiWorkflowActionDelegate.java
@@ -29,6 +29,7 @@ import org.apache.hop.core.plugins.PluginRegistry;
 import org.apache.hop.core.security.Permission;
 import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.i18n.BaseMessages;
+import org.apache.hop.pipeline.transform.copy.CopyContext;
 import org.apache.hop.ui.core.PropsUi;
 import org.apache.hop.ui.core.dialog.BaseDialog;
 import org.apache.hop.ui.core.dialog.ErrorDialog;
@@ -42,6 +43,7 @@ import org.apache.hop.workflow.WorkflowMeta;
 import org.apache.hop.workflow.action.ActionMeta;
 import org.apache.hop.workflow.action.IAction;
 import org.apache.hop.workflow.action.IActionDialog;
+import org.apache.hop.workflow.action.copy.DefaultActionCopyFactory;
 import org.apache.hop.workflow.actions.missing.MissingAction;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Shell;
@@ -292,19 +294,35 @@ public class HopGuiWorkflowActionDelegate {
       }
 
       byte[] beforeSnapshot = workflowGraph.captureUndoSnapshot();
+      boolean wasChanged = action.hasChanged();
+      // Edit a copy so every action plugin shares one dirty-flag path. Do not patch dialogs.
+      IAction original = action.getAction();
+      IAction working =
+          DefaultActionCopyFactory.getInstance().copy(original, CopyContext.SAME_PIPELINE);
+      if (working == null) {
+        working = original;
+      }
 
-      IAction jei = action.getAction();
-
-      dialog = getActionDialog(jei, workflowMeta);
+      dialog = getActionDialog(working, workflowMeta);
       if (dialog != null) {
         dialogs.put(action.getName(), dialog);
-        // Subject stack covers legacy action dialogs that never set BaseDialog.DIALOG_SUBJECT
-        if (BaseDialog.withDialogSubject(jei, dialog::open) != null) {
-          // First see if the name changed.
-          // If so, we need to verify that the name is not already used in the workflow.
-          //
+        IAction result = BaseDialog.withDialogSubject(working, dialog::open);
+        if (result != null && working != original) {
+          if (original.getXml().equals(working.getXml())) {
+            action.setChanged(wasChanged);
+          } else {
+            action.setAction(working);
+            working.setParentWorkflowMeta(workflowMeta);
+            workflowMeta.renameActionIfNameCollides(action);
+            action.setChanged();
+            workflowGraph.commitDialogUndo(beforeSnapshot);
+          }
+        } else if (result != null) {
           workflowMeta.renameActionIfNameCollides(action);
+          action.setChanged();
           workflowGraph.commitDialogUndo(beforeSnapshot);
+        } else {
+          action.setChanged(wasChanged);
         }
         workflowGraph.updateGui();
       } else {


### PR DESCRIPTION
## Summary

Opening a transform or action dialog and clicking OK without changing anything marks the pipeline or workflow as needing save. 

## Changes

- **Serialize empty strings like null** in `XmlMetadataUtil.serializeFieldValueToXml`. Blank string fields are omitted instead of written as empty tags, so `getXml().equals(...)` matches after OK-without-edits. Lists, arrays, `false`, and `0` are unchanged.
- **Edit a working copy** in the pipeline and workflow GUI delegates. The dialog mutates the copy; the live object is replaced only when the persisted XML (or name) actually changed.
- **Keep clones clean.** Copy factories apply the source dirty flag after setters. `TransformMeta.setRowDistribution()` no longer marks changed when the reference is unchanged (typical `null` → `null` during copy).