### PR TITLE
Fix label spacing and clear exclude mask on Add "Get file names"

### DIFF
--- a/plugins/transforms/getfilenames/src/main/java/org/apache/hop/pipeline/transforms/getfilenames/GetFileNamesDialog.java
+++ b/plugins/transforms/getfilenames/src/main/java/org/apache/hop/pipeline/transforms/getfilenames/GetFileNamesDialog.java
@@ -114,13 +114,13 @@ public class GetFileNamesDialog extends BaseTransformDialog {
     Label label = new Label(group, SWT.RIGHT);
     label.setText(BaseMessages.getString(PKG, "GetFileNamesDialog.FileField.Label"));
     PropsUi.setLook(label);
-    label.setLayoutData(
-        new FormDataBuilder().left(0, -margin).top(group, margin).right(middle, -margin).result());
+    label.setLayoutData(new FormDataBuilder().left(0, 0).top(0, 0).right(middle, -margin).result());
 
     wFileField = new Button(group, SWT.CHECK);
     PropsUi.setLook(wFileField);
     wFileField.setToolTipText(BaseMessages.getString(PKG, "GetFileNamesDialog.FileField.Tooltip"));
-    wFileField.setLayoutData(new FormDataBuilder().left(middle, -margin).top(0, margin).result());
+    wFileField.setLayoutData(
+        new FormDataBuilder().left(middle, 0).top(label, 0, SWT.CENTER).result());
 
     wFileField.addSelectionListener(
         new SelectionAdapter() {
@@ -168,11 +168,7 @@ public class GetFileNamesDialog extends BaseTransformDialog {
     PropsUi.setLook(wFilenameField);
     wFilenameField.addModifyListener(lsMod);
     wFilenameField.setLayoutData(
-        new FormDataBuilder()
-            .left(middle, -margin)
-            .top(wFileField, margin)
-            .right(100, -margin)
-            .result());
+        new FormDataBuilder().left(middle, 0).top(wFileField, margin).right(100, -margin).result());
 
     // Wildcard field
     Label wlWildcardField = new Label(group, SWT.RIGHT);
@@ -191,7 +187,7 @@ public class GetFileNamesDialog extends BaseTransformDialog {
     wWildcardField.addModifyListener(lsMod);
     wWildcardField.setLayoutData(
         new FormDataBuilder()
-            .left(middle, -margin)
+            .left(middle, 0)
             .top(wFilenameField, margin)
             .right(100, -margin)
             .result());
@@ -214,7 +210,7 @@ public class GetFileNamesDialog extends BaseTransformDialog {
     wExcludeWildcardField.addModifyListener(lsMod);
     wExcludeWildcardField.setLayoutData(
         new FormDataBuilder()
-            .left(middle, -margin)
+            .left(middle, 0)
             .top(wWildcardField, margin)
             .right(100, -margin)
             .result());
@@ -236,10 +232,7 @@ public class GetFileNamesDialog extends BaseTransformDialog {
     wIncludeSubFolder.setToolTipText(
         BaseMessages.getString(PKG, "GetFileNamesDialog.IncludeSubFolder.Tooltip"));
     wIncludeSubFolder.setLayoutData(
-        new FormDataBuilder()
-            .left(middle, -margin)
-            .top(wlIncludeSubFolder, 0, SWT.CENTER)
-            .result());
+        new FormDataBuilder().left(middle, 0).top(wlIncludeSubFolder, 0, SWT.CENTER).result());
 
     wIncludeSubFolder.addSelectionListener(
         new SelectionAdapter() {
@@ -339,6 +332,7 @@ public class GetFileNamesDialog extends BaseTransformDialog {
                 GetFileNamesMeta.RequiredFilesCode[0]);
             wFilename.setText("");
             wFilemask.setText("");
+            wExcludeFilemask.setText("");
             wFilenameList.removeEmptyRows();
             wFilenameList.setRowNums();
             wFilenameList.optWidth(true);
@@ -630,11 +624,7 @@ public class GetFileNamesDialog extends BaseTransformDialog {
     wInclRownum.setToolTipText(
         BaseMessages.getString(PKG, "GetFileNamesDialog.InclRownum.Tooltip"));
     wInclRownum.setLayoutData(
-        new FormDataBuilder()
-            .left(middle, -margin)
-            .top(wlInclRownum, 0, SWT.CENTER)
-            .right(100, -margin)
-            .result());
+        new FormDataBuilder().left(middle, 0).top(wlInclRownum, 0, SWT.CENTER).result());
     wInclRownum.addSelectionListener(
         new SelectionAdapter() {
           @Override
@@ -660,7 +650,7 @@ public class GetFileNamesDialog extends BaseTransformDialog {
     wInclRownumField.addModifyListener(lsMod);
     wInclRownumField.setLayoutData(
         new FormDataBuilder()
-            .left(middle, -margin)
+            .left(middle, 0)
             .top(wInclRownum, margin)
             .right(100, -margin)
             .result());
@@ -695,10 +685,7 @@ public class GetFileNamesDialog extends BaseTransformDialog {
     wDoNotFailIfNoFile.setToolTipText(
         BaseMessages.getString(PKG, "GetFileNamesDialog.DoNotFailIfNoFile.Tooltip"));
     wDoNotFailIfNoFile.setLayoutData(
-        new FormDataBuilder()
-            .left(middle, -margin)
-            .top(wlDoNotFailIfNoFile, 0, SWT.CENTER)
-            .result());
+        new FormDataBuilder().left(middle, 0).top(wlDoNotFailIfNoFile, 0, SWT.CENTER).result());
 
     // Raise an exception if no file?
     wlRaiseAnExceptionIfNoFile = new Label(wNoFilesFolderGroup, SWT.RIGHT);
@@ -718,7 +705,7 @@ public class GetFileNamesDialog extends BaseTransformDialog {
         BaseMessages.getString(PKG, "GetFileNamesDialog.RaiseAnExceptionIfNoFiles.Tooltip"));
     wRaiseAnExceptionIfNoFile.setLayoutData(
         new FormDataBuilder()
-            .left(middle, -margin)
+            .left(middle, 0)
             .top(wlRaiseAnExceptionIfNoFile, 0, SWT.CENTER)
             .result());
     wRaiseAnExceptionIfNoFile.addSelectionListener(


### PR DESCRIPTION
## Summary

- Increase the gap between labels and their controls in the Get file names dialog so checkboxes and text fields are no longer flush against the label (File tab, Filenames from field, Filter tab).
- Clear the exclusion wildcard after Add, the same way filename and inclusion wildcard are already cleared. Edit was copying exclude back into the field, then Add left it populated.
