### PR TITLE
Issue #8284 : Set PROJECT_HOME when hop-server enables a project

### DIFF
--- a/docker/integration-tests/integration-tests-hop_server.yaml
+++ b/docker/integration-tests/integration-tests-hop_server.yaml
@@ -39,6 +39,13 @@ services:
     build:
       context: ../../.
       dockerfile: docker/Dockerfile
+      # Same uid/gid as the test runner (JENKINS_UID from run-tests-docker.sh).
+      # hop-server writes mapped folders on /hop_server_volume (the host
+      # integration-tests/hop_server tree). The default image user is 501, so a
+      # 775 directory owned by the host user is AccessDenied (main-0015).
+      args:
+        - HOP_UID=${JENKINS_UID:-1000}
+        - HOP_GID=${JENKINS_GID:-1000}
     pull_policy: never
     hostname: hop-server
     ports:
@@ -50,6 +57,8 @@ services:
       - HOP_PROJECT_NAME=samples
       - HOP_PROJECT_FOLDER=/opt/hop/config/projects/samples
       - HOP_PROJECT_CONFIG_FILE_NAME=project-config.json
+      - HOP_ENVIRONMENT_NAME=server-dev
+      - HOP_ENVIRONMENT_CONFIG_FILE_NAME_PATHS=/hop_server_volume/server-env-config.json
     volumes:
       - ./../../integration-tests/hop_server/:/hop_server_volume
     healthcheck:

