### PR TITLE
Fix#8260  Keep Database Lookup length and precision when a return Type is set

### DIFF
--- a/plugins/transforms/databaselookup/src/main/java/org/apache/hop/pipeline/transforms/databaselookup/DatabaseLookupMeta.java
+++ b/plugins/transforms/databaselookup/src/main/java/org/apache/hop/pipeline/transforms/databaselookup/DatabaseLookupMeta.java
@@ -119,6 +119,8 @@ public class DatabaseLookupMeta extends BaseTransformMeta<DatabaseLookup, Databa
     try {
       // Prefer an explicit return type. When none is configured, infer from table field
       // metadata (info row from design-time / runtime, otherwise query the table).
+      // When a type is set, still clone the table field so length, precision, conversion
+      // mask and original JDBC metadata are kept (issue #8260).
       //
       IRowMeta tableFields = null;
       if (!Utils.isEmpty(infoRowMeta) && infoRowMeta[0] != null) {
@@ -131,19 +133,35 @@ public class DatabaseLookupMeta extends BaseTransformMeta<DatabaseLookup, Databa
                 ? returnValue.getNewName()
                 : returnValue.getTableField();
         int typeId = ValueMetaFactory.getIdForValueMeta(returnValue.getDefaultType());
+        IValueMeta source = tableField(tableFields, returnValue.getTableField());
+        if (source == null && tableFields == null) {
+          try {
+            tableFields = getTableFields(variables);
+          } catch (Exception e) {
+            if (typeId == IValueMeta.TYPE_NONE) {
+              if (e instanceof HopException hopException) {
+                throw hopException;
+              }
+              throw new HopException(e);
+            }
+          }
+          source = tableField(tableFields, returnValue.getTableField());
+        }
+
         IValueMeta v;
         if (typeId != IValueMeta.TYPE_NONE) {
-          v = ValueMetaFactory.createValueMeta(fieldName, typeId);
-        } else {
-          if (tableFields == null) {
-            tableFields = getTableFields(variables);
+          if (source != null) {
+            v = ValueMetaFactory.cloneValueMeta(source, typeId);
+            v.setName(fieldName);
+          } else {
+            v = ValueMetaFactory.createValueMeta(fieldName, typeId);
           }
+        } else {
           if (tableFields == null) {
             throw new HopTransformException(
                 BaseMessages.getString(
                     PKG, "DatabaseLookupMeta.Exception.UnableToRetrieveDataTypeOfReturnField"));
           }
-          IValueMeta source = tableFields.searchValueMeta(returnValue.getTableField());
           if (source == null) {
             throw new HopTransformException(
                 BaseMessages.getString(
@@ -359,6 +377,10 @@ public class DatabaseLookupMeta extends BaseTransformMeta<DatabaseLookup, Databa
               transformMeta);
       remarks.add(cr);
     }
+  }
+
+  private static IValueMeta tableField(IRowMeta tableFields, String name) {
+    return tableFields == null ? null : tableFields.searchValueMeta(name);
   }
 
   @Override

--- a/plugins/transforms/databaselookup/src/test/java/org/apache/hop/pipeline/transforms/databaselookup/DatabaseLookupMetaTest.java
+++ b/plugins/transforms/databaselookup/src/test/java/org/apache/hop/pipeline/transforms/databaselookup/DatabaseLookupMetaTest.java
@@ -200,7 +200,7 @@ class DatabaseLookupMetaTest {
 
     IRowMeta[] info = new IRowMeta[1];
     info[0] = new RowMeta();
-    info[0].addValueMeta(new ValueMetaInteger("amount"));
+    info[0].addValueMeta(new ValueMetaInteger("amount", 9, 0));
 
     IRowMeta row = new RowMeta();
     databaseLookupMeta.getFields(row, "Database lookup", info, null, null, null);
@@ -209,6 +209,69 @@ class DatabaseLookupMetaTest {
     IValueMeta amount = row.searchValueMeta("amount");
     assertNotNull(amount);
     assertEquals(IValueMeta.TYPE_STRING, amount.getType());
+    assertEquals(9, amount.getLength());
+    // String fields always report precision -1 (ValueMetaBase.getPrecision)
+    assertEquals(-1, amount.getPrecision());
+  }
+
+  @Test
+  void getFieldsKeepsLengthWhenConfiguredTypeMatchesTable() throws Exception {
+    Lookup lookup = databaseLookupMeta.getLookup();
+    lookup
+        .getReturnValues()
+        .add(
+            new ReturnValue(
+                "description",
+                "",
+                "",
+                "String",
+                ValueMetaString.getTrimTypeCode(IValueMeta.TRIM_TYPE_NONE)));
+
+    ValueMetaString tableField = new ValueMetaString("description", 30, -1);
+    tableField.setComments("dictionary_value");
+    tableField.setConversionMask("#");
+
+    IRowMeta[] info = new IRowMeta[1];
+    info[0] = new RowMeta();
+    info[0].addValueMeta(tableField);
+
+    IRowMeta row = new RowMeta();
+    databaseLookupMeta.getFields(row, "lookup type set", info, null, null, null);
+
+    IValueMeta description = row.searchValueMeta("description");
+    assertNotNull(description);
+    assertEquals(IValueMeta.TYPE_STRING, description.getType());
+    assertEquals(30, description.getLength());
+    assertEquals(-1, description.getPrecision());
+    assertEquals("#", description.getConversionMask());
+    assertEquals("dictionary_value", description.getComments());
+    assertEquals("lookup type set", description.getOrigin());
+  }
+
+  @Test
+  void getFieldsStillCreatesTypeWhenTableFieldIsMissing() throws Exception {
+    Lookup lookup = databaseLookupMeta.getLookup();
+    lookup
+        .getReturnValues()
+        .add(
+            new ReturnValue(
+                "description",
+                "",
+                "",
+                "String",
+                ValueMetaString.getTrimTypeCode(IValueMeta.TRIM_TYPE_NONE)));
+
+    IRowMeta[] info = new IRowMeta[1];
+    info[0] = new RowMeta();
+    info[0].addValueMeta(new ValueMetaString("other"));
+
+    IRowMeta row = new RowMeta();
+    databaseLookupMeta.getFields(row, "Database lookup", info, null, null, null);
+
+    IValueMeta description = row.searchValueMeta("description");
+    assertNotNull(description);
+    assertEquals(IValueMeta.TYPE_STRING, description.getType());
+    assertEquals(-1, description.getLength());
   }
 
   @Test


### PR DESCRIPTION
Fix https://github.com/apache/hop/issues/8260

## Summary
- Database Lookup's Get Fields always fills the Type column (for example String). After that, Hop built a brand-new output field and threw away the table's length. A `varchar(100)` column became String with no length (`-`), so Table Output / bulk loaders could generate the wrong DDL.
- This change still honors the Type you configure. It copies length, precision, mask, and JDBC comments from the table column instead of starting from an empty field. If the table column cannot be found, behavior is unchanged.