### PR TITLE
Issue apache#2362 Evaluate JsonPath functions in the JSON Input transform

### DIFF
--- a/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/jsoninput.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/pipeline/transforms/jsoninput.adoc
@@ -180,6 +180,14 @@ You can use Regex in the Path expression.
 
 *Example Path to filter on those that start with the letter 'a':* $.data[?(@=~/a.*/i)]
 
+*JsonPath functions*
+
+The aggregation functions provided by JayWay can be used at the end of a Path expression, e.g. `length()` (or its alias `size()`), `sum()`, `avg()`, `min()`, `max()`, `stddev()`, `keys()`, `first()`, `last()` and `index()`.
+
+*Example Path to retrieve the number of elements of an array:* $.someArray.length()
+
+A function always produces a single value, and therefore a single output row. Combining a function field with a field whose Path matches several elements is not supported: the transform reports a structure error because the two Paths do not yield the same number of rows. Read such a value in a dedicated JSON Input transform when the other fields return multiple rows.
+
 
 === Additional output fields tab
 

--- a/integration-tests/json/0015-json-input-jsonpath-functions.hpl
+++ b/integration-tests/json/0015-json-input-jsonpath-functions.hpl
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<pipeline>
+  <info>
+    <name>0015-json-input-jsonpath-functions</name>
+    <name_sync_with_filename>Y</name_sync_with_filename>
+    <description>Verifies that JsonPath functions (length(), sum(), max()) are evaluated by the JSON Input transform</description>
+    <extended_description/>
+    <pipeline_version/>
+    <pipeline_type>Normal</pipeline_type>
+    <parameters>
+    </parameters>
+    <capture_transform_performance>N</capture_transform_performance>
+    <transform_performance_capturing_delay>1000</transform_performance_capturing_delay>
+    <transform_performance_capturing_size_limit>100</transform_performance_capturing_size_limit>
+    <created_user>-</created_user>
+    <created_date>2026/09/01 09:00:00.000</created_date>
+    <modified_user>-</modified_user>
+    <modified_date>2026/09/01 09:00:00.000</modified_date>
+  </info>
+  <notepads>
+  </notepads>
+  <order>
+    <hop>
+      <from>Dummy JSON</from>
+      <to>Get Attributes</to>
+      <enabled>Y</enabled>
+    </hop>
+    <hop>
+      <from>Get Attributes</from>
+      <to>Validate</to>
+      <enabled>Y</enabled>
+    </hop>
+  </order>
+  <transform>
+    <name>Dummy JSON</name>
+    <type>DataGrid</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <data>
+      <line>
+        <item>{"name": "Goku", "moves": [{"moveName": "Kamehameha"}, {"moveName": "Spirit Bomb"}], "powers": [9500, 12000]}</item>
+      </line>
+      <line>
+        <item>{"name": "Vegeta", "moves": [{"moveName": "Galick Gun"}], "powers": [9000]}</item>
+      </line>
+      <line>
+        <item>{"name": "Gohan", "moves": [{"moveName": "Masenko"}, {"moveName": "Father-Son Kamehameha"}, {"moveName": "Ki Blast"}], "powers": [8500, 11000, 3000]}</item>
+      </line>
+    </data>
+    <fields>
+      <field>
+        <length>-1</length>
+        <precision>-1</precision>
+        <set_empty_string>N</set_empty_string>
+        <name>z_fighter</name>
+        <type>JSON</type>
+      </field>
+    </fields>
+    <attributes/>
+    <GUI>
+      <xloc>192</xloc>
+      <yloc>128</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>Get Attributes</name>
+    <type>JsonInput</type>
+    <description/>
+    <distribute>N</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <include>N</include>
+    <include_field/>
+    <rownum>N</rownum>
+    <addresultfile>N</addresultfile>
+    <readurl>N</readurl>
+    <removeSourceField>Y</removeSourceField>
+    <IsIgnoreEmptyFile>N</IsIgnoreEmptyFile>
+    <doNotFailIfNoFile>Y</doNotFailIfNoFile>
+    <ignoreMissingPath>N</ignoreMissingPath>
+    <defaultPathLeafToNull>Y</defaultPathLeafToNull>
+    <rownum_field/>
+    <file>
+      <name/>
+      <filemask/>
+      <exclude_filemask/>
+      <file_required>N</file_required>
+      <include_subfolders>N</include_subfolders>
+    </file>
+    <fields>
+      <field>
+        <name>name</name>
+        <path>$.name</path>
+        <type>String</type>
+        <format/>
+        <currency/>
+        <decimal/>
+        <group/>
+        <length>-1</length>
+        <precision>-1</precision>
+        <trim_type>none</trim_type>
+        <repeat>N</repeat>
+      </field>
+      <field>
+        <name>moveCount</name>
+        <path>$.moves.length()</path>
+        <type>Integer</type>
+        <format/>
+        <currency/>
+        <decimal/>
+        <group/>
+        <length>-1</length>
+        <precision>-1</precision>
+        <trim_type>none</trim_type>
+        <repeat>N</repeat>
+      </field>
+      <field>
+        <name>totalPower</name>
+        <path>$.powers.sum()</path>
+        <type>Number</type>
+        <format/>
+        <currency/>
+        <decimal/>
+        <group/>
+        <length>-1</length>
+        <precision>-1</precision>
+        <trim_type>none</trim_type>
+        <repeat>N</repeat>
+      </field>
+      <field>
+        <name>maxPower</name>
+        <path>$.powers.max()</path>
+        <type>Number</type>
+        <format/>
+        <currency/>
+        <decimal/>
+        <group/>
+        <length>-1</length>
+        <precision>-1</precision>
+        <trim_type>none</trim_type>
+        <repeat>N</repeat>
+      </field>
+    </fields>
+    <limit>0</limit>
+    <IsInFields>Y</IsInFields>
+    <IsAFile>N</IsAFile>
+    <valueField>z_fighter</valueField>
+    <shortFileFieldName/>
+    <pathFieldName/>
+    <hiddenFieldName/>
+    <lastModificationTimeFieldName/>
+    <uriNameFieldName/>
+    <rootUriNameFieldName/>
+    <extensionFieldName/>
+    <sizeFieldName/>
+    <attributes/>
+    <GUI>
+      <xloc>352</xloc>
+      <yloc>128</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>Validate</name>
+    <type>Dummy</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <attributes/>
+    <GUI>
+      <xloc>512</xloc>
+      <yloc>128</yloc>
+    </GUI>
+  </transform>
+  <transform_error_handling>
+  </transform_error_handling>
+  <attributes/>
+</pipeline>

