### PR TITLE
 Fixes #8327: Keep ServerPushSession active in Hop Web so logging refresh does not stall

### DIFF
--- a/rap/src/main/java/org/apache/hop/ui/hopgui/HopWebEntryPoint.java
+++ b/rap/src/main/java/org/apache/hop/ui/hopgui/HopWebEntryPoint.java
@@ -252,6 +252,11 @@ public class HopWebEntryPoint extends AbstractEntryPoint {
     // URL params were only for initial project/file; clear so they don't affect CLI/run.
     HopGui.getInstance().setCommandLineArguments(new ArrayList<>());
 
+    // Hop Web only delivers background asyncExec updates to the browser while a server
+    // push session is running. Start server push for the session so pipeline/workflow logs,
+    // notifications, and other async UI updates are pushed immediately without stalling.
+    ServerPushSessionFacade.start();
+
     HopWebUrlHelper.setUrlUpdater(new RapHopWebUrlUpdater());
 
     // Persist open tabs when the session ends (browser close, timeout, etc.).
@@ -271,7 +276,8 @@ public class HopWebEntryPoint extends AbstractEntryPoint {
                   NotificationService.getInstance().stop();
                   ServerPushSessionFacade.stop();
                 } catch (Exception e) {
-                  LogChannel.UI.logError("Error stopping notifications on session end", e);
+                  LogChannel.UI.logError(
+                      "Error stopping notifications and server push on session end", e);
                 }
                 try {
                   HopGui hopGui = HopGui.getInstance();

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/HopGuiPipelineGraph.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/pipeline/HopGuiPipelineGraph.java
@@ -167,7 +167,6 @@ import org.apache.hop.ui.hopgui.CanvasSvgFacade;
 import org.apache.hop.ui.hopgui.HopGui;
 import org.apache.hop.ui.hopgui.HopGuiExtensionPoint;
 import org.apache.hop.ui.hopgui.PaletteEngineFilter;
-import org.apache.hop.ui.hopgui.ServerPushSessionFacade;
 import org.apache.hop.ui.hopgui.TestIdFacade;
 import org.apache.hop.ui.hopgui.ToolbarFacade;
 import org.apache.hop.ui.hopgui.context.ContextDialogPlacement;
@@ -5562,7 +5561,6 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
   @Override
   public void start() {
     try {
-      ServerPushSessionFacade.start();
       Thread thread =
           new Thread(
               () ->
@@ -5575,7 +5573,6 @@ public class HopGuiPipelineGraph extends HopGuiAbstractGraph
                               } else {
                                 pipelineRunDelegate.executePipeline(
                                     hopGui.getLog(), pipelineMeta, false, LogLevel.BASIC);
-                                ServerPushSessionFacade.stop();
                               }
                             } catch (Throwable e) {
                               new ErrorDialog(

--- a/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/HopGuiWorkflowGraph.java
+++ b/ui/src/main/java/org/apache/hop/ui/hopgui/file/workflow/HopGuiWorkflowGraph.java
@@ -125,7 +125,6 @@ import org.apache.hop.ui.hopgui.CanvasSvgFacade;
 import org.apache.hop.ui.hopgui.HopGui;
 import org.apache.hop.ui.hopgui.HopGuiExtensionPoint;
 import org.apache.hop.ui.hopgui.PaletteEngineFilter;
-import org.apache.hop.ui.hopgui.ServerPushSessionFacade;
 import org.apache.hop.ui.hopgui.TestIdFacade;
 import org.apache.hop.ui.hopgui.ToolbarFacade;
 import org.apache.hop.ui.hopgui.context.ContextDialogPlacement;
@@ -2622,8 +2621,6 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
       image = "ui/images/run.svg")
   @Override
   public void start() {
-    ServerPushSessionFacade.start();
-
     Thread thread =
         new Thread(
             () ->
@@ -2633,7 +2630,6 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
                           try {
                             workflowRunDelegate.executeWorkflow(
                                 hopGui.getVariables(), workflowMeta, null);
-                            ServerPushSessionFacade.stop();
                           } catch (Exception e) {
                             stopRedrawTimer();
                             new ErrorDialog(
@@ -2911,7 +2907,6 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
       category = "i18n::HopGuiWorkflowGraph.ContextualAction.Category.Basic.Text",
       categoryOrder = "1")
   public void startWorkflowHere(HopGuiWorkflowActionContext context) {
-    ServerPushSessionFacade.start();
     Thread thread =
         new Thread(
             () ->
@@ -2924,7 +2919,6 @@ public class HopGuiWorkflowGraph extends HopGuiAbstractGraph
                                 hopGui.getVariables(),
                                 workflowMeta,
                                 context.getActionMeta().getName());
-                            ServerPushSessionFacade.stop();
                           } catch (Exception e) {
                             new ErrorDialog(
                                 hopGui.getActiveShell(),


### PR DESCRIPTION
Fixes #8327

### Problem

In Hop Web (running via Eclipse RAP in the browser), background UI updates triggered via `Display.asyncExec(...)` (such as log lines from `HopGuiLogBrowser`'s 1-second refresh timer) are buffered on the server and never delivered to the client browser unless an active `ServerPushSession` is running.

Previously:

- In `HopGuiPipelineGraph` and `HopGuiWorkflowGraph`, `ServerPushSessionFacade.stop()` was invoked prematurely immediately after kicking off the execution delegate, terminating server push while execution was actively running in the background.
- If background notifications were disabled, no server push session was running at all during the web session.
- As a result, the logging tab in the Results panel stalled and did not refresh until the user clicked, typed, or resized the browser window to trigger a client request.

### Solution

1. In `HopWebEntryPoint`, invoke `ServerPushSessionFacade.start()` upon session startup so server push remains active throughout the Hop Web user session. Clean shutdown is already handled during session destruction (`beforeDestroy`).
2. Remove premature `ServerPushSessionFacade.stop()` calls from `HopGuiPipelineGraph` and `HopGuiWorkflowGraph`.