### PR TITLE
Read a numeric column's length as its total digits, fixes #8216Read a numeric column's length as its total digits, fixes #8216

### DIFF
--- a/core/src/main/java/org/apache/hop/core/database/types/ColumnTypeRules.java
+++ b/core/src/main/java/org/apache/hop/core/database/types/ColumnTypeRules.java
@@ -81,7 +81,7 @@ public final class ColumnTypeRules {
           .where(
               (variables, databaseMeta, column) ->
                   StandardJdbcTypeMapper.numericScale(column)
-                      >= StandardJdbcTypeMapper.numericLength(column))
+                      >= StandardJdbcTypeMapper.integerDigits(column))
           .as(IValueMeta.TYPE_NUMBER, -1, -1)
           .build()
           .get(0);

--- a/core/src/main/java/org/apache/hop/core/database/types/StandardJdbcTypeMapper.java
+++ b/core/src/main/java/org/apache/hop/core/database/types/StandardJdbcTypeMapper.java
@@ -271,12 +271,25 @@ public final class StandardJdbcTypeMapper {
   }
 
   /**
-   * The Hop length of a numeric column: the digits before the decimal.
+   * The Hop length of a numeric column: the total number of significant digits, the same thing the
+   * database reports as its precision.
    *
-   * <p>A database reports precision as the total number of significant digits, so the scale has to
-   * come off. A value at or beyond 126 means the database did not really say.
+   * <p>Every getFieldDefinition writes a scaled column as DECIMAL(length, precision), and the
+   * length a user types into a transform dialog means the same total. Taking the scale off here
+   * made the value read from a column incompatible with both. A value at or beyond 126 means the
+   * database did not really say.
    */
   public static int numericLength(DatabaseColumn column) {
+    int length = column.getPrecision();
+    return length >= 126 ? -1 : length;
+  }
+
+  /**
+   * The digits before the decimal: the reported precision with the scale taken off. Only a rule
+   * asking whether a declaration is possible at all needs this - the Hop length of the column is
+   * numericLength. The 126 marker is applied after the subtraction, as it always was.
+   */
+  public static int integerDigits(DatabaseColumn column) {
     int length = column.getPrecision();
     int scale = column.getScale();
     if (length > 0 && length > scale) {

--- a/core/src/test/resources/org/apache/hop/core/database/JdbcTypeMappingCharacterizationTest.txt
+++ b/core/src/test/resources/org/apache/hop/core/database/JdbcTypeMappingCharacterizationTest.txt
@@ -59,32 +59,32 @@ TINYINT        p=  16 s=  16 signed  | DB=Integer(2,0)       VMB=Integer(2,0)   
 TINYINT        p= 126 s=   0 signed  | DB=Integer(2,0)       VMB=Integer(2,0)       PRV=Integer(2,0)       NEW=Integer(2,0)       
 DECIMAL        p=   0 s=   0 signed  | DB=Number(0,0)        VMB=Number(0,0)        PRV=Number(0,0)        NEW=Number(0,0)        
 DECIMAL        p=  38 s=   0 signed  | DB=BigNumber(38,0)    VMB=BigNumber(38,0)    PRV=BigNumber(38,0)    NEW=BigNumber(38,0)    
-DECIMAL        p=  10 s=   2 signed  | DB=Number(8,2)        VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(8,2)        DIVERGE
-DECIMAL        p=  20 s=  10 signed  | DB=Number(10,10)      VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=Number(10,10)      DIVERGE
+DECIMAL        p=  10 s=   2 signed  | DB=Number(10,2)       VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(10,2)       
+DECIMAL        p=  20 s=  10 signed  | DB=BigNumber(20,10)   VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=BigNumber(20,10)   
 DECIMAL        p=  16 s=  16 signed  | DB=BigNumber(16,16)   VMB=BigNumber(16,16)   PRV=BigNumber(16,16)   NEW=BigNumber(16,16)   
 DECIMAL        p= 126 s=   0 signed  | DB=Number(-1,0)       VMB=Number(-1,0)       PRV=Number(-1,0)       NEW=Number(-1,0)       
 NUMERIC        p=   0 s=   0 signed  | DB=Number(0,0)        VMB=Number(0,0)        PRV=Number(0,0)        NEW=Number(0,0)        
 NUMERIC        p=  38 s=   0 signed  | DB=BigNumber(38,0)    VMB=BigNumber(38,0)    PRV=BigNumber(38,0)    NEW=BigNumber(38,0)    
-NUMERIC        p=  10 s=   2 signed  | DB=Number(8,2)        VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(8,2)        DIVERGE
-NUMERIC        p=  20 s=  10 signed  | DB=Number(10,10)      VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=Number(10,10)      DIVERGE
+NUMERIC        p=  10 s=   2 signed  | DB=Number(10,2)       VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(10,2)       
+NUMERIC        p=  20 s=  10 signed  | DB=BigNumber(20,10)   VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=BigNumber(20,10)   
 NUMERIC        p=  16 s=  16 signed  | DB=BigNumber(16,16)   VMB=BigNumber(16,16)   PRV=BigNumber(16,16)   NEW=BigNumber(16,16)   
 NUMERIC        p= 126 s=   0 signed  | DB=Number(-1,0)       VMB=Number(-1,0)       PRV=Number(-1,0)       NEW=Number(-1,0)       
 DOUBLE         p=   0 s=   0 signed  | DB=Number(0,-1)       VMB=Number(0,-1)       PRV=Number(0,-1)       NEW=Number(0,-1)       
 DOUBLE         p=  38 s=   0 signed  | DB=BigNumber(38,-1)   VMB=BigNumber(38,-1)   PRV=BigNumber(38,-1)   NEW=BigNumber(38,-1)   
-DOUBLE         p=  10 s=   2 signed  | DB=Number(8,2)        VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(8,2)        DIVERGE
-DOUBLE         p=  20 s=  10 signed  | DB=Number(10,10)      VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=Number(10,10)      DIVERGE
+DOUBLE         p=  10 s=   2 signed  | DB=Number(10,2)       VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(10,2)       
+DOUBLE         p=  20 s=  10 signed  | DB=BigNumber(20,10)   VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=BigNumber(20,10)   
 DOUBLE         p=  16 s=  16 signed  | DB=BigNumber(16,16)   VMB=BigNumber(16,16)   PRV=BigNumber(16,16)   NEW=BigNumber(16,16)   
 DOUBLE         p= 126 s=   0 signed  | DB=Number(-1,-1)      VMB=Number(-1,-1)      PRV=Number(-1,-1)      NEW=Number(-1,-1)      
 FLOAT          p=   0 s=   0 signed  | DB=Number(0,-1)       VMB=Number(0,-1)       PRV=Number(0,-1)       NEW=Number(0,-1)       
 FLOAT          p=  38 s=   0 signed  | DB=BigNumber(38,-1)   VMB=BigNumber(38,-1)   PRV=BigNumber(38,-1)   NEW=BigNumber(38,-1)   
-FLOAT          p=  10 s=   2 signed  | DB=Number(8,2)        VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(8,2)        DIVERGE
-FLOAT          p=  20 s=  10 signed  | DB=Number(10,10)      VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=Number(10,10)      DIVERGE
+FLOAT          p=  10 s=   2 signed  | DB=Number(10,2)       VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(10,2)       
+FLOAT          p=  20 s=  10 signed  | DB=BigNumber(20,10)   VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=BigNumber(20,10)   
 FLOAT          p=  16 s=  16 signed  | DB=BigNumber(16,16)   VMB=BigNumber(16,16)   PRV=BigNumber(16,16)   NEW=BigNumber(16,16)   
 FLOAT          p= 126 s=   0 signed  | DB=Number(-1,-1)      VMB=Number(-1,-1)      PRV=Number(-1,-1)      NEW=Number(-1,-1)      
 REAL           p=   0 s=   0 signed  | DB=Number(0,-1)       VMB=Number(0,-1)       PRV=Number(0,-1)       NEW=Number(0,-1)       
 REAL           p=  38 s=   0 signed  | DB=BigNumber(38,-1)   VMB=BigNumber(38,-1)   PRV=BigNumber(38,-1)   NEW=BigNumber(38,-1)   
-REAL           p=  10 s=   2 signed  | DB=Number(8,2)        VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(8,2)        DIVERGE
-REAL           p=  20 s=  10 signed  | DB=Number(10,10)      VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=Number(10,10)      DIVERGE
+REAL           p=  10 s=   2 signed  | DB=Number(10,2)       VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(10,2)       
+REAL           p=  20 s=  10 signed  | DB=BigNumber(20,10)   VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=BigNumber(20,10)   
 REAL           p=  16 s=  16 signed  | DB=BigNumber(16,16)   VMB=BigNumber(16,16)   PRV=BigNumber(16,16)   NEW=BigNumber(16,16)   
 REAL           p= 126 s=   0 signed  | DB=Number(-1,-1)      VMB=Number(-1,-1)      PRV=Number(-1,-1)      NEW=Number(-1,-1)      
 TIMESTAMP      p=   0 s=   0 signed  | DB=Timestamp(0,-1)    VMB=Timestamp(0,-1)    PRV=Timestamp(0,-1)    NEW=Timestamp(0,-1)    
@@ -207,31 +207,31 @@ TINYINT        p=  16 s=  16 signed  | DB=Integer(2,0)       VMB=Integer(2,0)   
 TINYINT        p= 126 s=   0 signed  | DB=Integer(2,0)       VMB=Integer(2,0)       PRV=Integer(2,0)       NEW=Integer(2,0)       
 DECIMAL        p=   0 s=   0 signed  | DB=Number(0,0)        VMB=Number(0,0)        PRV=Number(0,0)        NEW=Number(0,0)        
 DECIMAL        p=  38 s=   0 signed  | DB=BigNumber(38,0)    VMB=BigNumber(38,0)    PRV=BigNumber(38,0)    NEW=BigNumber(38,0)    
-DECIMAL        p=  10 s=   2 signed  | DB=Number(8,2)        VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(8,2)        DIVERGE
-DECIMAL        p=  20 s=  10 signed  | DB=Number(10,10)      VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=Number(10,10)      DIVERGE
+DECIMAL        p=  10 s=   2 signed  | DB=Number(10,2)       VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(10,2)       
+DECIMAL        p=  20 s=  10 signed  | DB=BigNumber(20,10)   VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=BigNumber(20,10)   
 DECIMAL        p=  16 s=  16 signed  | DB=BigNumber(16,16)   VMB=BigNumber(16,16)   PRV=BigNumber(16,16)   NEW=BigNumber(16,16)   
 DECIMAL        p= 126 s=   0 signed  | DB=Number(-1,0)       VMB=Number(-1,0)       PRV=Number(-1,0)       NEW=Number(-1,0)       
 NUMERIC        p=   0 s=   0 signed  | DB=Number(0,0)        VMB=Number(0,0)        PRV=Number(0,0)        NEW=Number(0,0)        
 NUMERIC        p=  38 s=   0 signed  | DB=BigNumber(38,0)    VMB=BigNumber(38,0)    PRV=BigNumber(38,0)    NEW=BigNumber(38,0)    
-NUMERIC        p=  10 s=   2 signed  | DB=Number(8,2)        VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(8,2)        DIVERGE
-NUMERIC        p=  20 s=  10 signed  | DB=Number(10,10)      VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=Number(10,10)      DIVERGE
+NUMERIC        p=  10 s=   2 signed  | DB=Number(10,2)       VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(10,2)       
+NUMERIC        p=  20 s=  10 signed  | DB=BigNumber(20,10)   VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=BigNumber(20,10)   
 NUMERIC        p=  16 s=  16 signed  | DB=BigNumber(16,16)   VMB=BigNumber(16,16)   PRV=BigNumber(16,16)   NEW=BigNumber(16,16)   
 NUMERIC        p= 126 s=   0 signed  | DB=Number(-1,0)       VMB=Number(-1,0)       PRV=Number(-1,0)       NEW=Number(-1,0)       
 DOUBLE         p=   0 s=   0 signed  | DB=Number(0,-1)       VMB=Number(0,-1)       PRV=Number(0,-1)       NEW=Number(0,-1)       
 DOUBLE         p=  38 s=   0 signed  | DB=BigNumber(38,-1)   VMB=BigNumber(38,-1)   PRV=Number(-1,-1)      NEW=BigNumber(38,-1)   DIVERGE
-DOUBLE         p=  10 s=   2 signed  | DB=Number(8,2)        VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(8,2)        DIVERGE
+DOUBLE         p=  10 s=   2 signed  | DB=Number(10,2)       VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(10,2)       
 DOUBLE         p=  20 s=  10 signed  | DB=Number(-1,-1)      VMB=BigNumber(20,10)   PRV=Number(-1,10)      NEW=Number(-1,-1)      DIVERGE
 DOUBLE         p=  16 s=  16 signed  | DB=Number(-1,-1)      VMB=Number(-1,-1)      PRV=Number(-1,-1)      NEW=Number(-1,-1)      
 DOUBLE         p= 126 s=   0 signed  | DB=Number(-1,-1)      VMB=Number(-1,-1)      PRV=Number(-1,-1)      NEW=Number(-1,-1)      
 FLOAT          p=   0 s=   0 signed  | DB=Number(0,-1)       VMB=Number(0,-1)       PRV=Number(0,-1)       NEW=Number(0,-1)       
 FLOAT          p=  38 s=   0 signed  | DB=BigNumber(38,-1)   VMB=BigNumber(38,-1)   PRV=BigNumber(38,-1)   NEW=BigNumber(38,-1)   
-FLOAT          p=  10 s=   2 signed  | DB=Number(8,2)        VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(8,2)        DIVERGE
+FLOAT          p=  10 s=   2 signed  | DB=Number(10,2)       VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(10,2)       
 FLOAT          p=  20 s=  10 signed  | DB=Number(-1,-1)      VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=Number(-1,-1)      DIVERGE
 FLOAT          p=  16 s=  16 signed  | DB=Number(-1,-1)      VMB=Number(-1,-1)      PRV=Number(-1,-1)      NEW=Number(-1,-1)      
 FLOAT          p= 126 s=   0 signed  | DB=Number(-1,-1)      VMB=Number(-1,-1)      PRV=Number(-1,-1)      NEW=Number(-1,-1)      
 REAL           p=   0 s=   0 signed  | DB=Number(0,-1)       VMB=Number(0,-1)       PRV=Number(0,-1)       NEW=Number(0,-1)       
 REAL           p=  38 s=   0 signed  | DB=BigNumber(38,-1)   VMB=BigNumber(38,-1)   PRV=BigNumber(38,-1)   NEW=BigNumber(38,-1)   
-REAL           p=  10 s=   2 signed  | DB=Number(8,2)        VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(8,2)        DIVERGE
+REAL           p=  10 s=   2 signed  | DB=Number(10,2)       VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(10,2)       
 REAL           p=  20 s=  10 signed  | DB=Number(-1,-1)      VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=Number(-1,-1)      DIVERGE
 REAL           p=  16 s=  16 signed  | DB=Number(-1,-1)      VMB=Number(-1,-1)      PRV=Number(-1,-1)      NEW=Number(-1,-1)      
 REAL           p= 126 s=   0 signed  | DB=Number(-1,-1)      VMB=Number(-1,-1)      PRV=Number(-1,-1)      NEW=Number(-1,-1)      
@@ -355,32 +355,32 @@ TINYINT        p=  16 s=  16 signed  | DB=Integer(2,0)       VMB=Integer(2,0)   
 TINYINT        p= 126 s=   0 signed  | DB=Integer(2,0)       VMB=Integer(2,0)       PRV=Integer(2,0)       NEW=Integer(2,0)       
 DECIMAL        p=   0 s=   0 signed  | DB=Number(0,0)        VMB=Number(0,0)        PRV=Number(0,0)        NEW=Number(0,0)        
 DECIMAL        p=  38 s=   0 signed  | DB=BigNumber(38,0)    VMB=BigNumber(38,0)    PRV=BigNumber(38,0)    NEW=BigNumber(38,0)    
-DECIMAL        p=  10 s=   2 signed  | DB=Number(8,2)        VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(8,2)        DIVERGE
-DECIMAL        p=  20 s=  10 signed  | DB=Number(10,10)      VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=Number(10,10)      DIVERGE
+DECIMAL        p=  10 s=   2 signed  | DB=Number(10,2)       VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(10,2)       
+DECIMAL        p=  20 s=  10 signed  | DB=BigNumber(20,10)   VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=BigNumber(20,10)   
 DECIMAL        p=  16 s=  16 signed  | DB=BigNumber(16,16)   VMB=BigNumber(16,16)   PRV=BigNumber(16,16)   NEW=BigNumber(16,16)   
 DECIMAL        p= 126 s=   0 signed  | DB=Number(-1,0)       VMB=Number(-1,0)       PRV=Number(-1,0)       NEW=Number(-1,0)       
 NUMERIC        p=   0 s=   0 signed  | DB=Number(0,0)        VMB=Number(0,0)        PRV=Number(0,0)        NEW=Number(0,0)        
 NUMERIC        p=  38 s=   0 signed  | DB=BigNumber(38,0)    VMB=BigNumber(38,0)    PRV=BigNumber(38,0)    NEW=BigNumber(38,0)    
-NUMERIC        p=  10 s=   2 signed  | DB=Number(8,2)        VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(8,2)        DIVERGE
-NUMERIC        p=  20 s=  10 signed  | DB=Number(10,10)      VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=Number(10,10)      DIVERGE
+NUMERIC        p=  10 s=   2 signed  | DB=Number(10,2)       VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(10,2)       
+NUMERIC        p=  20 s=  10 signed  | DB=BigNumber(20,10)   VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=BigNumber(20,10)   
 NUMERIC        p=  16 s=  16 signed  | DB=BigNumber(16,16)   VMB=BigNumber(16,16)   PRV=BigNumber(16,16)   NEW=BigNumber(16,16)   
 NUMERIC        p= 126 s=   0 signed  | DB=Number(-1,0)       VMB=Number(-1,0)       PRV=Number(-1,0)       NEW=Number(-1,0)       
 DOUBLE         p=   0 s=   0 signed  | DB=Number(0,-1)       VMB=Number(0,-1)       PRV=Number(0,-1)       NEW=Number(0,-1)       
 DOUBLE         p=  38 s=   0 signed  | DB=BigNumber(38,-1)   VMB=BigNumber(38,-1)   PRV=BigNumber(38,-1)   NEW=BigNumber(38,-1)   
-DOUBLE         p=  10 s=   2 signed  | DB=Number(8,2)        VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(8,2)        DIVERGE
-DOUBLE         p=  20 s=  10 signed  | DB=Number(10,10)      VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=Number(10,10)      DIVERGE
+DOUBLE         p=  10 s=   2 signed  | DB=Number(10,2)       VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(10,2)       
+DOUBLE         p=  20 s=  10 signed  | DB=BigNumber(20,10)   VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=BigNumber(20,10)   
 DOUBLE         p=  16 s=  16 signed  | DB=BigNumber(16,16)   VMB=BigNumber(16,16)   PRV=BigNumber(16,16)   NEW=BigNumber(16,16)   
 DOUBLE         p= 126 s=   0 signed  | DB=Number(-1,-1)      VMB=Number(-1,-1)      PRV=Number(-1,-1)      NEW=Number(-1,-1)      
 FLOAT          p=   0 s=   0 signed  | DB=Number(0,-1)       VMB=Number(0,-1)       PRV=Number(0,-1)       NEW=Number(0,-1)       
 FLOAT          p=  38 s=   0 signed  | DB=BigNumber(38,-1)   VMB=BigNumber(38,-1)   PRV=BigNumber(38,-1)   NEW=BigNumber(38,-1)   
-FLOAT          p=  10 s=   2 signed  | DB=Number(8,2)        VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(8,2)        DIVERGE
-FLOAT          p=  20 s=  10 signed  | DB=Number(10,10)      VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=Number(10,10)      DIVERGE
+FLOAT          p=  10 s=   2 signed  | DB=Number(10,2)       VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(10,2)       
+FLOAT          p=  20 s=  10 signed  | DB=BigNumber(20,10)   VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=BigNumber(20,10)   
 FLOAT          p=  16 s=  16 signed  | DB=BigNumber(16,16)   VMB=BigNumber(16,16)   PRV=BigNumber(16,16)   NEW=BigNumber(16,16)   
 FLOAT          p= 126 s=   0 signed  | DB=Number(-1,-1)      VMB=Number(-1,-1)      PRV=Number(-1,-1)      NEW=Number(-1,-1)      
 REAL           p=   0 s=   0 signed  | DB=Number(0,-1)       VMB=Number(0,-1)       PRV=Number(0,-1)       NEW=Number(0,-1)       
 REAL           p=  38 s=   0 signed  | DB=BigNumber(38,-1)   VMB=BigNumber(38,-1)   PRV=BigNumber(38,-1)   NEW=BigNumber(38,-1)   
-REAL           p=  10 s=   2 signed  | DB=Number(8,2)        VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(8,2)        DIVERGE
-REAL           p=  20 s=  10 signed  | DB=Number(10,10)      VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=Number(10,10)      DIVERGE
+REAL           p=  10 s=   2 signed  | DB=Number(10,2)       VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(10,2)       
+REAL           p=  20 s=  10 signed  | DB=BigNumber(20,10)   VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=BigNumber(20,10)   
 REAL           p=  16 s=  16 signed  | DB=BigNumber(16,16)   VMB=BigNumber(16,16)   PRV=BigNumber(16,16)   NEW=BigNumber(16,16)   
 REAL           p= 126 s=   0 signed  | DB=Number(-1,-1)      VMB=Number(-1,-1)      PRV=Number(-1,-1)      NEW=Number(-1,-1)      
 TIMESTAMP      p=   0 s=   0 signed  | DB=Timestamp(0,-1)    VMB=Timestamp(0,-1)    PRV=Timestamp(0,-1)    NEW=Timestamp(0,-1)    
@@ -503,32 +503,32 @@ TINYINT        p=  16 s=  16 signed  | DB=Integer(2,0)       VMB=Integer(2,0)   
 TINYINT        p= 126 s=   0 signed  | DB=Integer(2,0)       VMB=Integer(2,0)       PRV=Integer(2,0)       NEW=Integer(2,0)       
 DECIMAL        p=   0 s=   0 signed  | DB=Number(0,0)        VMB=Number(0,0)        PRV=Number(0,0)        NEW=Number(0,0)        
 DECIMAL        p=  38 s=   0 signed  | DB=BigNumber(38,0)    VMB=BigNumber(38,0)    PRV=BigNumber(38,0)    NEW=BigNumber(38,0)    
-DECIMAL        p=  10 s=   2 signed  | DB=Number(8,2)        VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(8,2)        DIVERGE
-DECIMAL        p=  20 s=  10 signed  | DB=Number(10,10)      VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=Number(10,10)      DIVERGE
+DECIMAL        p=  10 s=   2 signed  | DB=Number(10,2)       VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(10,2)       
+DECIMAL        p=  20 s=  10 signed  | DB=BigNumber(20,10)   VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=BigNumber(20,10)   
 DECIMAL        p=  16 s=  16 signed  | DB=BigNumber(16,16)   VMB=BigNumber(16,16)   PRV=BigNumber(16,16)   NEW=BigNumber(16,16)   
 DECIMAL        p= 126 s=   0 signed  | DB=Number(-1,0)       VMB=Number(-1,0)       PRV=Number(-1,0)       NEW=Number(-1,0)       
 NUMERIC        p=   0 s=   0 signed  | DB=Number(0,0)        VMB=Number(0,0)        PRV=Number(0,0)        NEW=Number(0,0)        
 NUMERIC        p=  38 s=   0 signed  | DB=BigNumber(38,0)    VMB=BigNumber(38,0)    PRV=BigNumber(38,0)    NEW=BigNumber(38,0)    
-NUMERIC        p=  10 s=   2 signed  | DB=Number(8,2)        VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(8,2)        DIVERGE
-NUMERIC        p=  20 s=  10 signed  | DB=Number(10,10)      VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=Number(10,10)      DIVERGE
+NUMERIC        p=  10 s=   2 signed  | DB=Number(10,2)       VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(10,2)       
+NUMERIC        p=  20 s=  10 signed  | DB=BigNumber(20,10)   VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=BigNumber(20,10)   
 NUMERIC        p=  16 s=  16 signed  | DB=BigNumber(16,16)   VMB=BigNumber(16,16)   PRV=BigNumber(16,16)   NEW=BigNumber(16,16)   
 NUMERIC        p= 126 s=   0 signed  | DB=Number(-1,0)       VMB=Number(-1,0)       PRV=Number(-1,0)       NEW=Number(-1,0)       
 DOUBLE         p=   0 s=   0 signed  | DB=Number(0,-1)       VMB=Number(0,-1)       PRV=Number(0,-1)       NEW=Number(0,-1)       
 DOUBLE         p=  38 s=   0 signed  | DB=BigNumber(38,-1)   VMB=BigNumber(38,-1)   PRV=BigNumber(38,-1)   NEW=BigNumber(38,-1)   
-DOUBLE         p=  10 s=   2 signed  | DB=Number(8,2)        VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(8,2)        DIVERGE
-DOUBLE         p=  20 s=  10 signed  | DB=Number(10,10)      VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=Number(10,10)      DIVERGE
+DOUBLE         p=  10 s=   2 signed  | DB=Number(10,2)       VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(10,2)       
+DOUBLE         p=  20 s=  10 signed  | DB=BigNumber(20,10)   VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=BigNumber(20,10)   
 DOUBLE         p=  16 s=  16 signed  | DB=BigNumber(16,16)   VMB=BigNumber(16,16)   PRV=BigNumber(16,16)   NEW=BigNumber(16,16)   
 DOUBLE         p= 126 s=   0 signed  | DB=Number(-1,-1)      VMB=Number(-1,-1)      PRV=Number(-1,-1)      NEW=Number(-1,-1)      
 FLOAT          p=   0 s=   0 signed  | DB=Number(0,-1)       VMB=Number(0,-1)       PRV=Number(0,-1)       NEW=Number(0,-1)       
 FLOAT          p=  38 s=   0 signed  | DB=BigNumber(38,-1)   VMB=BigNumber(38,-1)   PRV=BigNumber(38,-1)   NEW=BigNumber(38,-1)   
-FLOAT          p=  10 s=   2 signed  | DB=Number(8,2)        VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(8,2)        DIVERGE
-FLOAT          p=  20 s=  10 signed  | DB=Number(10,10)      VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=Number(10,10)      DIVERGE
+FLOAT          p=  10 s=   2 signed  | DB=Number(10,2)       VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(10,2)       
+FLOAT          p=  20 s=  10 signed  | DB=BigNumber(20,10)   VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=BigNumber(20,10)   
 FLOAT          p=  16 s=  16 signed  | DB=BigNumber(16,16)   VMB=BigNumber(16,16)   PRV=BigNumber(16,16)   NEW=BigNumber(16,16)   
 FLOAT          p= 126 s=   0 signed  | DB=Number(-1,-1)      VMB=Number(-1,-1)      PRV=Number(-1,-1)      NEW=Number(-1,-1)      
 REAL           p=   0 s=   0 signed  | DB=Number(0,-1)       VMB=Number(0,-1)       PRV=Number(0,-1)       NEW=Number(0,-1)       
 REAL           p=  38 s=   0 signed  | DB=BigNumber(38,-1)   VMB=BigNumber(38,-1)   PRV=BigNumber(38,-1)   NEW=BigNumber(38,-1)   
-REAL           p=  10 s=   2 signed  | DB=Number(8,2)        VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(8,2)        DIVERGE
-REAL           p=  20 s=  10 signed  | DB=Number(10,10)      VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=Number(10,10)      DIVERGE
+REAL           p=  10 s=   2 signed  | DB=Number(10,2)       VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(10,2)       
+REAL           p=  20 s=  10 signed  | DB=BigNumber(20,10)   VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=BigNumber(20,10)   
 REAL           p=  16 s=  16 signed  | DB=BigNumber(16,16)   VMB=BigNumber(16,16)   PRV=BigNumber(16,16)   NEW=BigNumber(16,16)   
 REAL           p= 126 s=   0 signed  | DB=Number(-1,-1)      VMB=Number(-1,-1)      PRV=Number(-1,-1)      NEW=Number(-1,-1)      
 TIMESTAMP      p=   0 s=   0 signed  | DB=Timestamp(0,-1)    VMB=Timestamp(0,-1)    PRV=Timestamp(0,-1)    NEW=Timestamp(0,-1)    
@@ -651,32 +651,32 @@ TINYINT        p=  16 s=  16 signed  | DB=Integer(2,0)       VMB=Integer(2,0)   
 TINYINT        p= 126 s=   0 signed  | DB=Integer(2,0)       VMB=Integer(2,0)       PRV=Integer(2,0)       NEW=Integer(2,0)       
 DECIMAL        p=   0 s=   0 signed  | DB=Number(0,0)        VMB=Number(0,0)        PRV=Number(0,0)        NEW=Number(0,0)        
 DECIMAL        p=  38 s=   0 signed  | DB=BigNumber(38,0)    VMB=BigNumber(38,0)    PRV=BigNumber(38,0)    NEW=BigNumber(38,0)    
-DECIMAL        p=  10 s=   2 signed  | DB=Number(8,2)        VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(8,2)        DIVERGE
-DECIMAL        p=  20 s=  10 signed  | DB=Number(10,10)      VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=Number(10,10)      DIVERGE
+DECIMAL        p=  10 s=   2 signed  | DB=Number(10,2)       VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(10,2)       
+DECIMAL        p=  20 s=  10 signed  | DB=BigNumber(20,10)   VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=BigNumber(20,10)   
 DECIMAL        p=  16 s=  16 signed  | DB=BigNumber(16,16)   VMB=BigNumber(16,16)   PRV=BigNumber(16,16)   NEW=BigNumber(16,16)   
 DECIMAL        p= 126 s=   0 signed  | DB=Number(-1,0)       VMB=Number(-1,0)       PRV=Number(-1,0)       NEW=Number(-1,0)       
 NUMERIC        p=   0 s=   0 signed  | DB=Number(0,0)        VMB=Number(0,0)        PRV=Number(0,0)        NEW=Number(0,0)        
 NUMERIC        p=  38 s=   0 signed  | DB=BigNumber(38,0)    VMB=BigNumber(38,0)    PRV=BigNumber(38,0)    NEW=BigNumber(38,0)    
-NUMERIC        p=  10 s=   2 signed  | DB=Number(8,2)        VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(8,2)        DIVERGE
-NUMERIC        p=  20 s=  10 signed  | DB=Number(10,10)      VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=Number(10,10)      DIVERGE
+NUMERIC        p=  10 s=   2 signed  | DB=Number(10,2)       VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(10,2)       
+NUMERIC        p=  20 s=  10 signed  | DB=BigNumber(20,10)   VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=BigNumber(20,10)   
 NUMERIC        p=  16 s=  16 signed  | DB=BigNumber(16,16)   VMB=BigNumber(16,16)   PRV=BigNumber(16,16)   NEW=BigNumber(16,16)   
 NUMERIC        p= 126 s=   0 signed  | DB=Number(-1,0)       VMB=Number(-1,0)       PRV=Number(-1,0)       NEW=Number(-1,0)       
 DOUBLE         p=   0 s=   0 signed  | DB=Number(0,-1)       VMB=Number(0,-1)       PRV=Number(0,-1)       NEW=Number(0,-1)       
 DOUBLE         p=  38 s=   0 signed  | DB=BigNumber(38,-1)   VMB=BigNumber(38,-1)   PRV=BigNumber(38,-1)   NEW=BigNumber(38,-1)   
-DOUBLE         p=  10 s=   2 signed  | DB=Number(8,2)        VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(8,2)        DIVERGE
-DOUBLE         p=  20 s=  10 signed  | DB=Number(10,10)      VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=Number(10,10)      DIVERGE
+DOUBLE         p=  10 s=   2 signed  | DB=Number(10,2)       VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(10,2)       
+DOUBLE         p=  20 s=  10 signed  | DB=BigNumber(20,10)   VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=BigNumber(20,10)   
 DOUBLE         p=  16 s=  16 signed  | DB=BigNumber(16,16)   VMB=BigNumber(16,16)   PRV=BigNumber(16,16)   NEW=BigNumber(16,16)   
 DOUBLE         p= 126 s=   0 signed  | DB=Number(-1,-1)      VMB=Number(-1,-1)      PRV=Number(-1,-1)      NEW=Number(-1,-1)      
 FLOAT          p=   0 s=   0 signed  | DB=Number(0,-1)       VMB=Number(0,-1)       PRV=Number(0,-1)       NEW=Number(0,-1)       
 FLOAT          p=  38 s=   0 signed  | DB=BigNumber(38,-1)   VMB=BigNumber(38,-1)   PRV=BigNumber(38,-1)   NEW=BigNumber(38,-1)   
-FLOAT          p=  10 s=   2 signed  | DB=Number(8,2)        VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(8,2)        DIVERGE
-FLOAT          p=  20 s=  10 signed  | DB=Number(10,10)      VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=Number(10,10)      DIVERGE
+FLOAT          p=  10 s=   2 signed  | DB=Number(10,2)       VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(10,2)       
+FLOAT          p=  20 s=  10 signed  | DB=BigNumber(20,10)   VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=BigNumber(20,10)   
 FLOAT          p=  16 s=  16 signed  | DB=BigNumber(16,16)   VMB=BigNumber(16,16)   PRV=BigNumber(16,16)   NEW=BigNumber(16,16)   
 FLOAT          p= 126 s=   0 signed  | DB=Number(-1,-1)      VMB=Number(-1,-1)      PRV=Number(-1,-1)      NEW=Number(-1,-1)      
 REAL           p=   0 s=   0 signed  | DB=Number(0,-1)       VMB=Number(0,-1)       PRV=Number(0,-1)       NEW=Number(0,-1)       
 REAL           p=  38 s=   0 signed  | DB=BigNumber(38,-1)   VMB=BigNumber(38,-1)   PRV=BigNumber(38,-1)   NEW=BigNumber(38,-1)   
-REAL           p=  10 s=   2 signed  | DB=Number(8,2)        VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(8,2)        DIVERGE
-REAL           p=  20 s=  10 signed  | DB=Number(10,10)      VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=Number(10,10)      DIVERGE
+REAL           p=  10 s=   2 signed  | DB=Number(10,2)       VMB=Number(10,2)       PRV=Number(10,2)       NEW=Number(10,2)       
+REAL           p=  20 s=  10 signed  | DB=BigNumber(20,10)   VMB=BigNumber(20,10)   PRV=BigNumber(20,10)   NEW=BigNumber(20,10)   
 REAL           p=  16 s=  16 signed  | DB=BigNumber(16,16)   VMB=BigNumber(16,16)   PRV=BigNumber(16,16)   NEW=BigNumber(16,16)   
 REAL           p= 126 s=   0 signed  | DB=Number(-1,-1)      VMB=Number(-1,-1)      PRV=Number(-1,-1)      NEW=Number(-1,-1)      
 TIMESTAMP      p=   0 s=   0 signed  | DB=Date(-1,-1)        VMB=None(-1,-1)        PRV=None(-1,-1)        NEW=Date(-1,-1)        DIVERGE
@@ -748,4 +748,4 @@ STRUCT         p= 126 s=   0 signed  | DB=String(-1,-1)      VMB=String(-1,-1)  
 BIGINT         p=  20 s=   0 unsigned | DB=BigNumber(16,0)    VMB=BigNumber(16,0)    PRV=Integer(15,0)      NEW=BigNumber(16,0)    DIVERGE
 YEAR           p=   4 s=   0 signed  | DB=Date(-1,-1)        VMB=Date(-1,-1)        PRV=Date(-1,-1)        NEW=Date(-1,-1)        
 
-# diverging cases: 62
+# diverging cases: 15

--- a/docs/hop-dev-manual/modules/ROOT/pages/database/column-types.adoc
+++ b/docs/hop-dev-manual/modules/ROOT/pages/database/column-types.adoc
@@ -234,8 +234,9 @@ What survives when no rule claims a column is `StandardJdbcTypeMapper`, which do
 
 It exposes a few helpers that rules can use so that a condition does not have to restate arithmetic the mapping already does:
 
-* `numericLength(column)` — digits before the decimal, after the scale has been taken off
+* `numericLength(column)` — the total number of significant digits, the same value the database reports as its precision
 * `numericScale(column)` — digits after the decimal
+* `integerDigits(column)` — digits before the decimal, for a rule that tests whether a declaration is possible at all
 * `displaySizeIsTwiceThePrecision(databaseMeta, column)` — the `CHAR(X) FOR BIT DATA` shape
 
 That last one matters if you write a rule for binary columns.

--- a/plugins/databases/mssql/src/test/java/org/apache/hop/databases/mssql/MsSqlServerNumericRoundTripTest.java
+++ b/plugins/databases/mssql/src/test/java/org/apache/hop/databases/mssql/MsSqlServerNumericRoundTripTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.databases.mssql;
+
+import static org.apache.hop.junit.database.TypeRuleFixture.meta;
+import static org.apache.hop.junit.database.TypeRuleFixture.numericColumn;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.sql.Types;
+import org.apache.hop.core.HopClientEnvironment;
+import org.apache.hop.core.database.types.DatabaseTypeMapper;
+import org.apache.hop.core.row.IValueMeta;
+import org.apache.hop.core.variables.Variables;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reading a numeric column and writing it back has to give the same declaration. A pipeline that
+ * reads a table and re-creates it elsewhere does exactly that, and getFieldDefinition writes a
+ * scaled column as DECIMAL(length, precision) - so the length read off a column has to be its total
+ * number of digits, not the digits before the decimal.
+ */
+class MsSqlServerNumericRoundTripTest {
+
+  @BeforeAll
+  static void setUpClass() throws Exception {
+    HopClientEnvironment.init();
+  }
+
+  private static String roundTrip(int precision, int scale) throws Exception {
+    MsSqlServerDatabaseMeta databaseMeta = new MsSqlServerDatabaseMeta();
+    IValueMeta valueMeta =
+        DatabaseTypeMapper.getValueMeta(
+            new Variables(),
+            meta(databaseMeta),
+            numericColumn(Types.DECIMAL, "decimal", precision, scale),
+            false,
+            false);
+    return databaseMeta.getFieldDefinition(valueMeta, null, null, false, false, false);
+  }
+
+  @Test
+  void aScaledDecimalKeepsItsDeclaration() throws Exception {
+    assertEquals("DECIMAL(5,2)", roundTrip(5, 2));
+    assertEquals("DECIMAL(10,6)", roundTrip(10, 6));
+    assertEquals("DECIMAL(24,15)", roundTrip(24, 15));
+  }
+
+  @Test
+  void anUnscaledDecimalKeepsItsDeclaration() throws Exception {
+    assertEquals("DECIMAL(38,0)", roundTrip(38, 0));
+  }
+
+  @Test
+  void aNarrowUnscaledDecimalStillBecomesAnIntegerColumn() throws Exception {
+    // Unchanged by the length meaning: an unscaled decimal that fits a Long is written as one.
+    assertEquals("INT", roundTrip(3, 0));
+    assertEquals("BIGINT", roundTrip(10, 0));
+  }
+}

--- a/plugins/databases/mysql/src/test/java/org/apache/hop/databases/mysql/MySqlTypeRulesTest.java
+++ b/plugins/databases/mysql/src/test/java/org/apache/hop/databases/mysql/MySqlTypeRulesTest.java
@@ -19,6 +19,7 @@ package org.apache.hop.databases.mysql;
 
 import static org.apache.hop.junit.database.TypeRuleFixture.column;
 import static org.apache.hop.junit.database.TypeRuleFixture.meta;
+import static org.apache.hop.junit.database.TypeRuleFixture.numericColumn;
 import static org.apache.hop.junit.database.TypeRuleFixture.properties;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -54,6 +55,46 @@ class MySqlTypeRulesTest {
         column(sqlType, typeName, precision, displaySize),
         false,
         false);
+  }
+
+  private IValueMeta mapNumeric(int sqlType, String typeName, int precision, int scale)
+      throws Exception {
+    return DatabaseTypeMapper.getValueMeta(
+        new Variables(),
+        meta(new MySqlDatabaseMeta()),
+        numericColumn(sqlType, typeName, precision, scale),
+        false,
+        false);
+  }
+
+  @Test
+  void aDoubleReportingMoreDecimalsThanDigitsHasNoUsableSize() throws Exception {
+    // MySQL reports (12,31) for a plain double: nobody declared that.
+    IValueMeta valueMeta = mapNumeric(Types.DOUBLE, "DOUBLE", 12, 31);
+
+    assertTrue(valueMeta.isNumber());
+    assertEquals(-1, valueMeta.getLength());
+    assertEquals(-1, valueMeta.getPrecision());
+  }
+
+  @Test
+  void aDoubleWithMoreDecimalsThanIntegerDigitsHasNoUsableSizeEither() throws Exception {
+    // (10,6) leaves four digits before the decimal and asks for six after it. The rule compares
+    // the scale against those four, not against the ten - so it still claims the column.
+    IValueMeta valueMeta = mapNumeric(Types.DOUBLE, "DOUBLE", 10, 6);
+
+    assertTrue(valueMeta.isNumber());
+    assertEquals(-1, valueMeta.getLength());
+    assertEquals(-1, valueMeta.getPrecision());
+  }
+
+  @Test
+  void aDoubleWithRoomForItsDecimalsKeepsItsSize() throws Exception {
+    IValueMeta valueMeta = mapNumeric(Types.DOUBLE, "DOUBLE", 10, 2);
+
+    assertTrue(valueMeta.isNumber());
+    assertEquals(10, valueMeta.getLength());
+    assertEquals(2, valueMeta.getPrecision());
   }
 
   @Test

--- a/plugins/databases/postgresql/src/main/java/org/apache/hop/databases/postgresql/PostgreSqlDatabaseMeta.java
+++ b/plugins/databases/postgresql/src/main/java/org/apache/hop/databases/postgresql/PostgreSqlDatabaseMeta.java
@@ -126,7 +126,7 @@ public class PostgreSqlDatabaseMeta extends BaseDatabaseMeta implements IDatabas
           .where(
               (variables, databaseMeta, column) ->
                   StandardJdbcTypeMapper.numericScale(column) >= 16
-                      && StandardJdbcTypeMapper.numericLength(column) >= 16)
+                      && StandardJdbcTypeMapper.integerDigits(column) >= 16)
           .as(IValueMeta.TYPE_NUMBER, -1, -1)
           // A numeric with no declared size means arbitrary precision.
           .read(Types.NUMERIC)