--- a/integration-tests/json/datasets/golden-json-input-jsonpath-functions.csv
+++ b/integration-tests/json/datasets/golden-json-input-jsonpath-functions.csv
@@ -1,0 +1,4 @@
+name,moveCount,totalPower,maxPower
+Goku,2,21500.0,12000.0
+Vegeta,1,9000.0,9000.0
+Gohan,3,22500.0,11000.0

--- a/integration-tests/json/main-0015-json-input-jsonpath-functions.hwf
+++ b/integration-tests/json/main-0015-json-input-jsonpath-functions.hwf
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<workflow>
+  <name>main-0015-json-input-jsonpath-functions</name>
+  <name_sync_with_filename>Y</name_sync_with_filename>
+  <description/>
+  <extended_description/>
+  <workflow_version/>
+  <created_user>-</created_user>
+  <created_date>2026/09/01 09:00:00.000</created_date>
+  <modified_user>-</modified_user>
+  <modified_date>2026/09/01 09:00:00.000</modified_date>
+  <parameters>
+    </parameters>
+  <actions>
+    <action>
+      <name>Start</name>
+      <description/>
+      <type>SPECIAL</type>
+      <attributes/>
+      <DayOfMonth>1</DayOfMonth>
+      <doNotWaitOnFirstExecution>N</doNotWaitOnFirstExecution>
+      <hour>12</hour>
+      <intervalMinutes>60</intervalMinutes>
+      <intervalSeconds>0</intervalSeconds>
+      <minutes>0</minutes>
+      <repeat>N</repeat>
+      <schedulerType>0</schedulerType>
+      <weekDay>1</weekDay>
+      <parallel>N</parallel>
+      <xloc>50</xloc>
+      <yloc>50</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>Run Pipeline Unit Tests</name>
+      <description/>
+      <type>RunPipelineTests</type>
+      <attributes/>
+      <test_names>
+        <test_name>
+          <name>0015-json-input-jsonpath-functions UNIT</name>
+        </test_name>
+      </test_names>
+      <parallel>N</parallel>
+      <xloc>256</xloc>
+      <yloc>48</yloc>
+      <attributes_hac/>
+    </action>
+  </actions>
+  <hops>
+    <hop>
+      <from>Start</from>
+      <to>Run Pipeline Unit Tests</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>Y</unconditional>
+    </hop>
+  </hops>
+  <notepads>
+  </notepads>
+  <attributes/>
+</workflow>