--- a/engine/src/main/java/org/apache/hop/pipeline/PipelineMeta.java
+++ b/engine/src/main/java/org/apache/hop/pipeline/PipelineMeta.java
@@ -1546,7 +1546,7 @@ public class PipelineMeta extends AbstractMeta
     // OK, try to load using the VFS stuff...
     Document doc;
     try {
-      final FileObject pipelineFile = HopVfs.getFileObject(filename);
+      final FileObject pipelineFile = HopVfs.getFileObject(filename, parentVariableSpace);
       if (!pipelineFile.exists()) {
         throw new HopXmlException(
             BaseMessages.getString(PKG, "PipelineMeta.Exception.InvalidXMLPath", filename));

--- a/engine/src/main/java/org/apache/hop/workflow/WorkflowMeta.java
+++ b/engine/src/main/java/org/apache/hop/workflow/WorkflowMeta.java
@@ -392,7 +392,7 @@ public class WorkflowMeta extends AbstractMeta
       throws HopXmlException {
     try {
       // OK, try to load using the VFS stuff...
-      Document doc = XmlHandler.loadXmlFile(HopVfs.getFileObject(filename));
+      Document doc = XmlHandler.loadXmlFile(HopVfs.getFileObject(filename, variables));
       if (doc != null) {
         // The workflowNode
         Node workflowNode = XmlHandler.getSubNode(doc, XML_TAG);

--- a/engine/src/main/java/org/apache/hop/www/BaseHttpServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/BaseHttpServlet.java
@@ -56,7 +56,7 @@ public class BaseHttpServlet extends HttpServlet {
 
   @Setter @Getter protected WorkflowMap workflowMap;
 
-  @Setter @Getter protected HopServerConfig serverConfig;
+  @Setter protected HopServerConfig serverConfig;
   protected IVariables variables;
 
   @Setter @Getter protected boolean supportGraphicEnvironment;
@@ -383,8 +383,52 @@ public class BaseHttpServlet extends HttpServlet {
   public void setup(PipelineMap pipelineMap, WorkflowMap workflowMap) {
     this.pipelineMap = pipelineMap;
     this.workflowMap = workflowMap;
-    this.serverConfig = pipelineMap.getHopServerConfig();
-    this.variables = serverConfig.getVariables();
+    this.serverConfig = pipelineMap != null ? pipelineMap.getHopServerConfig() : null;
+    HopServerConfig config = getServerConfig();
+    this.variables =
+        config != null && config.getVariables() != null
+            ? config.getVariables()
+            : Variables.getADefaultVariableSpace();
+  }
+
+  /**
+   * The config the pipeline or workflow map currently holds. Read back on every call so replacing
+   * the config after {@link #setup(PipelineMap, WorkflowMap)} (as hop-server does when it loads
+   * hop-server.xml) is visible to servlets. Same idea as {@code HopServerApiContext}.
+   */
+  public HopServerConfig getServerConfig() {
+    if (pipelineMap != null && pipelineMap.getHopServerConfig() != null) {
+      return pipelineMap.getHopServerConfig();
+    }
+    if (workflowMap != null && workflowMap.getHopServerConfig() != null) {
+      return workflowMap.getHopServerConfig();
+    }
+    return serverConfig;
+  }
+
+  /**
+   * Live variable space of this server. Project and environment variables such as {@code
+   * PROJECT_HOME} live here after {@code -j}/{@code -e} at startup.
+   */
+  protected IVariables getServletVariables() {
+    HopServerConfig config = getServerConfig();
+    if (config != null && config.getVariables() != null) {
+      return config.getVariables();
+    }
+    if (variables != null) {
+      return variables;
+    }
+    return Variables.getADefaultVariableSpace();
+  }
+
+  /**
+   * A per-request copy of {@link #getServletVariables()} so query parameters cannot leak into the
+   * server-wide space.
+   */
+  protected IVariables copyServletVariables() {
+    IVariables copy = new Variables();
+    copy.copyFrom(getServletVariables());
+    return copy;
   }
 
   private String getContentEncoding(String contentTypeValue) {

--- a/engine/src/main/java/org/apache/hop/www/ExecPipelineServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/ExecPipelineServlet.java
@@ -35,6 +35,7 @@ import org.apache.hop.core.logging.LoggingObjectType;
 import org.apache.hop.core.logging.SimpleLoggingObject;
 import org.apache.hop.core.metadata.SerializableMetadataProvider;
 import org.apache.hop.core.util.Utils;
+import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.metadata.api.IHopMetadataProvider;
 import org.apache.hop.pipeline.PipelineConfiguration;
 import org.apache.hop.pipeline.PipelineExecutionConfiguration;
@@ -129,6 +130,9 @@ public class ExecPipelineServlet extends BaseHttpServlet implements IHopServerPl
       return;
     }
 
+    IVariables requestVars = copyServletVariables();
+    String resolvedPipelinePath = requestVars.resolve(pipelineOption);
+
     try {
       // Get metadata provider from server config
       IHopMetadataProvider metadataProvider = getServerConfig().getMetadataProvider();
@@ -136,12 +140,11 @@ public class ExecPipelineServlet extends BaseHttpServlet implements IHopServerPl
         throw new HopException("Metadata provider is not available");
       }
 
-      // Resolve variables in the pipeline path (e.g., ${PROJECT_HOME})
-      String resolvedPipelinePath = variables.resolve(pipelineOption);
-
-      // Load pipeline from file
+      // Load pipeline from file. Path is resolved against a per-request copy of the server
+      // variables so ${PROJECT_HOME} (and environment config vars) work, and query parameters
+      // cannot leak into the server-wide space. See issue #8284.
       PipelineMeta pipelineMeta =
-          new PipelineMeta(resolvedPipelinePath, metadataProvider, variables);
+          new PipelineMeta(resolvedPipelinePath, metadataProvider, requestVars);
 
       // Set the servlet parameters as variables/parameters in the pipeline
       String[] parameters = pipelineMeta.listParameters();
@@ -155,7 +158,7 @@ public class ExecPipelineServlet extends BaseHttpServlet implements IHopServerPl
           // If it's a pipeline parameter, it will be set later via setParameterValue
           // Otherwise, set as variable
           if (Const.indexOfString(parameter, parameters) < 0) {
-            variables.setVariable(parameter, values[0]);
+            requestVars.setVariable(parameter, values[0]);
           }
         }
       }
@@ -202,8 +205,8 @@ public class ExecPipelineServlet extends BaseHttpServlet implements IHopServerPl
       // Create the pipeline engine using the run configuration from execution configuration
       IPipelineEngine<PipelineMeta> pipeline =
           PipelineEngineFactory.createPipelineEngine(
-              variables,
-              variables.resolve(pipelineExecutionConfiguration.getRunConfiguration()),
+              requestVars,
+              requestVars.resolve(pipelineExecutionConfiguration.getRunConfiguration()),
               metadataProvider,
               pipelineMeta);
       pipeline.setParent(servletLoggingObject);
@@ -256,7 +259,7 @@ public class ExecPipelineServlet extends BaseHttpServlet implements IHopServerPl
         String safePipelineOption =
             pipelineOption != null ? Encode.forHtml(pipelineOption) : "null";
         String safeResolved =
-            pipelineOption != null ? Encode.forHtml(variables.resolve(pipelineOption)) : "null";
+            resolvedPipelinePath != null ? Encode.forHtml(resolvedPipelinePath) : "null";
         WebResult notFound =
             new WebResult(
                 WebResult.STRING_ERROR,

--- a/engine/src/main/java/org/apache/hop/www/ExecWorkflowServlet.java
+++ b/engine/src/main/java/org/apache/hop/www/ExecWorkflowServlet.java
@@ -35,6 +35,7 @@ import org.apache.hop.core.logging.LogLevel;
 import org.apache.hop.core.logging.LoggingObjectType;
 import org.apache.hop.core.logging.SimpleLoggingObject;
 import org.apache.hop.core.util.Utils;
+import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.metadata.api.IHopMetadataProvider;
 import org.apache.hop.workflow.WorkflowConfiguration;
 import org.apache.hop.workflow.WorkflowExecutionConfiguration;
@@ -129,6 +130,9 @@ public class ExecWorkflowServlet extends BaseHttpServlet implements IHopServerPl
       return;
     }
 
+    IVariables requestVars = copyServletVariables();
+    String resolvedWorkflowPath = requestVars.resolve(workflowOption);
+
     try {
       // Get metadata provider from server config
       IHopMetadataProvider metadataProvider = getServerConfig().getMetadataProvider();
@@ -136,12 +140,11 @@ public class ExecWorkflowServlet extends BaseHttpServlet implements IHopServerPl
         throw new HopException("Metadata provider is not available");
       }
 
-      // Resolve variables in the workflow path (e.g., ${PROJECT_HOME})
-      String resolvedWorkflowPath = variables.resolve(workflowOption);
-
-      // Load workflow from file
+      // Load workflow from file. Path is resolved against a per-request copy of the server
+      // variables so ${PROJECT_HOME} (and environment config vars) work, and query parameters
+      // cannot leak into the server-wide space. See issue #8284.
       WorkflowMeta workflowMeta =
-          new WorkflowMeta(variables, resolvedWorkflowPath, metadataProvider);
+          new WorkflowMeta(requestVars, resolvedWorkflowPath, metadataProvider);
 
       // Set the servlet parameters as variables/parameters in the workflow
       String[] parameters = workflowMeta.listParameters();
@@ -155,7 +158,7 @@ public class ExecWorkflowServlet extends BaseHttpServlet implements IHopServerPl
           // If it's a workflow parameter, it will be set later via setParameterValue
           // Otherwise, set as variable
           if (Const.indexOfString(parameter, parameters) < 0) {
-            variables.setVariable(parameter, values[0]);
+            requestVars.setVariable(parameter, values[0]);
           }
         }
       }
@@ -202,8 +205,8 @@ public class ExecWorkflowServlet extends BaseHttpServlet implements IHopServerPl
       // Create the workflow engine using the run configuration from execution configuration
       IWorkflowEngine<WorkflowMeta> workflow =
           WorkflowEngineFactory.createWorkflowEngine(
-              variables,
-              variables.resolve(workflowExecutionConfiguration.getRunConfiguration()),
+              requestVars,
+              requestVars.resolve(workflowExecutionConfiguration.getRunConfiguration()),
               metadataProvider,
               workflowMeta,
               servletLoggingObject);
@@ -254,7 +257,7 @@ public class ExecWorkflowServlet extends BaseHttpServlet implements IHopServerPl
         String safeWorkflowOption =
             workflowOption != null ? Encode.forHtml(workflowOption) : "null";
         String safeResolved =
-            workflowOption != null ? Encode.forHtml(variables.resolve(workflowOption)) : "null";
+            resolvedWorkflowPath != null ? Encode.forHtml(resolvedWorkflowPath) : "null";
         WebResult notFound =
             new WebResult(
                 WebResult.STRING_ERROR,

--- a/engine/src/main/java/org/apache/hop/www/HopServer.java
+++ b/engine/src/main/java/org/apache/hop/www/HopServer.java
@@ -438,10 +438,23 @@ public class HopServer implements Runnable, IHasHopMetadataProvider, IHopCommand
         setupByHostNameAndPort(hostname, port);
       }
 
-      // Pass the variables and metadata provider
+      // Root-level options such as --project / --environment enable the project before this
+      // subcommand runs. Use that metadata provider when it was rebuilt against the project folder.
+      //
+      MultiMetadataProvider instanceProvider = HopMetadataInstance.getMetadataProvider();
+      if (instanceProvider != null
+          && StringUtils.isNotEmpty(variables.getVariable(Const.HOP_METADATA_FOLDER))) {
+        metadataProvider = instanceProvider;
+      }
+
+      // Pass the variables and metadata provider. setupByFileName / setupByHostNameAndPort
+      // replace this.config with a new HopServerConfig whose constructor variables do not
+      // contain PROJECT_HOME; reconnect the space that enableProject() just populated.
       //
       config.setVariables(variables);
       config.setMetadataProvider(metadataProvider);
+
+      logEnabledProjectVariables();
 
       // enable auth
       if (this.enableAuth != null) {
@@ -737,6 +750,36 @@ public class HopServer implements Runnable, IHasHopMetadataProvider, IHopCommand
       System.err.println("General error found, something went horribly wrong!");
       System.err.println(Const.getStackTracker(e));
       System.exit(2);
+    }
+  }
+
+  /**
+   * After mixins have run, log the project/environment identity the servlets will resolve against.
+   * A project name without PROJECT_HOME means enablement did not land on this variable space, and
+   * {@code /hop/execPipeline?pipeline=${PROJECT_HOME}/...} would fail. See issue #8284.
+   */
+  void logEnabledProjectVariables() throws HopException {
+    if (variables == null || log == null) {
+      return;
+    }
+    String projectName = variables.getVariable("HOP_PROJECT_NAME");
+    String environmentName = variables.getVariable("HOP_ENVIRONMENT_NAME");
+    String projectHome = variables.getVariable("PROJECT_HOME");
+    String metadataFolder = variables.getVariable(Const.HOP_METADATA_FOLDER);
+    log.logBasic(
+        "Hop Server variables: HOP_PROJECT_NAME="
+            + Const.NVL(projectName, "")
+            + ", HOP_ENVIRONMENT_NAME="
+            + Const.NVL(environmentName, "")
+            + ", PROJECT_HOME="
+            + Const.NVL(projectHome, "")
+            + ", HOP_METADATA_FOLDER="
+            + Const.NVL(metadataFolder, ""));
+    if (StringUtils.isNotEmpty(projectName) && StringUtils.isEmpty(projectHome)) {
+      throw new HopException(
+          "Project '"
+              + projectName
+              + "' is enabled but PROJECT_HOME is not set. Pipelines and workflows cannot resolve ${PROJECT_HOME}.");
     }
   }
 

--- a/engine/src/test/java/org/apache/hop/www/BaseHttpServletTest.java
+++ b/engine/src/test/java/org/apache/hop/www/BaseHttpServletTest.java
@@ -42,6 +42,8 @@ import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import org.apache.hop.core.exception.HopRuntimeException;
 import org.apache.hop.core.logging.ILogChannel;
+import org.apache.hop.core.variables.IVariables;
+import org.apache.hop.core.variables.Variables;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -53,6 +55,56 @@ class BaseHttpServletTest {
   void setUp() {
     servlet = new BaseHttpServlet();
     servlet.setLog(mock(ILogChannel.class));
+  }
+
+  @Test
+  void getServletVariablesReadsLiveConfigAfterReplacement() {
+    PipelineMap pipelineMap = new PipelineMap();
+    HopServerConfig config = new HopServerConfig();
+    IVariables first = new Variables();
+    first.setVariable("PROJECT_HOME", "/tmp/project-a");
+    config.setVariables(first);
+    pipelineMap.setHopServerConfig(config);
+
+    servlet.setup(pipelineMap, null);
+    assertEquals("/tmp/project-a", servlet.getServletVariables().getVariable("PROJECT_HOME"));
+
+    IVariables second = new Variables();
+    second.setVariable("PROJECT_HOME", "/tmp/project-b");
+    config.setVariables(second);
+    assertEquals("/tmp/project-b", servlet.getServletVariables().getVariable("PROJECT_HOME"));
+  }
+
+  @Test
+  void copyServletVariablesDoesNotMutateServerSpace() {
+    PipelineMap pipelineMap = new PipelineMap();
+    HopServerConfig config = new HopServerConfig();
+    IVariables serverVars = new Variables();
+    serverVars.setVariable("PROJECT_HOME", "/tmp/project");
+    config.setVariables(serverVars);
+    pipelineMap.setHopServerConfig(config);
+
+    servlet.setup(pipelineMap, null);
+    IVariables copy = servlet.copyServletVariables();
+    copy.setVariable("FOO", "bar");
+
+    assertEquals("/tmp/project", copy.getVariable("PROJECT_HOME"));
+    assertEquals("bar", copy.getVariable("FOO"));
+    assertNull(config.getVariables().getVariable("FOO"));
+    assertEquals("/tmp/project", config.getVariables().getVariable("PROJECT_HOME"));
+  }
+
+  @Test
+  void getServerConfigPrefersPipelineMapOverField() {
+    HopServerConfig fieldConfig = new HopServerConfig();
+    servlet.setServerConfig(fieldConfig);
+
+    PipelineMap pipelineMap = new PipelineMap();
+    HopServerConfig mapConfig = new HopServerConfig();
+    pipelineMap.setHopServerConfig(mapConfig);
+    servlet.setPipelineMap(pipelineMap);
+
+    assertEquals(mapConfig, servlet.getServerConfig());
   }
 
   @Test

--- a/engine/src/test/java/org/apache/hop/www/ExecPipelineServletTest.java
+++ b/engine/src/test/java/org/apache/hop/www/ExecPipelineServletTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hop.www;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.List;
+import java.util.Vector;
+import org.apache.hop.core.encryption.Encr;
+import org.apache.hop.core.variables.IVariables;
+import org.apache.hop.core.variables.Variables;
+import org.apache.hop.junit.rules.RestoreHopEngineEnvironmentExtension;
+import org.apache.hop.metadata.serializer.multi.MultiMetadataProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(RestoreHopEngineEnvironmentExtension.class)
+class ExecPipelineServletTest {
+
+  private HopServerConfig config;
+  private IVariables serverVariables;
+  private ExecPipelineServlet servlet;
+
+  @BeforeEach
+  void setUp() {
+    serverVariables = new Variables();
+    serverVariables.setVariable("PROJECT_HOME", "/tmp/issue-8284-home");
+
+    config = new HopServerConfig();
+    config.setVariables(serverVariables);
+    config.setMetadataProvider(
+        new MultiMetadataProvider(Encr.getEncoder(), List.of(), serverVariables));
+
+    PipelineMap pipelineMap = new PipelineMap();
+    pipelineMap.setHopServerConfig(config);
+    servlet = new ExecPipelineServlet(pipelineMap);
+    servlet.setJettyMode(false);
+  }
+
+  @Test
+  void projectHomeInPipelinePathIsResolvedFromServerVariables() throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter out = new StringWriter();
+    when(response.getWriter()).thenReturn(new PrintWriter(out));
+    when(request.getParameter("pipeline")).thenReturn("${PROJECT_HOME}/missing.hpl");
+    when(request.getParameterNames()).thenReturn(new Vector<>(List.of("pipeline")).elements());
+
+    servlet.doGet(request, response);
+
+    String body = out.toString();
+    assertTrue(
+        body.contains("/tmp/issue-8284-home/missing.hpl"),
+        "resolved path should appear in the error: " + body);
+    assertFalse(body.contains("${PROJECT_HOME}/missing.hpl"));
+  }
+
+  @Test
+  void requestParametersDoNotLeakIntoServerVariableSpace() throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter out = new StringWriter();
+    when(response.getWriter()).thenReturn(new PrintWriter(out));
+    when(request.getParameter("pipeline")).thenReturn("${PROJECT_HOME}/missing.hpl");
+    when(request.getParameter("FOO")).thenReturn("bar");
+    when(request.getParameterValues("FOO")).thenReturn(new String[] {"bar"});
+    when(request.getParameterNames())
+        .thenReturn(Collections.enumeration(List.of("pipeline", "FOO")));
+
+    servlet.doGet(request, response);
+
+    assertNull(serverVariables.getVariable("FOO"));
+    assertEquals("/tmp/issue-8284-home", serverVariables.getVariable("PROJECT_HOME"));
+  }
+}

--- a/engine/src/test/java/org/apache/hop/www/HopServerConfigTest.java
+++ b/engine/src/test/java/org/apache/hop/www/HopServerConfigTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import org.apache.hop.core.Const;
 import org.apache.hop.core.exception.HopXmlException;
+import org.apache.hop.core.logging.ILogChannel;
 import org.apache.hop.core.variables.IVariables;
 import org.apache.hop.core.variables.Variables;
 import org.apache.hop.core.xml.XmlHandler;
@@ -34,6 +35,7 @@ import org.apache.hop.server.HopServerMeta;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
@@ -277,6 +279,21 @@ class HopServerConfigTest {
     assertNull(variables.getVariable(Const.INTERNAL_VARIABLE_HOP_SERVER_NAME));
     assertNull(variables.getVariable(Const.INTERNAL_VARIABLE_HOP_SERVER_HOSTNAME));
     assertNull(variables.getVariable(Const.INTERNAL_VARIABLE_HOP_SERVER_PORT));
+  }
+
+  @Test
+  void setVariablesAfterXmlLoadIsVisibleToServlets() throws HopXmlException {
+    Node configNode = getConfigNode(getConfigWithEmptyOptionsNode());
+    HopServerConfig fromXml = new HopServerConfig(Mockito.mock(ILogChannel.class), configNode);
+    IVariables enabled = new Variables();
+    enabled.setVariable("PROJECT_HOME", "/opt/project");
+    fromXml.setVariables(enabled);
+
+    PipelineMap map = new PipelineMap();
+    map.setHopServerConfig(fromXml);
+    BaseHttpServlet servlet = new BaseHttpServlet();
+    servlet.setup(map, null);
+    assertEquals("/opt/project", servlet.getServletVariables().getVariable("PROJECT_HOME"));
   }
 
   @Test

--- a/engine/src/test/java/org/apache/hop/www/HopServerTest.java
+++ b/engine/src/test/java/org/apache/hop/www/HopServerTest.java
@@ -18,10 +18,41 @@
 package org.apache.hop.www;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
+import org.apache.hop.core.exception.HopException;
+import org.apache.hop.core.logging.ILogChannel;
+import org.apache.hop.core.variables.IVariables;
+import org.apache.hop.core.variables.Variables;
 import org.junit.jupiter.api.Test;
 
 class HopServerTest {
+
+  @Test
+  void logEnabledProjectVariablesFailsWhenProjectNameSetWithoutHome() {
+    HopServer hopServer = new HopServer();
+    hopServer.setLog(mock(ILogChannel.class));
+    IVariables variables = new Variables();
+    variables.setVariable("HOP_PROJECT_NAME", "samples");
+    hopServer.setVariables(variables);
+
+    HopException thrown = assertThrows(HopException.class, hopServer::logEnabledProjectVariables);
+    assertTrue(thrown.getMessage().contains("PROJECT_HOME"));
+  }
+
+  @Test
+  void logEnabledProjectVariablesAcceptsProjectWithHome() throws HopException {
+    HopServer hopServer = new HopServer();
+    hopServer.setLog(mock(ILogChannel.class));
+    IVariables variables = new Variables();
+    variables.setVariable("HOP_PROJECT_NAME", "samples");
+    variables.setVariable("PROJECT_HOME", "/opt/hop/config/projects/samples");
+    hopServer.setVariables(variables);
+
+    hopServer.logEnabledProjectVariables();
+  }
 
   @Test
   void testApplySystemPropertiesPreservesEqualsSignsInValue() {

--- a/integration-tests/hop_server/0016-echo-server-variables.hpl
+++ b/integration-tests/hop_server/0016-echo-server-variables.hpl
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<pipeline>
+  <info>
+    <name>0016-echo-server-variables</name>
+    <name_sync_with_filename>Y</name_sync_with_filename>
+    <description>Aborts unless hop-server applied project and environment variables (issue #8284). No files: hop-server UID cannot write the client volume.</description>
+    <extended_description/>
+    <pipeline_version/>
+    <pipeline_type>Normal</pipeline_type>
+    <parameters>
+    </parameters>
+    <capture_transform_performance>N</capture_transform_performance>
+    <transform_performance_capturing_delay>1000</transform_performance_capturing_delay>
+    <transform_performance_capturing_size_limit>100</transform_performance_capturing_size_limit>
+    <created_user>-</created_user>
+    <created_date>2026/09/08 00:00:00.000</created_date>
+    <modified_user>-</modified_user>
+    <modified_date>2026/09/08 00:00:00.000</modified_date>
+    <key_for_session_key/>
+    <is_key_private>N</is_key_private>
+  </info>
+  <notepads>
+  </notepads>
+  <order>
+    <hop>
+      <from>Get server variables</from>
+      <to>Variables match?</to>
+      <enabled>Y</enabled>
+    </hop>
+    <hop>
+      <from>Variables match?</from>
+      <to>OK</to>
+      <enabled>Y</enabled>
+    </hop>
+    <hop>
+      <from>Variables match?</from>
+      <to>Abort</to>
+      <enabled>Y</enabled>
+    </hop>
+  </order>
+  <transform>
+    <name>Get server variables</name>
+    <type>GetVariable</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <fields>
+      <field>
+        <length>-1</length>
+        <name>project_home</name>
+        <precision>-1</precision>
+        <trim_type>none</trim_type>
+        <type>String</type>
+        <variable>${PROJECT_HOME}</variable>
+      </field>
+      <field>
+        <length>-1</length>
+        <name>hop_project_name</name>
+        <precision>-1</precision>
+        <trim_type>none</trim_type>
+        <type>String</type>
+        <variable>${HOP_PROJECT_NAME}</variable>
+      </field>
+      <field>
+        <length>-1</length>
+        <name>hop_environment_name</name>
+        <precision>-1</precision>
+        <trim_type>none</trim_type>
+        <type>String</type>
+        <variable>${HOP_ENVIRONMENT_NAME}</variable>
+      </field>
+      <field>
+        <length>-1</length>
+        <name>server_it_marker</name>
+        <precision>-1</precision>
+        <trim_type>none</trim_type>
+        <type>String</type>
+        <variable>${SERVER_IT_MARKER}</variable>
+      </field>
+    </fields>
+    <attributes/>
+    <GUI>
+      <xloc>144</xloc>
+      <yloc>96</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>Variables match?</name>
+    <type>FilterRows</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <send_true_to>OK</send_true_to>
+    <send_false_to>Abort</send_false_to>
+    <compare>
+      <condition>
+        <negated>N</negated>
+        <conditions>
+          <condition>
+            <negated>N</negated>
+            <operator>-</operator>
+            <leftvalue>server_it_marker</leftvalue>
+            <function>=</function>
+            <rightvalue/>
+            <value>
+              <name>constant</name>
+              <type>String</type>
+              <text>from-environment</text>
+              <length>-1</length>
+              <precision>-1</precision>
+              <isnull>N</isnull>
+            </value>
+          </condition>
+          <condition>
+            <negated>N</negated>
+            <operator>AND</operator>
+            <leftvalue>hop_environment_name</leftvalue>
+            <function>=</function>
+            <rightvalue/>
+            <value>
+              <name>constant</name>
+              <type>String</type>
+              <text>server-dev</text>
+              <length>-1</length>
+              <precision>-1</precision>
+              <isnull>N</isnull>
+            </value>
+          </condition>
+          <condition>
+            <negated>N</negated>
+            <operator>AND</operator>
+            <leftvalue>hop_project_name</leftvalue>
+            <function>=</function>
+            <rightvalue/>
+            <value>
+              <name>constant</name>
+              <type>String</type>
+              <text>samples</text>
+              <length>-1</length>
+              <precision>-1</precision>
+              <isnull>N</isnull>
+            </value>
+          </condition>
+        </conditions>
+      </condition>
+    </compare>
+    <attributes/>
+    <GUI>
+      <xloc>368</xloc>
+      <yloc>96</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>OK</name>
+    <type>Dummy</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <attributes/>
+    <GUI>
+      <xloc>592</xloc>
+      <yloc>48</yloc>
+    </GUI>
+  </transform>
+  <transform>
+    <name>Abort</name>
+    <type>Abort</type>
+    <description/>
+    <distribute>Y</distribute>
+    <custom_distribution/>
+    <copies>1</copies>
+    <partitioning>
+      <method>none</method>
+      <schema_name/>
+    </partitioning>
+    <abort_option>ABORT_WITH_ERROR</abort_option>
+    <always_log_rows>Y</always_log_rows>
+    <message>hop-server did not apply project/environment variables (issue #8284)</message>
+    <row_threshold>0</row_threshold>
+    <attributes/>
+    <GUI>
+      <xloc>592</xloc>
+      <yloc>160</yloc>
+    </GUI>
+  </transform>
+  <transform_error_handling>
+  </transform_error_handling>
+  <attributes/>
+</pipeline>

--- a/integration-tests/hop_server/main-0015-test-exported-pipeline-datapath.hwf
+++ b/integration-tests/hop_server/main-0015-test-exported-pipeline-datapath.hwf
@@ -81,6 +81,34 @@ limitations under the License.
       <attributes_hac/>
     </action>
     <action>
+      <name>Make mapped output writable by hop-server</name>
+      <description>output-0015/extraction is a git-tracked 775 directory owned by the test
+        runner. hop-server used to run as uid 501 and then could not recreate the file the
+        cleanup step just deleted (AccessDeniedException). World-writable so a cached image
+        with a different uid can still write.</description>
+      <type>SHELL</type>
+      <attributes/>
+      <filename/>
+      <work_directory/>
+      <arg_from_previous>N</arg_from_previous>
+      <exec_per_row>N</exec_per_row>
+      <set_logfile>N</set_logfile>
+      <logfile/>
+      <set_append_logfile>N</set_append_logfile>
+      <logext/>
+      <add_date>N</add_date>
+      <add_time>N</add_time>
+      <insertScript>Y</insertScript>
+      <script>mkdir -p "${PROJECT_HOME}/output-0015/extraction"
+chmod -R a+rwx "${PROJECT_HOME}/output-0015"
+</script>
+      <loglevel>Basic</loglevel>
+      <parallel>N</parallel>
+      <xloc>350</xloc>
+      <yloc>50</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
       <name>Run pipeline on the server with exported resources</name>
       <description/>
       <type>PIPELINE</type>
@@ -130,10 +158,17 @@ limitations under the License.
     </hop>
     <hop>
       <from>Cleanup expected path</from>
-      <to>Run pipeline on the server with exported resources</to>
+      <to>Make mapped output writable by hop-server</to>
       <enabled>Y</enabled>
       <evaluation>Y</evaluation>
       <unconditional>Y</unconditional>
+    </hop>
+    <hop>
+      <from>Make mapped output writable by hop-server</from>
+      <to>Run pipeline on the server with exported resources</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>N</unconditional>
     </hop>
     <hop>
       <from>Run pipeline on the server with exported resources</from>

--- a/integration-tests/hop_server/main-0016-test-server-project-environment-variables.hwf
+++ b/integration-tests/hop_server/main-0016-test-server-project-environment-variables.hwf
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<workflow>
+  <name>main-0016-test-server-project-environment-variables</name>
+  <name_sync_with_filename>Y</name_sync_with_filename>
+  <description>Proves hop-server started with a project and environment exposes PROJECT_HOME and environment config variables to /hop/execPipeline (issue #8284).</description>
+  <extended_description/>
+  <workflow_version/>
+  <created_user>-</created_user>
+  <created_date>2026/09/08 00:00:00.000</created_date>
+  <modified_user>-</modified_user>
+  <modified_date>2026/09/08 00:00:00.000</modified_date>
+  <parameters>
+    </parameters>
+  <actions>
+    <action>
+      <name>Start</name>
+      <description/>
+      <type>SPECIAL</type>
+      <attributes/>
+      <repeat>N</repeat>
+      <schedulerType>0</schedulerType>
+      <intervalSeconds>0</intervalSeconds>
+      <intervalMinutes>60</intervalMinutes>
+      <hour>12</hour>
+      <minutes>0</minutes>
+      <weekDay>1</weekDay>
+      <DayOfMonth>1</DayOfMonth>
+      <parallel>N</parallel>
+      <xloc>48</xloc>
+      <yloc>48</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>ExecPipeline with PROJECT_HOME path</name>
+      <description>Path resolution of ${PROJECT_HOME} against the samples project enabled on hop-server</description>
+      <type>SHELL</type>
+      <attributes/>
+      <filename/>
+      <work_directory/>
+      <arg_from_previous>N</arg_from_previous>
+      <exec_per_row>N</exec_per_row>
+      <set_logfile>N</set_logfile>
+      <logfile/>
+      <set_append_logfile>N</set_append_logfile>
+      <logext/>
+      <add_date>N</add_date>
+      <add_time>N</add_time>
+      <insertScript>Y</insertScript>
+      <script>curl -u cluster:cluster --fail -L -s "http://hop-server:8181/hop/execPipeline?pipeline=%24%7BPROJECT_HOME%7D/pipelines/pipeline-with-parameter.hpl&amp;PRM_EXAMPLE=test_from_var&amp;level=BASIC" | grep -q "&lt;result>OK&lt;/result>" || exit 1</script>
+      <loglevel>Basic</loglevel>
+      <parallel>N</parallel>
+      <xloc>192</xloc>
+      <yloc>48</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>ExecPipeline echo server variables</name>
+      <description>Run a pipeline on the server that aborts unless PROJECT_HOME, HOP_ENVIRONMENT_NAME and SERVER_IT_MARKER are set</description>
+      <type>SHELL</type>
+      <attributes/>
+      <filename/>
+      <work_directory/>
+      <arg_from_previous>N</arg_from_previous>
+      <exec_per_row>N</exec_per_row>
+      <set_logfile>N</set_logfile>
+      <logfile/>
+      <set_append_logfile>N</set_append_logfile>
+      <logext/>
+      <add_date>N</add_date>
+      <add_time>N</add_time>
+      <insertScript>Y</insertScript>
+      <script>curl -u cluster:cluster --fail -L -s "http://hop-server:8181/hop/execPipeline?pipeline=/hop_server_volume/0016-echo-server-variables.hpl&amp;level=BASIC" | grep -q "&lt;result>OK&lt;/result>" || exit 1</script>
+      <loglevel>Basic</loglevel>
+      <parallel>N</parallel>
+      <xloc>192</xloc>
+      <yloc>128</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>Success</name>
+      <description/>
+      <type>SUCCESS</type>
+      <attributes/>
+      <parallel>N</parallel>
+      <xloc>192</xloc>
+      <yloc>208</yloc>
+      <attributes_hac/>
+    </action>
+    <action>
+      <name>Abort workflow</name>
+      <description/>
+      <type>ABORT</type>
+      <attributes/>
+      <always_log_rows>N</always_log_rows>
+      <parallel>N</parallel>
+      <xloc>400</xloc>
+      <yloc>128</yloc>
+      <attributes_hac/>
+    </action>
+  </actions>
+  <hops>
+    <hop>
+      <from>Start</from>
+      <to>ExecPipeline with PROJECT_HOME path</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>Y</unconditional>
+    </hop>
+    <hop>
+      <from>ExecPipeline with PROJECT_HOME path</from>
+      <to>ExecPipeline echo server variables</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>N</unconditional>
+    </hop>
+    <hop>
+      <from>ExecPipeline echo server variables</from>
+      <to>Success</to>
+      <enabled>Y</enabled>
+      <evaluation>Y</evaluation>
+      <unconditional>N</unconditional>
+    </hop>
+    <hop>
+      <from>ExecPipeline with PROJECT_HOME path</from>
+      <to>Abort workflow</to>
+      <enabled>Y</enabled>
+      <evaluation>N</evaluation>
+      <unconditional>N</unconditional>
+    </hop>
+    <hop>
+      <from>ExecPipeline echo server variables</from>
+      <to>Abort workflow</to>
+      <enabled>Y</enabled>
+      <evaluation>N</evaluation>
+      <unconditional>N</unconditional>
+    </hop>
+  </hops>
+  <notepads>
+  </notepads>
+  <attributes/>
+</workflow>

--- a/integration-tests/hop_server/server-env-config.json
+++ b/integration-tests/hop_server/server-env-config.json
@@ -1,0 +1,7 @@
+{
+  "variables" : [ {
+    "name" : "SERVER_IT_MARKER",
+    "value" : "from-environment",
+    "description" : "Distinctive environment variable used by main-0016 to prove hop-server applied -e / HOP_ENVIRONMENT_NAME config files (issue #8284)."
+  } ]
+}

--- a/plugins/misc/projects/src/main/java/org/apache/hop/projects/config/ProjectsOptionPlugin.java
+++ b/plugins/misc/projects/src/main/java/org/apache/hop/projects/config/ProjectsOptionPlugin.java
@@ -33,6 +33,7 @@ import org.apache.hop.metadata.util.HopMetadataInstance;
 import org.apache.hop.projects.environment.LifecycleEnvironment;
 import org.apache.hop.projects.project.Project;
 import org.apache.hop.projects.project.ProjectConfig;
+import org.apache.hop.projects.util.Defaults;
 import org.apache.hop.projects.util.ProjectsConfigHelper;
 import org.apache.hop.projects.util.ProjectsUtil;
 import picocli.CommandLine;
@@ -104,10 +105,18 @@ public class ProjectsOptionPlugin implements IConfigOptions {
     projectName = projectOption;
     environmentName = environmentOption;
 
+    // A later mixin (hop-server, hop-run) often has empty -e/-j even though the root command
+    // already enabled an environment. Inherit HOP_ENVIRONMENT_NAME so environment config files
+    // are not dropped on the second configure(). Only do this when this mixin specified neither.
     if (StringUtils.isEmpty(projectName) && StringUtils.isEmpty(environmentName)) {
-      projectName =
-          ProjectsConfigHelper.determineActiveProject(
-              projectName, environmentName, registeredProjects, variables);
+      if (variables != null) {
+        environmentName = variables.getVariable(Defaults.VARIABLE_HOP_ENVIRONMENT_NAME);
+      }
+      if (StringUtils.isEmpty(environmentName)) {
+        projectName =
+            ProjectsConfigHelper.determineActiveProject(
+                projectName, environmentName, registeredProjects, variables);
+      }
     }
 
     if (hasHopMetadataProvider == null
@@ -237,6 +246,11 @@ public class ProjectsOptionPlugin implements IConfigOptions {
 
     if (ProjectsConfigHelper.alreadyEnabled(projectName, environmentName)
         && (extraConfigFiles == null || extraConfigFiles.isEmpty())) {
+      // Skip the expensive second enable (VFS reset, metadata rebuild, extension points) but
+      // still apply PROJECT_HOME and environment config variables onto this variables instance.
+      // hop-server rebuilds HopServerConfig after the mixin runs; a different IVariables than
+      // the one that was first enabled must still resolve ${PROJECT_HOME}. See issue #8284.
+      applyEnabledProjectVariables(variables, projectConfig, configurationFiles, environmentName);
       MultiMetadataProvider current = HopMetadataInstance.getMetadataProvider();
       if (hasHopMetadataProvider != null && current != null) {
         hasHopMetadataProvider.setMetadataProvider(current);
@@ -265,6 +279,25 @@ public class ProjectsOptionPlugin implements IConfigOptions {
       return true;
     } catch (Exception e) {
       throw new HopException("Error enabling project '" + projectName + "'", e);
+    }
+  }
+
+  /**
+   * Copy project and environment variables onto {@code variables} without rebuilding metadata or
+   * resetting VFS. Used when the same project/environment was already enabled on another instance.
+   */
+  static void applyEnabledProjectVariables(
+      IVariables variables,
+      ProjectConfig projectConfig,
+      List<String> configurationFiles,
+      String environmentName)
+      throws HopException {
+    if (variables == null || projectConfig == null) {
+      return;
+    }
+    Project project = projectConfig.loadProject(variables);
+    if (project != null) {
+      project.modifyVariables(variables, projectConfig, configurationFiles, environmentName);
     }
   }
 }

--- a/plugins/misc/projects/src/test/java/org/apache/hop/projects/util/ProjectsConfigHelperTest.java
+++ b/plugins/misc/projects/src/test/java/org/apache/hop/projects/util/ProjectsConfigHelperTest.java
@@ -322,6 +322,83 @@ public class ProjectsConfigHelperTest {
     assertTrue(HopConfig.isInMemoryMode());
     assertNotNull(ProjectsConfigSingleton.getConfig().findProjectConfig("my-proj"));
     assertNotNull(ProjectsConfigSingleton.getConfig().findEnvironment("my-env"));
+    assertEquals(
+        projectDir.toAbsolutePath().toString(),
+        variables.getVariable(ProjectsUtil.VARIABLE_PROJECT_HOME));
+    assertEquals("test_val", variables.getVariable("TEST_ENV_VAR"));
+    assertEquals("my-env", variables.getVariable(Defaults.VARIABLE_HOP_ENVIRONMENT_NAME));
+  }
+
+  @Test
+  public void testAlreadyEnabledAppliesVariablesToASecondInstance() throws Exception {
+    Path projectDir = tempRoot.resolve("second-vars");
+    Files.createDirectories(projectDir);
+    Path confFile = tempRoot.resolve("second-env.json");
+    Files.writeString(
+        confFile,
+        "{ \"variables\" : [ {\"name\" : \"ENV_MARKER\", \"value\" : \"from-env\"} ] }\n",
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        projectDir.resolve(ProjectsConfig.DEFAULT_PROJECT_CONFIG_FILENAME),
+        "{ \"metadataBaseFolder\" : \"${PROJECT_HOME}/metadata\" }\n",
+        StandardCharsets.UTF_8);
+
+    ProjectsOptionPlugin first = new ProjectsOptionPlugin();
+    first.setProjectLocations(new String[] {"second-vars=" + projectDir.toAbsolutePath()});
+    first.setEnvironments(new String[] {"second-env=" + confFile.toAbsolutePath()});
+    first.setEnvironmentOption("second-env");
+    IVariables firstVars = new Variables();
+    first.handleOption(LogChannel.GENERAL, null, firstVars);
+    registeredProjects.add("second-vars");
+    registeredEnvironments.add("second-env");
+
+    assertEquals("from-env", firstVars.getVariable("ENV_MARKER"));
+
+    IVariables secondVars = new Variables();
+    ProjectsOptionPlugin second = new ProjectsOptionPlugin();
+    second.setEnvironmentOption("second-env");
+    TestMetadataHolder holder = new TestMetadataHolder();
+    second.handleOption(LogChannel.GENERAL, holder, secondVars);
+
+    assertEquals(
+        projectDir.toAbsolutePath().toString(),
+        secondVars.getVariable(ProjectsUtil.VARIABLE_PROJECT_HOME));
+    assertEquals("from-env", secondVars.getVariable("ENV_MARKER"));
+    assertEquals("second-env", secondVars.getVariable(Defaults.VARIABLE_HOP_ENVIRONMENT_NAME));
+  }
+
+  @Test
+  public void testServerMixinInheritsEnvironmentNameFromVariables() throws Exception {
+    Path projectDir = tempRoot.resolve("inherit-env");
+    Files.createDirectories(projectDir);
+    Path confFile = tempRoot.resolve("inherit-env.json");
+    Files.writeString(
+        confFile,
+        "{ \"variables\" : [ {\"name\" : \"INHERITED_ENV\", \"value\" : \"kept\"} ] }\n",
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        projectDir.resolve(ProjectsConfig.DEFAULT_PROJECT_CONFIG_FILENAME),
+        "{ \"metadataBaseFolder\" : \"${PROJECT_HOME}/metadata\" }\n",
+        StandardCharsets.UTF_8);
+
+    ProjectsOptionPlugin root = new ProjectsOptionPlugin();
+    root.setProjectLocations(new String[] {"inherit-env=" + projectDir.toAbsolutePath()});
+    root.setEnvironments(new String[] {"inherit-env=" + confFile.toAbsolutePath()});
+    root.setEnvironmentOption("inherit-env");
+    IVariables variables = new Variables();
+    root.handleOption(LogChannel.GENERAL, null, variables);
+    registeredProjects.add("inherit-env");
+    registeredEnvironments.add("inherit-env");
+
+    // hop-server mixin: no -e on this command, but HOP_ENVIRONMENT_NAME is already set.
+    ProjectsOptionPlugin serverMixin = new ProjectsOptionPlugin();
+    TestMetadataHolder holder = new TestMetadataHolder();
+    serverMixin.handleOption(LogChannel.GENERAL, holder, variables);
+
+    assertEquals("kept", variables.getVariable("INHERITED_ENV"));
+    assertEquals(
+        projectDir.toAbsolutePath().toString(),
+        variables.getVariable(ProjectsUtil.VARIABLE_PROJECT_HOME));
   }
 
   @Test


### PR DESCRIPTION
When hop-server is started with `-j` / `-e` (or Docker `HOP_PROJECT_NAME` / `HOP_ENVIRONMENT_NAME`), `/hop/execPipeline?pipeline=${PROJECT_HOME}/...` failed even though absolute paths worked. `hop-run` was fine.

`enableProject()` wrote `PROJECT_HOME` and environment config variables onto the CLI variable space, then `setupByFileName()` / `setupByHostNameAndPort()` replaced `HopServerConfig` with a fresh space. A second mixin after root `-e` could also skip applying those variables, or re-enable the project without environment config files.

### Changes
- Keep applying project/environment variables when the same project is already enabled; inherit `HOP_ENVIRONMENT_NAME` on a later mixin that has no `-e`.
- Re-bind the enabled variable space and metadata provider after hop-server rebuilds its config.
- Resolve execPipeline/execWorkflow paths against a per-request copy of the live server variables (do not mutate the server space with query parameters).
- Load pipeline/workflow files through VFS with the parent variable space.
- hop_server IT: start environment `server-dev`, add `main-0016` for `${PROJECT_HOME}` and environment vars, run hop-server as the test-runner uid, and chmod the mapped `output-0015` folder so main-0015 is not AccessDenied.

Fixes #8284

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).