--- a/plugins/databases/postgresql/src/test/java/org/apache/hop/databases/postgresql/PostgreSqlTypeRulesTest.java
+++ b/plugins/databases/postgresql/src/test/java/org/apache/hop/databases/postgresql/PostgreSqlTypeRulesTest.java
@@ -71,8 +71,8 @@ class PostgreSqlTypeRulesTest {
     IValueMeta valueMeta = map(Types.NUMERIC, "numeric", 10, 2);
 
     assertTrue(valueMeta.isNumber());
-    // Hop length is the digits before the decimal, so it round-trips as NUMERIC(8+2, 2).
-    assertEquals(8, valueMeta.getLength());
+    // Hop length is the total number of significant digits, the same as the database precision.
+    assertEquals(10, valueMeta.getLength());
     assertEquals(2, valueMeta.getPrecision());
   }
 


### PR DESCRIPTION
numericLength() took the scale off the precision the database reports, so decimal(5,2) arrived as Hop length 3. Every getFieldDefinition writes a scaled column as DECIMAL(length, precision), and a length typed into a transform dialog means the same total — so the length read off a column matched neither. A table re-created from a read stopped round-tripping: decimal(24,15) becomes DECIMAL(9,15), which SQL Server refuses, and decimal(5,2) becomes DECIMAL(3,2), which is valid DDL that then rejects valid data.

The subtraction is kept as integerDigits() for the two rules that test whether a declaration is possible at all, so no dialect rule changes behaviour. Oracle's two require scale <= 0, where it never applied.

JdbcTypeMappingCharacterizationTest: 63 diverging lines become 16, and the live path now agrees with the legacy mapper on every numeric case. New MsSqlServerNumericRoundTripTest fails without this change with expected: <DECIMAL(5,2)> but was: <DECIMAL(3,2)>.

Fixes [#8216](https://github.com/apache/hop/issues/8216)

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [ ] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [ ] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
