### PR TITLE
Issue #8292 : Rename in-memory short option from -im to -ime

### DIFF
--- a/docs/hop-user-manual/modules/ROOT/pages/hop-run/index.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/hop-run/index.adoc
@@ -146,7 +146,7 @@ Check the xref:pipeline/pipeline-run-configurations/pipeline-run-configurations.
 |```--system-properties```
 |A comma separated list of KEY=VALUE pairs
 
-|```-im```
+|```-ime```
 |```--in-memory```
 |Keep Hop configuration in memory. Changes are not written to `hop-config.json`. Implied by `--project-locations` and `--environments`.
 

--- a/docs/hop-user-manual/modules/ROOT/pages/hop-tools/hop-gui.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/hop-tools/hop-gui.adoc
@@ -47,7 +47,7 @@ The same `-j`, `-e` and `-f` options work with `hop-gui.sh` / `hop-gui.bat`.
 .Output of help
 [source,bash]
 ----
-Usage: hop gui [-hV] [-im] [-e=<environmentOption>] [-f=<filename>]
+Usage: hop gui [-hV] [-ime] [-e=<environmentOption>] [-f=<filename>]
                [-j=<projectOption>]
                [--environment-conf-files=<environmentConfigFiles>[,
                <environmentConfigFiles>...]]... [--environments=<environments>[,
@@ -58,7 +58,7 @@ The Hop GUI
                           The name of the lifecycle environment to use
   -f, --file=<filename>   The filename of the workflow or pipeline to open
   -h, --help              Show this help message and exit.
-      -im, --in-memory    Keep configuration in memory without persisting to
+      -ime, --in-memory   Keep configuration in memory without persisting to
                             hop-config.json
   -j, --project=<projectOption>
                           The name of the project to use
@@ -76,7 +76,7 @@ The available options are listed in more detail in the table below:
 |`-e`|`--environment`|The name of the lifecycle environment to enable. The project name is taken from that environment, so you do not need `-j` as well. See xref:projects/projects-environments.adoc[Projects and Environments].
 |`-f`|`--file`|The filename of the workflow or pipeline to open. Relative paths are resolved against the current directory, then `{openvar}PROJECT_HOME{closevar}`.
 |`-h`|`--help`|Displays this help message and quits.
-|`-im`|`--in-memory`|Keep Hop configuration in memory. Changes are not written to `hop-config.json`.
+|`-ime`|`--in-memory`|Keep Hop configuration in memory. Changes are not written to `hop-config.json`.
 |`-j`|`--project`|The name of the project to enable. Not needed when `-e` is set.
 |`-pl`|`--project-locations`|Comma-separated project locations to register for this process only (`name=/path` or a zip/jar). See xref:projects/advanced.adoc#_use_a_project_without_hop_config_json[Use a project without hop-config.json].
 ||`--environments`|Comma-separated environment definitions (`name=[project:]file1;file2`) registered in memory for this process.

--- a/docs/hop-user-manual/modules/ROOT/pages/hop-tools/hop.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/hop-tools/hop.adoc
@@ -33,7 +33,7 @@ The command list depends on the plugins in your installation; the sample below s
 [source,bash]
 ----
 $ ./hop help
-Usage: hop [-hV] [--dev-debug] [--dev-debug-wait] [-im]
+Usage: hop [-hV] [--dev-debug] [--dev-debug-wait] [-ime]
            [-e=<environmentOption>] [-j=<projectOption>]
            [--environment-conf-files=<environmentConfigFiles>[,
            <environmentConfigFiles>...]]... [--environments=<environments>[,
@@ -43,7 +43,7 @@ Usage: hop [-hV] [--dev-debug] [--dev-debug-wait] [-im]
   -e, --environment=<environmentOption>
                          The name of the lifecycle environment to use
   -h, --help             Show this help message and exit.
-      -im, --in-memory   Keep configuration in memory without persisting to
+      -ime, --in-memory  Keep configuration in memory without persisting to
                            hop-config.json
   -j, --project=<projectOption>
                          The name of the project to use
@@ -74,7 +74,7 @@ Commands:
 |Short|Extended|Description
 |`-e`|`--environment`|The name of the lifecycle environment to enable before the subcommand runs.
 |`-h`|`--help`|Displays this help message and quits.
-|`-im`|`--in-memory`|Keep Hop configuration in memory. Changes are not written to `hop-config.json`. Implied by `--project-locations` and `--environments`.
+|`-ime`|`--in-memory`|Keep Hop configuration in memory. Changes are not written to `hop-config.json`. Implied by `--project-locations` and `--environments`.
 |`-j`|`--project`|The name of the project to enable before the subcommand runs.
 |`-pl`|`--project-locations`|Comma-separated project locations to register for this process only (`name=/path`, a zip/jar, or a bare folder). See xref:projects/advanced.adoc#_use_a_project_without_hop_config_json[Use a project without hop-config.json].
 ||`--environments`|Comma-separated environment definitions (`name=[project:]file1;file2`) registered in memory for this process.

--- a/docs/hop-user-manual/modules/ROOT/pages/projects/advanced.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/projects/advanced.adoc
@@ -212,7 +212,7 @@ hop --project-locations edw=/data/edw --environments edw-prod=/data/edw-prod.jso
 If the project name is omitted, Hop infers it from the registered projects.
 `--environment-conf-files` (also `--environment-config-files`) adds extra variable files to the enabled project or environment.
 
-`-im` / `--in-memory` keeps Hop configuration in memory even when you are not using `--project-locations`.
+`-ime` / `--in-memory` keeps Hop configuration in memory even when you are not using `--project-locations`.
 The same behaviour can be enabled with the `{openvar}HOP_CONFIG_IN_MEMORY{closevar}` system variable set to `Y`.
 
 These options are available on the `hop` root command (so they apply before `run`, `gui`, `search`, and so on) and on the subcommands themselves (`hop run -pl ...`, `hop gui -pl ...`).

--- a/docs/hop-user-manual/modules/ROOT/pages/variables.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/variables.adoc
@@ -332,7 +332,7 @@ Additionally, the following environment variables can help you to add even more 
 |===
 |Variable|Default|Description
 |HOP_AUTO_CREATE_CONFIG|N|Set this variable to 'Y' to automatically create config file when it's missing.
-|HOP_CONFIG_IN_MEMORY|N|Set this variable to 'Y' to keep the Hop configuration in memory without persisting to disk. The `{openvar}HOP_CONFIG_IN_MEMORY{closevar}` equivalent on the command line is `-im` / `--in-memory`.
+|HOP_CONFIG_IN_MEMORY|N|Set this variable to 'Y' to keep the Hop configuration in memory without persisting to disk. The `{openvar}HOP_CONFIG_IN_MEMORY{closevar}` equivalent on the command line is `-ime` / `--in-memory`.
 |HOP_METADATA_FOLDER|-|The system environment variable pointing to the alternative location for the Hop metadata folder
 |HOP_REDIRECT_STDERR|N|Set this variable to Y to redirect stderr to Hop logging.
 |HOP_REDIRECT_STDOUT|N|Set this variable to Y to redirect stdout to Hop logging.

--- a/engine/src/main/java/org/apache/hop/hop/Hop.java
+++ b/engine/src/main/java/org/apache/hop/hop/Hop.java
@@ -210,7 +210,7 @@ public class Hop {
       if (arg == null) {
         continue;
       }
-      if (arg.equals("-im")
+      if (arg.equals("-ime")
           || arg.equals("--in-memory")
           || arg.equals("-pl")
           || arg.startsWith("-pl=")

--- a/plugins/misc/projects/src/main/java/org/apache/hop/projects/config/ProjectsOptionPlugin.java
+++ b/plugins/misc/projects/src/main/java/org/apache/hop/projects/config/ProjectsOptionPlugin.java
@@ -72,7 +72,7 @@ public class ProjectsOptionPlugin implements IConfigOptions {
   protected String[] environmentConfigFiles = null;
 
   @CommandLine.Option(
-      names = {"-im", "--in-memory"},
+      names = {"-ime", "--in-memory"},
       description = "Keep configuration in memory without persisting to hop-config.json")
   protected boolean inMemory = false;
 


### PR DESCRIPTION
`hop doc` failed to start because the projects plugin and the documentation plugin both claimed `-im`.

The projects in-memory flag is now `-ime` / `--in-memory`. `hop doc` keeps `-im` / `--include-metadata`. The early argument scan in `Hop` was updated so `hop doc -im` no longer enables in-memory config.

Fixes #8292

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [ ] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).