--- a/integration-tests/json/metadata/dataset/golden-json-input-jsonpath-functions.json
+++ b/integration-tests/json/metadata/dataset/golden-json-input-jsonpath-functions.json
@@ -1,0 +1,41 @@
+{
+  "base_filename": "golden-json-input-jsonpath-functions.csv",
+  "virtualPath": "",
+  "name": "golden-json-input-jsonpath-functions",
+  "description": "",
+  "dataset_fields": [
+    {
+      "field_comment": "",
+      "field_length": -1,
+      "field_type": 2,
+      "field_precision": -1,
+      "field_name": "name",
+      "field_format": ""
+    },
+    {
+      "field_comment": "",
+      "field_length": -1,
+      "field_type": 5,
+      "field_precision": -1,
+      "field_name": "moveCount",
+      "field_format": ""
+    },
+    {
+      "field_comment": "",
+      "field_length": -1,
+      "field_type": 1,
+      "field_precision": -1,
+      "field_name": "totalPower",
+      "field_format": ""
+    },
+    {
+      "field_comment": "",
+      "field_length": -1,
+      "field_type": 1,
+      "field_precision": -1,
+      "field_name": "maxPower",
+      "field_format": ""
+    }
+  ],
+  "folder_name": "${HOP_DATASETS_FOLDER}"
+}

--- a/integration-tests/json/metadata/unit-test/0015-json-input-jsonpath-functions UNIT.json
+++ b/integration-tests/json/metadata/unit-test/0015-json-input-jsonpath-functions UNIT.json
@@ -1,0 +1,43 @@
+{
+  "database_replacements": [],
+  "autoOpening": true,
+  "description": "",
+  "persist_filename": "",
+  "test_type": "UNIT_TEST",
+  "variableValues": [],
+  "basePath": "",
+  "golden_data_sets": [
+    {
+      "field_mappings": [
+        {
+          "transform_field": "name",
+          "data_set_field": "name"
+        },
+        {
+          "transform_field": "moveCount",
+          "data_set_field": "moveCount"
+        },
+        {
+          "transform_field": "totalPower",
+          "data_set_field": "totalPower"
+        },
+        {
+          "transform_field": "maxPower",
+          "data_set_field": "maxPower"
+        }
+      ],
+      "field_order": [
+        "name",
+        "moveCount",
+        "totalPower",
+        "maxPower"
+      ],
+      "data_set_name": "golden-json-input-jsonpath-functions",
+      "transform_name": "Validate"
+    }
+  ],
+  "input_data_sets": [],
+  "name": "0015-json-input-jsonpath-functions UNIT",
+  "trans_test_tweaks": [],
+  "pipeline_filename": "./0015-json-input-jsonpath-functions.hpl"
+}

--- a/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsoninput/reader/FastJsonReader.java
+++ b/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsoninput/reader/FastJsonReader.java
@@ -29,6 +29,7 @@ import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import java.io.InputStream;
 import java.util.AbstractList;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.RandomAccess;
