### PR TITLE
Fix project variable resolution in environment file paths

### DIFF
--- a/plugins/misc/projects/src/main/java/org/apache/hop/projects/project/Project.java
+++ b/plugins/misc/projects/src/main/java/org/apache/hop/projects/project/Project.java
@@ -256,6 +256,10 @@ public class Project extends ConfigFile implements IConfigFile {
       variables.setVariable(ProjectsUtil.VARIABLE_PROJECT_HOME, realValue);
     }
 
+    // Project variables can be used in environment configuration file paths.
+    //
+    applyProjectVariables(variables);
+
     // Apply the described variables from the various configuration files in the given order...
     //
     for (String configurationFile : configurationFiles) {
@@ -314,6 +318,12 @@ public class Project extends ConfigFile implements IConfigFile {
       String realValue = variables.resolve(dataSetsCsvFolder);
       variables.setVariable(ProjectsUtil.VARIABLE_HOP_DATASETS_FOLDER, realValue);
     }
+    // Keep project variables as the final values when a configuration file defines the same name.
+    //
+    applyProjectVariables(variables);
+  }
+
+  private void applyProjectVariables(IVariables variables) {
     for (DescribedVariable variable : getDescribedVariables()) {
       if (variable.getName() != null) {
         variables.setVariable(variable.getName(), variable.getValue());

--- a/plugins/misc/projects/src/test/java/org/apache/hop/projects/project/ProjectTest.java
+++ b/plugins/misc/projects/src/test/java/org/apache/hop/projects/project/ProjectTest.java
@@ -30,6 +30,9 @@ import java.util.Comparator;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+import org.apache.hop.core.config.DescribedVariablesConfigFile;
+import org.apache.hop.core.logging.HopLogStore;
+import org.apache.hop.core.variables.DescribedVariable;
 import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.core.variables.Variables;
 import org.apache.hop.projects.config.ProjectsConfig;
@@ -198,6 +201,37 @@ public class ProjectTest {
         parentHome.toString(), variables.getVariable(ProjectsUtil.VARIABLE_PARENT_PROJECT_HOME));
     assertEquals("child-proj", variables.getVariable(Defaults.VARIABLE_HOP_PROJECT_NAME));
     assertEquals(childHome.toString(), variables.getVariable(ProjectsUtil.VARIABLE_PROJECT_HOME));
+  }
+
+  @Test
+  public void testProjectVariableResolvesEnvironmentConfigurationFilePath() throws Exception {
+    HopLogStore.init();
+    tempRoot = Files.createTempDirectory("hop-project-environment-variable");
+    Path projectHome = tempRoot.resolve("project");
+    Path configFolder = projectHome.resolve("config");
+    Files.createDirectories(configFolder);
+
+    Path environmentFile = configFolder.resolve("environment.json");
+    DescribedVariablesConfigFile configFile =
+        new DescribedVariablesConfigFile(environmentFile.toString());
+    configFile.setDescribedVariable(new DescribedVariable("ENVIRONMENT_VALUE", "loaded", ""));
+    configFile.saveToFile();
+
+    ProjectConfig projectConfig =
+        new ProjectConfig(
+            "project", projectHome.toString(), ProjectsConfig.DEFAULT_PROJECT_CONFIG_FILENAME);
+    Project project = new Project();
+    project
+        .getDescribedVariables()
+        .add(
+            new DescribedVariable(
+                "CONFIG_HOME", "${" + ProjectsUtil.VARIABLE_PROJECT_HOME + "}/config", ""));
+
+    IVariables variables = new Variables();
+    project.modifyVariables(
+        variables, projectConfig, java.util.List.of("${CONFIG_HOME}/environment.json"), "dev");
+
+    assertEquals("loaded", variables.getVariable("ENVIRONMENT_VALUE"));
   }
 
   @Test


### PR DESCRIPTION
Fixes #8187.

Project variables were applied after environment configuration files were loaded, so paths such as ${CONFIG_HOME}/environment.json could not be resolved.

Apply project variables before resolving those paths, then reapply them afterward to preserve the existing variable precedence.

Added a regression test using CONFIG_HOME=${PROJECT_HOME}/config and a real environment configuration file. Before the fix, the expected environment value was null. With the fix, the file is loaded and all 13 ProjectTest tests pass.

Validation:
- ./mvnw -pl plugins/misc/projects -am -Dtest=ProjectTest -Dsurefire.failIfNoSpecifiedTests=false test
- Spotless formatting and validation
- git diff --check

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)