### PR TITLE
Issue #8299 : Word-split HOP_CONFIG_OPTIONS when invoking hop-conf

### DIFF
--- a/docker/resources/load-and-execute.sh
+++ b/docker/resources/load-and-execute.sh
@@ -305,9 +305,9 @@ if [ -n "${HOP_CONFIG_OPTIONS}" ]; then
   # We have a hop-config to run with the given options
   #
   echo "Configuring Hop with : ${HOP_CONFIG_OPTIONS}"
-  # Docker env vars cannot carry a bash array, so word-split into arguments.
-  # shellcheck disable=SC2206
-  HOP_CONFIG_OPTION_ARRAY=(${HOP_CONFIG_OPTIONS})
+  # Docker env vars cannot carry a bash array; split like a shell would,
+  # honouring quotes so option values may contain spaces.
+  mapfile -t HOP_CONFIG_OPTION_ARRAY < <(xargs -n1 printf '%s\n' <<< "${HOP_CONFIG_OPTIONS}")
   "${DEPLOYMENT_PATH}"/hop-conf.sh \
     "${HOP_CONFIG_OPTION_ARRAY[@]}" \
     2>&1 | tee ${HOP_LOG_PATH}

--- a/docker/resources/load-and-execute.sh
+++ b/docker/resources/load-and-execute.sh
@@ -305,8 +305,11 @@ if [ -n "${HOP_CONFIG_OPTIONS}" ]; then
   # We have a hop-config to run with the given options
   #
   echo "Configuring Hop with : ${HOP_CONFIG_OPTIONS}"
+  # Docker env vars cannot carry a bash array, so word-split into arguments.
+  # shellcheck disable=SC2206
+  HOP_CONFIG_OPTION_ARRAY=(${HOP_CONFIG_OPTIONS})
   "${DEPLOYMENT_PATH}"/hop-conf.sh \
-    "${HOP_CONFIG_OPTIONS}" \
+    "${HOP_CONFIG_OPTION_ARRAY[@]}" \
     2>&1 | tee ${HOP_LOG_PATH}
 fi
 

--- a/docs/hop-user-manual/modules/ROOT/pages/docker-container.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/docker-container.adoc
@@ -171,7 +171,7 @@ You can specify the properties as a comma separated list, e.g. `PROP1=xxx,PROP2=
 |
 |If you specify a value for this variable, they will be used to execute `hop-conf.sh` right before execution of the short- or long-lived container.
 You can use it for example to configure values for keys, plugins, and so on.
-Specify multiple options separated by spaces, for example `--set-variable=FOO=bar --describe-variable=FOO=Example`.
+Specify multiple options separated by spaces. Enclose values containing spaces in quotes, for example `--set-variable=FOO=bar --describe-variable=FOO="An example variable"`.
 
 |```HOP_COMMAND```
 |

--- a/docs/hop-user-manual/modules/ROOT/pages/docker-container.adoc
+++ b/docs/hop-user-manual/modules/ROOT/pages/docker-container.adoc
@@ -171,6 +171,7 @@ You can specify the properties as a comma separated list, e.g. `PROP1=xxx,PROP2=
 |
 |If you specify a value for this variable, they will be used to execute `hop-conf.sh` right before execution of the short- or long-lived container.
 You can use it for example to configure values for keys, plugins, and so on.
+Specify multiple options separated by spaces, for example `--set-variable=FOO=bar --describe-variable=FOO=Example`.
 
 |```HOP_COMMAND```
 |


### PR DESCRIPTION
`HOP_CONFIG_OPTIONS` was expanded in double quotes in `load-and-execute.sh`, so the entire Docker/Compose string was passed to `hop-conf.sh` as a single argument. Multiple options such as `--set-variable=FOO=bar --describe-variable=FOO=Example` then failed as unmatched.

This is the leftover from #7063 / #7090, which added the missing `$` but left the quotes in place.

## What changed

- Word-split `HOP_CONFIG_OPTIONS` into a bash array and expand `"${array[@]}"` (same pattern as `HOP_EXEC_OPTIONS`). Environment variables cannot carry arrays, so this is the Docker Compose-friendly equivalent.
- Document that multiple options are space-separated.

Fixes #8299

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [ ] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).