@@ -299,7 +300,7 @@ public class FastJsonReader implements IJsonReader {
     int i = 0;
     for (JsonPath path : paths) {
       Object raw = getReadContext().read(path);
-      List<Object> result = normalizeJsonPathResult(raw);
+      List<Object> result = raw == null ? readFunctionPath(path) : normalizeJsonPathResult(raw);
       if (result.size() != lastSize && lastSize > 0 && !result.isEmpty()) {
         throw new JsonInputException(
             BaseMessages.getString(
@@ -320,6 +321,27 @@ public class FastJsonReader implements IJsonReader {
       i++;
     }
     return results;
+  }
+
+  /**
+   * JsonPath never evaluates a function path (length(), sum(), keys(), ...) while
+   * ALWAYS_RETURN_LIST is set: combined with SUPPRESS_EXCEPTIONS it silently yields null. Such a
+   * path is re-evaluated here without that option, and the scalar it produces is exposed as a
+   * single row.
+   */
+  private List<Object> readFunctionPath(JsonPath path) throws JsonInputException {
+    ReadContext context = getReadContext();
+    EnumSet<Option> options = EnumSet.noneOf(Option.class);
+    options.addAll(context.configuration().getOptions());
+    options.remove(Option.ALWAYS_RETURN_LIST);
+    Configuration functionConfiguration =
+        context.configuration().setOptions(options.toArray(new Option[0]));
+    Object document = context.json();
+    Object value = path.read(document, functionConfiguration);
+    if (value instanceof List<?> || value instanceof ArrayNode) {
+      return normalizeJsonPathResult(value);
+    }
+    return Collections.singletonList(value);
   }
 
   public static boolean isAllNull(Iterable<?> list) {

--- a/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsoninput/reader/FastJsonReader.java
+++ b/plugins/transforms/json/src/main/java/org/apache/hop/pipeline/transforms/jsoninput/reader/FastJsonReader.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.ParseContext;
 import com.jayway.jsonpath.ReadContext;
@@ -323,12 +324,6 @@ public class FastJsonReader implements IJsonReader {
     return results;
   }
 
-  /**
-   * JsonPath never evaluates a function path (length(), sum(), keys(), ...) while
-   * ALWAYS_RETURN_LIST is set: combined with SUPPRESS_EXCEPTIONS it silently yields null. Such a
-   * path is re-evaluated here without that option, and the scalar it produces is exposed as a
-   * single row.
-   */
   private List<Object> readFunctionPath(JsonPath path) throws JsonInputException {
     ReadContext context = getReadContext();
     EnumSet<Option> options = EnumSet.noneOf(Option.class);
@@ -337,7 +332,20 @@ public class FastJsonReader implements IJsonReader {
     Configuration functionConfiguration =
         context.configuration().setOptions(options.toArray(new Option[0]));
     Object document = context.json();
-    Object value = path.read(document, functionConfiguration);
+    Object value;
+    try {
+      value = path.read(document, functionConfiguration);
+    } catch (JsonPathException e) {
+      // A function may still throw where SUPPRESS_EXCEPTIONS cannot help, e.g. an aggregation over
+      // an empty array. Honour the option and let the missing path handling decide what to do.
+      if (!options.contains(Option.SUPPRESS_EXCEPTIONS)) {
+        throw e;
+      }
+      if (log.isDebug()) {
+        log.logDebug(e.getMessage());
+      }
+      value = null;
+    }
     if (value instanceof List<?> || value instanceof ArrayNode) {
       return normalizeJsonPathResult(value);
     }

--- a/plugins/transforms/json/src/test/java/org/apache/hop/pipeline/transforms/jsoninput/reader/FastJsonReaderTest.java
+++ b/plugins/transforms/json/src/test/java/org/apache/hop/pipeline/transforms/jsoninput/reader/FastJsonReaderTest.java
@@ -20,15 +20,20 @@ package org.apache.hop.pipeline.transforms.jsoninput.reader;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.Option;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import org.apache.hop.core.IRowSet;
 import org.apache.hop.core.exception.HopException;
 import org.apache.hop.core.logging.ILogChannel;
 import org.apache.hop.pipeline.transforms.jsoninput.JsonInputField;
@@ -109,5 +114,58 @@ class FastJsonReaderTest {
     mainList.add(l2);
     mainList.add(l3);
     assertEquals(3, FastJsonReader.getMaxRowSize(Collections.singletonList(mainList)));
+  }
+
+  private static final String ARRAY_JSON = "{\"someArray\":[{\"x\":1},{\"x\":2}]}";
+
+  private static IRowSet readString(String json, String path) throws HopException {
+    JsonInputField field = new JsonInputField("value");
+    field.setPath(path);
+    FastJsonReader reader =
+        new FastJsonReader(new JsonInputField[] {field}, mock(ILogChannel.class));
+    return reader.parseStringValue(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
+  }
+
+  @Test
+  void testLengthFunctionPathReturnsNumberOfArrayElements() throws Exception {
+    IRowSet rowSet = readString(ARRAY_JSON, "$.someArray.length()");
+    Object[] row = rowSet.getRow();
+    assertNotNull(row);
+    assertEquals(2, ((Number) row[0]).intValue());
+  }
+
+  @Test
+  void testSumFunctionPathIsEvaluated() throws Exception {
+    IRowSet rowSet = readString("{\"values\":[1,2,4]}", "$.values.sum()");
+    Object[] row = rowSet.getRow();
+    assertNotNull(row);
+    assertEquals(7, ((Number) row[0]).intValue());
+  }
+
+  @Test
+  void testFunctionPathReturnsSingleRow() throws Exception {
+    IRowSet rowSet = readString(ARRAY_JSON, "$.someArray.length()");
+    assertNotNull(rowSet.getRow());
+    assertNull(rowSet.getRow());
+  }
+
+  @Test
+  void testLengthFunctionPathOnJsonNodeInput() throws Exception {
+    JsonInputField field = new JsonInputField("value");
+    field.setPath("$.someArray.length()");
+    FastJsonReader reader =
+        new FastJsonReader(new JsonInputField[] {field}, mock(ILogChannel.class));
+    IRowSet rowSet = reader.parseJsonNodeValue(new ObjectMapper().readTree(ARRAY_JSON));
+    Object[] row = rowSet.getRow();
+    assertNotNull(row);
+    assertEquals(2, ((Number) row[0]).intValue());
+  }
+
+  @Test
+  void testRegularPathStillReturnsOneRowPerMatch() throws Exception {
+    IRowSet rowSet = readString(ARRAY_JSON, "$.someArray[*].x");
+    assertNotNull(rowSet.getRow());
+    assertNotNull(rowSet.getRow());
+    assertNull(rowSet.getRow());
   }
 }

--- a/plugins/transforms/json/src/test/java/org/apache/hop/pipeline/transforms/jsoninput/reader/FastJsonReaderTest.java
+++ b/plugins/transforms/json/src/test/java/org/apache/hop/pipeline/transforms/jsoninput/reader/FastJsonReaderTest.java
@@ -168,4 +168,19 @@ class FastJsonReaderTest {
     assertNotNull(rowSet.getRow());
     assertNull(rowSet.getRow());
   }
+
+  @Test
+  void testFailingFunctionPathIsSuppressedAsNullValue() throws Exception {
+    JsonInputField field = new JsonInputField("value");
+    field.setPath("$.emptyList.sum()");
+    FastJsonReader reader =
+        new FastJsonReader(new JsonInputField[] {field}, mock(ILogChannel.class));
+    reader.setIgnoreMissingPath(true);
+    IRowSet rowSet =
+        reader.parseStringValue(
+            new ByteArrayInputStream("{\"emptyList\":[]}".getBytes(StandardCharsets.UTF_8)));
+    Object[] row = rowSet.getRow();
+    assertNotNull(row);
+    assertNull(row[0]);
+  }
 }


### PR DESCRIPTION
  - JsonPath refuses to evaluate a function path (length(), sum(), keys(), ...)
    while ALWAYS_RETURN_LIST is set and, with SUPPRESS_EXCEPTIONS, returns null
    instead; such a path is now re-evaluated without that option and its scalar
    result exposed as a single row.
  - The null returned in that case reached normalizeJsonPathResult and caused a
    NullPointerException while building the error message; the case is now
    handled before it gets there.
  - Document JsonPath functions in the JSON Input transform page, including the
    single-row constraint.

Fixes #2362 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
