### PR TITLE
Fix #8233: write the NUL separator as an escape so the sources stay text

### DIFF
--- a/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/metadata/MetadataPerspective.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/perspective/metadata/MetadataPerspective.java
@@ -3158,7 +3158,7 @@ public class MetadataPerspective implements IHopPerspective, TabClosable, IMetad
         // by default. Seed each default-expanded node once per session so the default holds until
         // the user changes it.
         boolean defaultExpanded = "C".equals(path[0]) || "UC".equals(path[0]);
-        if (defaultExpanded && treeStateSeeded.add(String.join(" ", path))) {
+        if (defaultExpanded && treeStateSeeded.add(String.join("\0", path))) {
           TreeMemory.getInstance().storeExpanded(METADATA_PERSPECTIVE_TREE, path, true);
         }
         item.setExpanded(TreeMemory.getInstance().isExpanded(METADATA_PERSPECTIVE_TREE, path));
@@ -3177,7 +3177,7 @@ public class MetadataPerspective implements IHopPerspective, TabClosable, IMetad
     String[] path = treeMemoryPath(item);
     if (path != null) {
       TreeMemory.getInstance().storeExpanded(METADATA_PERSPECTIVE_TREE, path, expanded);
-      treeStateSeeded.add(String.join(" ", path));
+      treeStateSeeded.add(String.join("\0", path));
     }
   }
 

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/search/HopGuiSearchHelper.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/search/HopGuiSearchHelper.java
@@ -458,7 +458,7 @@ public final class HopGuiSearchHelper {
 
   /** A match's user-visible identity within its object: where it is plus what matched. */
   private static String matchIdentity(ISearchResult result) {
-    return Const.NVL(result.getComponent(), "") + " " + Const.NVL(result.getMatchingString(), "");
+    return Const.NVL(result.getComponent(), "") + "\0" + Const.NVL(result.getMatchingString(), "");
   }
 
   /** Mutable per-object bucket used only while {@link #groupResults grouping}. */


### PR DESCRIPTION
Two Java files use a NUL character as a separator, written as a real byte in the source. Git treats those files as binary and skips line-ending normalization, so on Windows a build rewrites them with CRLF and they appear as a ~4200-line change with no content change.

This writes the separator as the escape "\0" instead. Same character at runtime, and both files become normal text files for Git.

Fixes #8233
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [ ] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [ ] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
