### PR TITLE
Fix Do not mark a pipeline or workflow dirty when a dialog is OK without edits

### DIFF
--- a/core/src/main/java/org/apache/hop/core/xml/XmlHandler.java
+++ b/core/src/main/java/org/apache/hop/core/xml/XmlHandler.java
@@ -37,6 +37,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import javax.xml.XMLConstants;
@@ -1212,6 +1213,125 @@ public class XmlHandler {
     String tag = "wrap";
     String newXml = openTag(tag) + xml + closeTag(tag);
     return loadXmlString(newXml, tag);
+  }
+
+  /**
+   * Compare two XML fragments for change detection, treating an omitted element (a {@code null}
+   * field, which {@link org.apache.hop.metadata.serializer.xml.XmlMetadataUtil} does not write) as
+   * the same as an empty element such as {@code <tag/>} (an empty string).
+   *
+   * <p>Serialization still distinguishes null from empty string. This method is only for deciding
+   * whether a dialog OK wrote the same persisted content back, typically after SWT widgets turned
+   * null into {@code ""}.
+   *
+   * @param left first XML fragment, may be null
+   * @param right second XML fragment, may be null
+   * @return true if the documents are equal after ignoring empty-valued elements
+   */
+  public static boolean sameContentIgnoringEmptyValues(String left, String right) {
+    if (Objects.equals(left, right)) {
+      return true;
+    }
+    if (left == null || right == null) {
+      return false;
+    }
+    try {
+      return sameElementIgnoringEmptyValues(wrapLoadXmlString(left), wrapLoadXmlString(right));
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private static boolean sameElementIgnoringEmptyValues(Node left, Node right) {
+    if (!Objects.equals(left.getNodeName(), right.getNodeName())) {
+      return false;
+    }
+    if (!sameAttributes(left, right)) {
+      return false;
+    }
+    List<Node> leftChildren = significantElementChildren(left);
+    List<Node> rightChildren = significantElementChildren(right);
+    if (leftChildren.size() != rightChildren.size()) {
+      return false;
+    }
+    if (leftChildren.isEmpty()) {
+      return Objects.equals(directText(left), directText(right));
+    }
+    for (int i = 0; i < leftChildren.size(); i++) {
+      if (!sameElementIgnoringEmptyValues(leftChildren.get(i), rightChildren.get(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean sameAttributes(Node left, Node right) {
+    NamedNodeMap leftAttrs = left.getAttributes();
+    NamedNodeMap rightAttrs = right.getAttributes();
+    int leftCount = leftAttrs == null ? 0 : leftAttrs.getLength();
+    int rightCount = rightAttrs == null ? 0 : rightAttrs.getLength();
+    if (leftCount != rightCount) {
+      return false;
+    }
+    if (leftCount == 0) {
+      return true;
+    }
+    for (int i = 0; i < leftCount; i++) {
+      Node attr = leftAttrs.item(i);
+      Node other = rightAttrs.getNamedItem(attr.getNodeName());
+      if (other == null || !Objects.equals(attr.getNodeValue(), other.getNodeValue())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static List<Node> significantElementChildren(Node parent) {
+    List<Node> children = new ArrayList<>();
+    NodeList nodes = parent.getChildNodes();
+    for (int i = 0; i < nodes.getLength(); i++) {
+      Node child = nodes.item(i);
+      if (child.getNodeType() == Node.ELEMENT_NODE && hasSignificantContent(child)) {
+        children.add(child);
+      }
+    }
+    return children;
+  }
+
+  /**
+   * True when the element has attributes, non-whitespace text, or a child that itself has
+   * significant content. The opposite is an omitted null field versus {@code <tag/>} for an empty
+   * string.
+   */
+  private static boolean hasSignificantContent(Node element) {
+    NamedNodeMap attributes = element.getAttributes();
+    if (attributes != null && attributes.getLength() > 0) {
+      return true;
+    }
+    if (!directText(element).isEmpty()) {
+      return true;
+    }
+    NodeList nodes = element.getChildNodes();
+    for (int i = 0; i < nodes.getLength(); i++) {
+      Node child = nodes.item(i);
+      if (child.getNodeType() == Node.ELEMENT_NODE && hasSignificantContent(child)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String directText(Node element) {
+    StringBuilder text = new StringBuilder();
+    NodeList nodes = element.getChildNodes();
+    for (int i = 0; i < nodes.getLength(); i++) {
+      Node child = nodes.item(i);
+      short type = child.getNodeType();
+      if (type == Node.TEXT_NODE || type == Node.CDATA_SECTION_NODE) {
+        text.append(child.getNodeValue());
+      }
+    }
+    return text.toString().trim();
   }
 
   public static String getLicenseHeader(IVariables variables) throws HopException {

--- a/core/src/test/java/org/apache/hop/core/xml/XmlHandlerUnitTest.java
+++ b/core/src/test/java/org/apache/hop/core/xml/XmlHandlerUnitTest.java
@@ -18,8 +18,10 @@
 package org.apache.hop.core.xml;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -337,5 +339,41 @@ class XmlHandlerUnitTest {
     subNode = XmlHandler.getSubNodeByNr(rootNode, "xpto", 3, false);
     assertNotNull(subNode);
     assertEquals("3", subNode.getTextContent());
+  }
+
+  @Test
+  void omittedElementEqualsEmptyElement() {
+    String withNullField = "<transform><name>Abort</name></transform>";
+    String withEmptyField = "<transform><name>Abort</name><message/></transform>";
+    String withEmptyPair = "<transform><name>Abort</name><message></message></transform>";
+    assertTrue(XmlHandler.sameContentIgnoringEmptyValues(withNullField, withEmptyField));
+    assertTrue(XmlHandler.sameContentIgnoringEmptyValues(withNullField, withEmptyPair));
+    assertTrue(XmlHandler.sameContentIgnoringEmptyValues(withEmptyField, withEmptyPair));
+  }
+
+  @Test
+  void nestedEmptyElementsEqualOmittedParent() {
+    String omitted = "<transform><name>Calc</name></transform>";
+    String emptyNested =
+        "<transform><name>Calc</name><fields><field><format/></field></fields></transform>";
+    assertTrue(XmlHandler.sameContentIgnoringEmptyValues(omitted, emptyNested));
+  }
+
+  @Test
+  void realTextChangeIsStillDetected() {
+    String before = "<transform><name>Abort</name></transform>";
+    String after = "<transform><name>Abort</name><message>stop</message></transform>";
+    assertFalse(XmlHandler.sameContentIgnoringEmptyValues(before, after));
+    assertFalse(
+        XmlHandler.sameContentIgnoringEmptyValues(
+            "<transform><message>old</message></transform>",
+            "<transform><message>new</message></transform>"));
+  }
+
+  @Test
+  void extraEmptyListItemIsIgnored() {
+    String oneField = "<fields><field><name>a</name></field></fields>";
+    String trailingEmpty = "<fields><field><name>a</name></field><field/></fields>";
+    assertTrue(XmlHandler.sameContentIgnoringEmptyValues(oneField, trailingEmpty));
   }
 }

--- a/core/src/test/java/org/apache/hop/metadata/serializer/xml/XmlMetadataUtilTest.java
+++ b/core/src/test/java/org/apache/hop/metadata/serializer/xml/XmlMetadataUtilTest.java
@@ -95,7 +95,7 @@ class XmlMetadataUtilTest {
     Node fieldsNode = XmlHandler.getSubNode(node, "fields");
     List<Node> fieldNodes = XmlHandler.getNodes(fieldsNode, "field");
     assertEquals(3, fieldNodes.size());
-    Node fieldNode = fieldNodes.get(0);
+    Node fieldNode = fieldNodes.getFirst();
     assertEquals("a", XmlHandler.getTagValue(fieldNode, "name"));
     assertEquals("String", XmlHandler.getTagValue(fieldNode, "type"));
     assertEquals("50", XmlHandler.getTagValue(fieldNode, "length"));
@@ -222,6 +222,21 @@ class XmlMetadataUtilTest {
   }
 
   @Test
+  void nullAndEmptyStringSerializeDifferentlyButCompareEqualForChangeDetection() throws Exception {
+    Field withNullFormat = new Field("a", "String", 50, -1, null, TestEnum.ONE);
+    Field withEmptyFormat = new Field("a", "String", 50, -1, "", TestEnum.ONE);
+
+    String nullXml = XmlMetadataUtil.serializeObjectToXml(withNullFormat);
+    String emptyXml = XmlMetadataUtil.serializeObjectToXml(withEmptyFormat);
+
+    assertFalse(nullXml.contains("<format"), "null is omitted from XML");
+    assertTrue(emptyXml.contains("<format"), "empty string is written as a tag");
+    assertTrue(
+        XmlHandler.sameContentIgnoringEmptyValues(nullXml, emptyXml),
+        "dialog OK that turns null into empty string is not a content change");
+  }
+
+  @Test
   void testListReferenceSerializationWithEmptyReference() throws Exception {
     String xml =
         """
@@ -239,7 +254,7 @@ class XmlMetadataUtilTest {
 
     assertEquals(1, withCopy.getSteps().size());
     assertEquals(1, withCopy.getHops().size());
-    assertEquals("S1", withCopy.getHops().get(0).getFrom().getName());
-    assertNull(withCopy.getHops().get(0).getTo());
+    assertEquals("S1", withCopy.getHops().getFirst().getFrom().getName());
+    assertNull(withCopy.getHops().getFirst().getTo());
   }
 }

--- a/engine/src/main/java/org/apache/hop/core/undo/XmlSnapshotUndo.java
+++ b/engine/src/main/java/org/apache/hop/core/undo/XmlSnapshotUndo.java
@@ -183,7 +183,8 @@ public class XmlSnapshotUndo<M> {
 
   /**
    * Gzip headers include a timestamp, so compressed bytes of identical XML are not equal. Compare
-   * inflated XML instead.
+   * inflated XML instead. Empty elements ({@code <tag/>}) are treated as the same as omitted
+   * elements so a dialog OK that only turns {@code null} into {@code ""} is not recorded as undo.
    */
   public static boolean sameXmlContent(byte[] left, byte[] right) {
     if (left == right) {
@@ -193,7 +194,7 @@ public class XmlSnapshotUndo<M> {
       return false;
     }
     try {
-      return decompress(left).equals(decompress(right));
+      return XmlHandler.sameContentIgnoringEmptyValues(decompress(left), decompress(right));
     } catch (IOException e) {
       return false;
     }

--- a/engine/src/main/java/org/apache/hop/pipeline/transform/copy/DefaultTransformMetaCopyFactory.java
+++ b/engine/src/main/java/org/apache/hop/pipeline/transform/copy/DefaultTransformMetaCopyFactory.java
@@ -127,6 +127,10 @@ public class DefaultTransformMetaCopyFactory implements ITransformMetaCopyFactor
         if (copy.getTransform() != null) {
           copy.getTransform().setChanged();
         }
+      } else {
+        // Copying location / row distribution uses setters that flip wrapperChanged. A snapshot of
+        // an unchanged transform must stay unchanged so dialog OK-without-edits is not dirty.
+        copy.setChanged(false);
       }
     } else {
       // Explicitly clear changed state if not preserving it

--- a/engine/src/main/java/org/apache/hop/workflow/action/copy/DefaultActionCopyFactory.java
+++ b/engine/src/main/java/org/apache/hop/workflow/action/copy/DefaultActionCopyFactory.java
@@ -202,11 +202,14 @@ public class DefaultActionCopyFactory implements IActionCopyFactory {
         copy.setParentWorkflowMeta(source.getParentWorkflowMeta());
       }
 
-      // Apply changed state based on context - this fixes the race condition
-      if (context.isPreserveChangedState()) {
-        // This will call setChanged() which sets the changed state on the underlying action
+      // Apply changed state based on context. Copying location uses setters that flip
+      // wrapperChanged, so a snapshot of an unchanged action must be cleared when the source is
+      // clean. Always marking the copy changed made dialog OK-without-edits look like a real edit.
+      if (context.isPreserveChangedState() && source.hasChanged()) {
         copy.setChanged();
         log.logRowlevel("Set changed state on copied ActionMeta");
+      } else {
+        copy.setChanged(false);
       }
 
       log.logRowlevel("Successfully copied ActionMeta");

--- a/engine/src/test/java/org/apache/hop/core/undo/XmlSnapshotUndoTest.java
+++ b/engine/src/test/java/org/apache/hop/core/undo/XmlSnapshotUndoTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hop.core.HopEnvironment;
 import org.apache.hop.core.NotePadMeta;
+import org.apache.hop.core.xml.XmlHandler;
 import org.apache.hop.metadata.serializer.memory.MemoryMetadataProvider;
 import org.apache.hop.pipeline.PipelineHopMeta;
 import org.apache.hop.pipeline.PipelineMeta;
@@ -151,6 +152,16 @@ class XmlSnapshotUndoTest {
     byte[] first = undo.captureSnapshot(pipelineMeta, metadataProvider);
     byte[] second = undo.captureSnapshot(pipelineMeta, metadataProvider);
     assertTrue(XmlSnapshotUndo.sameXmlContent(first, second));
+  }
+
+  @Test
+  void sameXmlContentTreatsOmittedAndEmptyElementsAsEqual() throws Exception {
+    String omitted = XmlHandler.aroundTag("pipeline", "<transform><name>A</name></transform>");
+    String empty =
+        XmlHandler.aroundTag("pipeline", "<transform><name>A</name><message/></transform>");
+    assertTrue(
+        XmlSnapshotUndo.sameXmlContent(
+            XmlSnapshotUndo.compress(omitted), XmlSnapshotUndo.compress(empty)));
   }
 
   @Test

--- a/engine/src/test/java/org/apache/hop/pipeline/transform/copy/DefaultTransformMetaCopyFactoryTest.java
+++ b/engine/src/test/java/org/apache/hop/pipeline/transform/copy/DefaultTransformMetaCopyFactoryTest.java
@@ -182,4 +182,18 @@ class DefaultTransformMetaCopyFactoryTest {
     assertTrue(
         cloned.getTransform().hasChanged(), "Clone inner transform should preserve changed state");
   }
+
+  @Test
+  void copyOfUnchangedTransformIsNotMarkedChanged() {
+    sourceTransformMeta.setLocation(50, 80);
+    sourceTransformMeta.setChanged(false);
+    dummyMeta.setChanged(false);
+
+    TransformMeta copy = factory.copy(sourceTransformMeta, CopyContext.DEFAULT);
+
+    assertFalse(sourceTransformMeta.hasChanged(), "Source should stay unchanged");
+    assertFalse(
+        copy.hasChanged(),
+        "Copying a clean transform must not mark the copy changed (location/row-distribution setters used to flip wrapperChanged)");
+  }
 }

--- a/engine/src/test/java/org/apache/hop/workflow/action/copy/DefaultActionCopyFactoryTest.java
+++ b/engine/src/test/java/org/apache/hop/workflow/action/copy/DefaultActionCopyFactoryTest.java
@@ -197,6 +197,17 @@ class DefaultActionCopyFactoryTest {
   }
 
   @Test
+  void copyOfUnchangedActionMetaIsNotMarkedChanged() {
+    sourceActionMeta.setLocation(40, 60);
+    sourceActionMeta.setChanged(false);
+
+    ActionMeta copy = factory.copy(sourceActionMeta, CopyContext.DEFAULT);
+
+    assertFalse(sourceActionMeta.hasChanged(), "Source should stay unchanged");
+    assertFalse(copy.hasChanged(), "Copying a clean action must not mark the copy changed");
+  }
+
+  @Test
   void testIntegrationWithReplaceMeta() {
     // Test that replaceMeta now uses the copy factory
     ActionMeta target = new ActionMeta();

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/delegates/HopGuiPipelineTransformDelegate.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/delegates/HopGuiPipelineTransformDelegate.java
@@ -39,6 +39,7 @@ import org.apache.hop.core.security.Permission;
 import org.apache.hop.core.util.StringUtil;
 import org.apache.hop.core.util.Utils;
 import org.apache.hop.core.variables.IVariables;
+import org.apache.hop.core.xml.XmlHandler;
 import org.apache.hop.history.AuditManager;
 import org.apache.hop.i18n.BaseMessages;
 import org.apache.hop.pipeline.IPartitioner;
@@ -200,6 +201,9 @@ public class HopGuiPipelineTransformDelegate {
       dialog = getTransformDialog(transformMeta.getTransform(), pipelineMeta, name);
       TransformMeta before = null;
       byte[] beforeSnapshot = null;
+      // Capture from the live object. A clone is often already "changed" because copying location
+      // or row distribution goes through setters that flip wrapperChanged.
+      boolean alreadyChanged = transformMeta.hasChanged();
       if (dialog != null) {
         dialogs.put(name, dialog);
 
@@ -267,7 +271,7 @@ public class HopGuiPipelineTransformDelegate {
         if (hasTransformMetaChanged(before, after)) {
           transformMeta.setChanged();
         } else {
-          transformMeta.setChanged(before.hasChanged());
+          transformMeta.setChanged(alreadyChanged);
         }
       }
       pipelineGraph.updateGui();
@@ -547,6 +551,7 @@ public class HopGuiPipelineTransformDelegate {
   }
 
   public void editTransformPartitioning(PipelineMeta pipelineMeta, TransformMeta transformMeta) {
+    boolean alreadyChanged = transformMeta.hasChanged();
     byte[] beforeSnapshot = pipelineGraph.captureUndoSnapshot();
     String[] schemaNames;
     try {
@@ -610,7 +615,7 @@ public class HopGuiPipelineTransformDelegate {
         if (hasTransformMetaChanged(partitionBefore, partitionAfter)) {
           transformMeta.setChanged();
         } else {
-          transformMeta.setChanged(partitionBefore.hasChanged());
+          transformMeta.setChanged(alreadyChanged);
         }
         pipelineGraph.redraw();
       }
@@ -676,6 +681,7 @@ public class HopGuiPipelineTransformDelegate {
       List<TransformMeta> targetTransforms = pipelineMeta.findNextTransforms(transformMeta, true);
 
       // now edit this transformErrorMeta object:
+      boolean alreadyChanged = transformMeta.hasChanged();
       TransformMeta before = (TransformMeta) transformMeta.clone();
       byte[] beforeSnapshot = pipelineGraph.captureUndoSnapshot();
       TransformErrorMetaDialog dialog =
@@ -693,7 +699,7 @@ public class HopGuiPipelineTransformDelegate {
         if (hasTransformMetaChanged(before, after)) {
           transformMeta.setChanged();
         } else {
-          transformMeta.setChanged(before.hasChanged());
+          transformMeta.setChanged(alreadyChanged);
         }
         pipelineGraph.redraw();
       }
@@ -703,14 +709,19 @@ public class HopGuiPipelineTransformDelegate {
   /**
    * Returns {@code true} if two transform snapshots differ in persisted configuration (transform
    * body, partitioning, GUI placement, and error handling).
+   *
+   * <p>Omitted XML elements ({@code null} fields) and empty elements ({@code <tag/>} from an empty
+   * string) are treated as the same so a dialog OK that only round-trips widget text does not mark
+   * the pipeline dirty. Serialization still writes them differently.
    */
   private static boolean hasTransformMetaChanged(TransformMeta before, TransformMeta after) {
     try {
-      if (!before.getXml().equals(after.getXml())) {
+      if (!XmlHandler.sameContentIgnoringEmptyValues(before.getXml(), after.getXml())) {
         return true;
       }
 
-      return !getErrorMetaXml(before).equals(getErrorMetaXml(after));
+      return !XmlHandler.sameContentIgnoringEmptyValues(
+          getErrorMetaXml(before), getErrorMetaXml(after));
     } catch (HopException e) {
       // If comparison fails, treat as changed to avoid losing edits.
       return true;

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/delegates/HopGuiWorkflowActionDelegate.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/delegates/HopGuiWorkflowActionDelegate.java
@@ -28,6 +28,7 @@ import org.apache.hop.core.plugins.IPlugin;
 import org.apache.hop.core.plugins.PluginRegistry;
 import org.apache.hop.core.security.Permission;
 import org.apache.hop.core.variables.IVariables;
+import org.apache.hop.core.xml.XmlHandler;
 import org.apache.hop.i18n.BaseMessages;
 import org.apache.hop.ui.core.PropsUi;
 import org.apache.hop.ui.core.dialog.BaseDialog;
@@ -292,6 +293,8 @@ public class HopGuiWorkflowActionDelegate {
       }
 
       byte[] beforeSnapshot = workflowGraph.captureUndoSnapshot();
+      boolean alreadyChanged = action.hasChanged();
+      String beforeXml = action.getXml();
 
       IAction jei = action.getAction();
 
@@ -305,6 +308,11 @@ public class HopGuiWorkflowActionDelegate {
           //
           workflowMeta.renameActionIfNameCollides(action);
           workflowGraph.commitDialogUndo(beforeSnapshot);
+          if (hasActionMetaChanged(beforeXml, action.getXml())) {
+            action.setChanged();
+          } else {
+            action.setChanged(alreadyChanged);
+          }
         }
         workflowGraph.updateGui();
       } else {
@@ -403,5 +411,15 @@ public class HopGuiWorkflowActionDelegate {
     workflowMeta.addAction(copyOfAction);
 
     workflowGraph.updateGui();
+  }
+
+  /**
+   * Returns {@code true} if two action snapshots differ in persisted configuration. Omitted XML
+   * elements ({@code null} fields) and empty elements ({@code <tag/>} from an empty string) are
+   * treated as the same so a dialog OK that only round-trips widget text does not mark the workflow
+   * dirty.
+   */
+  private static boolean hasActionMetaChanged(String beforeXml, String afterXml) {
+    return !XmlHandler.sameContentIgnoringEmptyValues(beforeXml, afterXml);
   }
 }


### PR DESCRIPTION
Opening a transform or action, changing nothing, and clicking OK used to mark the pipeline or workflow as needing save. Cancel or closing the dialog without OK did not. This was easy to hit on every component, because it came from the shared OK path rather than from one plugin.


## How it works

Two separate false positives were stacked:

1. **SWT widgets turn `null` into `""`.** `XmlMetadataUtil` omits a `null` field and writes `<tag/>` for an empty string. Dialog `getInfo()` / `ok()` always writes widget text back, so OK without edits produced XML that failed a string equals. Comparison now uses `XmlHandler.sameContentIgnoringEmptyValues`, which treats an omitted element as the same as an empty one. Undo snapshot compare uses the same helper. Disk format is unchanged: `null` is still omitted, `""` is still a tag.

2. **The dirty flag was restored from a clone.** After OK, the delegate did `setChanged(before.hasChanged())` when XML matched. Copying a transform or action goes through `setLocation` / `setRowDistribution`, and those setters flip `wrapperChanged`. A clone of a clean object therefore looked dirty, so OK without edits still marked the file changed. The live `hasChanged()` flag from before the dialog is used instead. Copy factories also clear that induced flag when the source is unchanged.

Workflow actions had no XML compare at all. Several dialogs call `setChanged()` unconditionally on OK (Start is the obvious case). They now use the same omitted-vs-empty comparison, then restore the live flag when content did not change.

Entry points:

* `HopGuiPipelineTransformDelegate` (transform dialog, partitioning, error handling)
* `HopGuiWorkflowActionDelegate`
* `DefaultTransformMetaCopyFactory` / `DefaultActionCopyFactory`

## Tests

* `XmlHandlerUnitTest` (omitted vs `<tag/>` / `<tag></tag>`, nested empty shells, real text still detected, trailing empty list item)
* `XmlMetadataUtilTest.nullAndEmptyStringSerializeDifferentlyButCompareEqualForChangeDetection`
* `XmlSnapshotUndoTest.sameXmlContentTreatsOmittedAndEmptyElementsAsEqual`
* `DefaultTransformMetaCopyFactoryTest.copyOfUnchangedTransformIsNotMarkedChanged`
* `DefaultActionCopyFactoryTest.copyOfUnchangedActionMetaIsNotMarkedChanged`