### PR TITLE
[#8324][build] setup ECJ compilation

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -16,9 +16,29 @@
   ~ limitations under the License.
   -->
 <extensions>
+    <!-- not really needed by default and quite outdated
     <extension>
-        <groupId>co.leantechniques</groupId>
-        <artifactId>maven-buildtime-extension</artifactId>
-        <version>3.0.3</version>
+      <groupId>co.leantechniques</groupId>
+      <artifactId>maven-buildtime-extension</artifactId>
+      <version>3.0.3</version>
+    <extension>
+    -->
+    <!--
+    $ docker run -d \
+      -p 16686:16686 \
+      -p 4317:4317 \
+      -p 4318:4318 \
+      jaegertracing/jaeger
+    $ mvn \
+      -Dotel.traces.exporter=otlp \
+      -Dotel.exporter.otlp.endpoint=http://localhost:4317 \
+      -Dotel.instrumentation.maven.transfer.enabled=false \
+      -DskipTests
+      clean install -T0.75C
+    <extension>
+        <groupId>io.opentelemetry.contrib</groupId>
+        <artifactId>opentelemetry-maven-extension</artifactId>
+        <version>1.55.0-alpha</version>
     </extension>
+    -->
 </extensions>

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -19,3 +19,5 @@
 --add-exports java.base/sun.nio.ch=ALL-UNNAMED
 -Dorg.slf4j.simpleLogger.log.org.jacoco.maven.AgentMojo=warn
 -Dorg.slf4j.simpleLogger.log.org.jacoco.maven.AgentITMojo=warn
+-Djdk.attach.allowAttachSelf=true
+-XX:+EnableDynamicAgentLoading

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -844,6 +844,18 @@
                 <groupId>xerces</groupId>
                 <artifactId>xercesImpl</artifactId>
                 <version>${xerces.version}</version>
+                <exclusions>
+                    <!-- ECJ (our maven-compiler-plugin compilerId) refuses jars
+                         shipping classes in packages exported by JDK modules:
+                         xml-apis ships javax.xml.*, org.w3c.dom and org.xml.sax,
+                         all split packages vs the java.xml module. The JDK 21
+                         provides these APIs so xml-apis is not needed at runtime
+                         either. -->
+                    <exclusion>
+                        <groupId>xml-apis</groupId>
+                        <artifactId>xml-apis</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>xml-apis</groupId>

--- a/plugins/actions/xml/pom.xml
+++ b/plugins/actions/xml/pom.xml
@@ -51,6 +51,12 @@
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>

--- a/plugins/tech/cassandra/pom.xml
+++ b/plugins/tech/cassandra/pom.xml
@@ -31,6 +31,7 @@
     <properties>
         <cassandra-all.version>4.1.11</cassandra-all.version>
         <cassandra-java-driver.version>4.17.0</cassandra-java-driver.version>
+        <high-scale-lib.version>1.0.6</high-scale-lib.version>
     </properties>
 
     <dependencyManagement>
@@ -97,6 +98,16 @@
                     <groupId>ch.qos.logback</groupId>
                     <artifactId>logback-core</artifactId>
                 </exclusion>
+                <!-- ECJ (our maven-compiler-plugin compilerId) refuses jars that
+                     ship classes in java.* packages: split package vs java.base.
+                     high-scale-lib ships java/util/Hashtable.class and
+                     java/util/concurrent/ConcurrentHashMap.class; Cassandra still
+                     needs it at runtime so it is copied into the plugin zip by
+                     the dependency plugin execution below instead. -->
+                <exclusion>
+                    <groupId>com.boundary</groupId>
+                    <artifactId>high-scale-lib</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>*</artifactId>
@@ -124,6 +135,13 @@
                 <exclusion>
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-math3</artifactId>
+                </exclusion>
+                <!-- ECJ (see high-scale-lib above): sjk-cli ships
+                     java/lang/ProcessBuilder.class. Only cassandra's nodetool Sjk
+                     command uses these so they are not needed by Hop at all. -->
+                <exclusion>
+                    <groupId>org.gridkit.jvmtool</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.lz4</groupId>
@@ -213,4 +231,36 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>ensure-high-scale-lib-in-plugin-zip</id>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <phase>prepare-package</phase>
+                        <configuration>
+                            <!-- excluded from cassandra-all only to keep it off the
+                                 ECJ compile classpath (java.* split package), it is
+                                 still needed at runtime by Cassandra caches/logging
+                                 so it must ship inside the plugin zip. -->
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.boundary</groupId>
+                                    <artifactId>high-scale-lib</artifactId>
+                                    <version>${high-scale-lib.version}</version>
+                                </artifactItem>
+                            </artifactItems>
+                            <outputDirectory>${project.build.directory}/hop-plugin-lib</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,8 @@
         <byte-buddy.version>1.18.11</byte-buddy.version>
         <commonmark.version>0.30.0</commonmark.version>
         <cyclonedx-maven-plugin.version>2.9.3</cyclonedx-maven-plugin.version>
+        <gmavenplus-plugin.version>4.3.1</gmavenplus-plugin.version>
+        <groovy.version>4.0.28</groovy.version>
         <grpc.version>1.83.1</grpc.version>
         <hadoop.thirdparty.version>1.4.0</hadoop.thirdparty.version>
         <hadoop.version>3.4.2</hadoop.version>
@@ -160,6 +162,7 @@
         <objenesis.version>3.6</objenesis.version>
         <opentelemetry.version>1.65.0</opentelemetry.version>
         <org.eclipse.platform.version>3.134.0</org.eclipse.platform.version>
+        <plexus-compiler.version>2.17.0</plexus-compiler.version>
         <project.build.outputTimestamp>1786535563</project.build.outputTimestamp>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -381,12 +384,109 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>ensure-lombok-ecj-agent-jar</id>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.projectlombok</groupId>
+                                    <artifactId>lombok</artifactId>
+                                    <version>${lombok.version}</version>
+                                </artifactItem>
+                            </artifactItems>
+                            <outputDirectory>${maven.multiModuleProjectDirectory}/.mvn</outputDirectory>
+                            <overWriteIfNewer>false</overWriteIfNewer>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>${gmavenplus-plugin.version}</version>
+                <inherited>false</inherited>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.groovy</groupId>
+                        <artifactId>groovy</artifactId>
+                        <version>${groovy.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>attach-lombok-ecj-agent</id>
+                        <goals>
+                            <goal>execute</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                            <skipScriptExecution>${lombok.ecj.agent.attached}</skipScriptExecution>
+                            <scripts>
+                                <script><![CDATA[
+import com.sun.tools.attach.VirtualMachine
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+
+if (System.getProperty('lombok.ecj.agent.skip') != 'true') {
+    synchronized (System.getProperties()) {
+        if (System.getProperty('lombok.ecj.agent.attached') == null) {
+            def lombokJar = new File(System.getProperty('maven.multiModuleProjectDirectory'), '.mvn/lombok-' + project.properties['lombok.version'] + '.jar')
+            if (!lombokJar.isFile() || lombokJar.length() < 1000000L) {
+                throw new IllegalStateException('Lombok jar missing or incomplete for the ECJ agent attach, expected ' + lombokJar)
+            }
+            def agentJar = Files.createTempFile('lombok-ecj-agent-', '.jar').toFile()
+            agentJar.deleteOnExit()
+            Files.copy(lombokJar.toPath(), agentJar.toPath(), StandardCopyOption.REPLACE_EXISTING)
+            try {
+                def vm = VirtualMachine.attach(String.valueOf(ProcessHandle.current().pid()))
+                try {
+                    vm.loadAgent(agentJar.absolutePath, 'ECJ')
+                } finally {
+                    vm.detach()
+                }
+                System.setProperty('lombok.ecj.agent.attached', 'true')
+                log.info('Lombok ECJ agent attached (source: ' + lombokJar + ')')
+            } catch (Throwable t) {
+                throw new IllegalStateException('Unable to self-attach the Lombok ECJ agent, ensure -Djdk.attach.allowAttachSelf=true is in .mvn/jvm.config and the environment allows self-attach, or skip it with -Dlombok.ecj.agent.skip=true', t)
+            }
+        }
+    }
+}
+                                ]]></script>
+                            </scripts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.16.0</version>
                 <configuration>
+                    <compilerId>eclipse</compilerId>
                     <compilerArgs>
                         <arg>-Xlint:-options</arg>
                     </compilerArgs>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.plexus</groupId>
+                        <artifactId>plexus-compiler-eclipse</artifactId>
+                        <version>${plexus-compiler.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok</artifactId>
+                        <version>${lombok.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Proposal to use ECJ for compilation.

Small pitfall: requires to build at least once to setup the lombok.jar since ECJ needs lombok to be a javaagent and now maven compiler doesn't/will not fork anymore so we can't just configure compiler JVM.

Time goes from 7.7mn to 1.0 - -Pfast-build mode else javadoc and friends are slow and makes it closer to 10mn.

current:

<img width="1814" height="1438" alt="image" src="https://github.com/user-attachments/assets/bdfb5bfe-0532-4193-816b-64b0b5a817e1" />

with ECJ:

<img width="1814" height="1438" alt="image" src="https://github.com/user-attachments/assets/88829083-d4b9-42a3-92f0-095c9c1e18ed" />



------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:
- [X] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [X] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`.
- [X] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [X] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
